### PR TITLE
Pass client User-Agent, X-Forwarded headers

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/ScenarioGroup.cs
+++ b/src/Okta.Sdk.IntegrationTests/ScenarioGroup.cs
@@ -28,7 +28,7 @@ namespace Okta.Sdk.IntegrationTests
                 return _defaultClient.Value;
             }
 
-            var configuredOrgUrl = _defaultClient.Value.DataStore.RequestExecutor.OrgUrl;
+            var configuredOrgUrl = _defaultClient.Value.Configuration.OrgUrl;
             var orgUrlWithScenarioName = $"{configuredOrgUrl}/{scenarioName}";
 
             return new OktaClient(new OktaClientConfiguration

--- a/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
@@ -31,10 +31,11 @@ namespace Okta.Sdk.UnitTests
             var dataStore = new DefaultDataStore(
                 mockRequestExecutor,
                 new DefaultSerializer(),
+                new ResourceFactory(null, null),
                 NullLogger.Instance);
 
             var collection = new CollectionClient<User>(
-                dataStore, new HttpRequest { Uri = "http://mock-collection.dev" });
+                dataStore, new HttpRequest { Uri = "http://mock-collection.dev" }, null);
 
             var count = await collection.Count();
         }
@@ -46,10 +47,11 @@ namespace Okta.Sdk.UnitTests
             var dataStore = new DefaultDataStore(
                 mockRequestExecutor,
                 new DefaultSerializer(),
+                new ResourceFactory(null, null),
                 NullLogger.Instance);
 
             var collection = new CollectionClient<User>(
-                dataStore, new HttpRequest { Uri = "http://mock-collection.dev" });
+                dataStore, new HttpRequest { Uri = "http://mock-collection.dev" }, null);
 
             var activeUsers = await collection.Where(x => x.Status == "ACTIVE").ToList();
             activeUsers.Count.Should().Be(2);

--- a/src/Okta.Sdk.UnitTests/DefaultDataStoreShould.cs
+++ b/src/Okta.Sdk.UnitTests/DefaultDataStoreShould.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -22,11 +23,11 @@ namespace Okta.Sdk.UnitTests
             // If the RequestExecutor returns a null HttpResponse, throw an informative exception.
 
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => dataStore.GetAsync<TestResource>(request, CancellationToken.None));
+                () => dataStore.GetAsync<TestResource>(request, null, CancellationToken.None));
         }
 
         [Fact]
@@ -36,12 +37,12 @@ namespace Okta.Sdk.UnitTests
 
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .GetAsync("https://foo.dev", CancellationToken.None)
+                .GetAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200, Payload = null });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
-            var response = await dataStore.GetAsync<TestResource>(request, CancellationToken.None);
+            var response = await dataStore.GetAsync<TestResource>(request, null, CancellationToken.None);
             response.StatusCode.Should().Be(200);
 
             response.Payload.Should().NotBeNull();
@@ -55,12 +56,12 @@ namespace Okta.Sdk.UnitTests
 
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .GetAsync("https://foo.dev", CancellationToken.None)
+                .GetAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200, Payload = string.Empty });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
-            var response = await dataStore.GetAsync<TestResource>(request, CancellationToken.None);
+            var response = await dataStore.GetAsync<TestResource>(request, null, CancellationToken.None);
             response.StatusCode.Should().Be(200);
 
             response.Payload.Should().NotBeNull();
@@ -73,11 +74,11 @@ namespace Okta.Sdk.UnitTests
             // If the RequestExecutor returns a null HttpResponse, throw an informative exception.
 
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => dataStore.GetArrayAsync<TestResource>(request, CancellationToken.None));
+                () => dataStore.GetArrayAsync<TestResource>(request, null, CancellationToken.None));
         }
 
         [Fact]
@@ -85,14 +86,14 @@ namespace Okta.Sdk.UnitTests
         {
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .GetAsync("https://foo.dev", CancellationToken.None)
+                .GetAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200 });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
-            await dataStore.GetAsync<TestResource>(request, CancellationToken.None);
+            await dataStore.GetAsync<TestResource>(request, null, CancellationToken.None);
 
-            await mockRequestExecutor.Received().GetAsync("https://foo.dev", CancellationToken.None);
+            await mockRequestExecutor.Received().GetAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None);
         }
 
         [Fact]
@@ -100,14 +101,14 @@ namespace Okta.Sdk.UnitTests
         {
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .PostAsync("https://foo.dev", "{}", CancellationToken.None)
+                .PostAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), "{}", CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200 });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev", Payload = new { } };
-            await dataStore.PostAsync<TestResource>(request, CancellationToken.None);
+            await dataStore.PostAsync<TestResource>(request, null, CancellationToken.None);
 
-            await mockRequestExecutor.Received().PostAsync("https://foo.dev", "{}", CancellationToken.None);
+            await mockRequestExecutor.Received().PostAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), "{}", CancellationToken.None);
         }
 
         [Fact]
@@ -115,14 +116,14 @@ namespace Okta.Sdk.UnitTests
         {
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .PutAsync("https://foo.dev", "{}", CancellationToken.None)
+                .PutAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), "{}", CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200 });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev", Payload = new { } };
-            await dataStore.PutAsync<TestResource>(request, CancellationToken.None);
+            await dataStore.PutAsync<TestResource>(request, null, CancellationToken.None);
 
-            await mockRequestExecutor.Received().PutAsync("https://foo.dev", "{}", CancellationToken.None);
+            await mockRequestExecutor.Received().PutAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), "{}", CancellationToken.None);
         }
 
         [Fact]
@@ -130,14 +131,14 @@ namespace Okta.Sdk.UnitTests
         {
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();
             mockRequestExecutor
-                .DeleteAsync("https://foo.dev", CancellationToken.None)
+                .DeleteAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None)
                 .Returns(new HttpResponse<string>() { StatusCode = 200 });
-            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), NullLogger.Instance);
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
 
             var request = new HttpRequest { Uri = "https://foo.dev" };
-            await dataStore.DeleteAsync(request, CancellationToken.None);
+            await dataStore.DeleteAsync(request, null, CancellationToken.None);
 
-            await mockRequestExecutor.Received().DeleteAsync("https://foo.dev", CancellationToken.None);
+            await mockRequestExecutor.Received().DeleteAsync("https://foo.dev", Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), CancellationToken.None);
         }
     }
 }

--- a/src/Okta.Sdk.UnitTests/MockedCollectionRequestExecutor{T}.cs
+++ b/src/Okta.Sdk.UnitTests/MockedCollectionRequestExecutor{T}.cs
@@ -46,37 +46,37 @@ namespace Okta.Sdk.UnitTests
             return Task.FromResult(JsonConvert.SerializeObject(itemData));
         }
 
-        public async Task<HttpResponse<string>> GetAsync(string href, CancellationToken cancellationToken)
+        public async Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
-            var headers = new List<KeyValuePair<string, IEnumerable<string>>>
+            var responseHeaders = new List<KeyValuePair<string, IEnumerable<string>>>
             {
                 new KeyValuePair<string, IEnumerable<string>>("Link", new[] { $"<{BaseUrl}?page={_currentPage}>; rel=\"self\"" }),
             };
 
             if ((_currentPage + 1) * _pageSize < _items.Length)
             {
-                headers.Add(new KeyValuePair<string, IEnumerable<string>>("Link", new[] { $"<{BaseUrl}?page={_currentPage + 1}>; rel=\"next\"" }));
+                responseHeaders.Add(new KeyValuePair<string, IEnumerable<string>>("Link", new[] { $"<{BaseUrl}?page={_currentPage + 1}>; rel=\"next\"" }));
             }
 
             return new HttpResponse<string>
             {
                 StatusCode = 200,
-                Headers = headers,
+                Headers = responseHeaders,
                 Payload = await GetBodyAsync(href, cancellationToken),
             };
         }
 
-        public Task<HttpResponse<string>> PostAsync(string href, string body, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<HttpResponse<string>> PutAsync(string href, string body, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<HttpResponse<string>> DeleteAsync(string href, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/Okta.Sdk.UnitTests/MockedStringRequestExecutor.cs
+++ b/src/Okta.Sdk.UnitTests/MockedStringRequestExecutor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Okta.Sdk.Internal;
@@ -21,27 +22,24 @@ namespace Okta.Sdk.UnitTests
             _returnThis = returnThis ?? throw new ArgumentNullException(nameof(returnThis));
         }
 
-        public Task<string> GetBodyAsync(string href, CancellationToken cancellationToken)
-            => Task.FromResult(_returnThis);
-
-        public async Task<HttpResponse<string>> GetAsync(string href, CancellationToken cancellationToken)
-            => new HttpResponse<string>
+        public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponse<string>
             {
                 StatusCode = 200,
-                Payload = await GetBodyAsync(href, cancellationToken),
-            };
+                Payload = _returnThis,
+            });
 
-        public Task<HttpResponse<string>> PostAsync(string href, string body, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<HttpResponse<string>> PutAsync(string href, string body, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<HttpResponse<string>> DeleteAsync(string href, CancellationToken cancellationToken)
+        public Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/Okta.Sdk.UnitTests/NestedResourceShould.cs
+++ b/src/Okta.Sdk.UnitTests/NestedResourceShould.cs
@@ -34,7 +34,7 @@ namespace Okta.Sdk.UnitTests
                 },
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<TestNestedResource>(data);
 
             resource.Should().NotBeNull();
@@ -60,7 +60,7 @@ namespace Okta.Sdk.UnitTests
                 },
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<TestNestedResource>(data);
 
             resource.GetModifiedData().Count.Should().Be(0);

--- a/src/Okta.Sdk.UnitTests/ResourceCreator.cs
+++ b/src/Okta.Sdk.UnitTests/ResourceCreator.cs
@@ -37,7 +37,7 @@ namespace Okta.Sdk.UnitTests
 
         public static implicit operator T(ResourceCreator<T> creator)
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             return factory.CreateNew<T>(creator._data);
         }
 

--- a/src/Okta.Sdk.UnitTests/ResourceFactoryShould.cs
+++ b/src/Okta.Sdk.UnitTests/ResourceFactoryShould.cs
@@ -20,7 +20,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void ThrowIfCreateNewTDoesNotDeriveFromResource()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var fakeData = new Dictionary<string, object>();
 
             Assert.Throws<InvalidOperationException>(() => factory.CreateNew<string>(fakeData));
@@ -30,7 +30,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void ThrowIfCreateFromExistingDataTDoesNotDeriveFromResource()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var fakeData = new Dictionary<string, object>();
 
             Assert.Throws<InvalidOperationException>(() => factory.CreateFromExistingData<string>(fakeData));

--- a/src/Okta.Sdk.UnitTests/ResourceShould.cs
+++ b/src/Okta.Sdk.UnitTests/ResourceShould.cs
@@ -41,7 +41,7 @@ namespace Okta.Sdk.UnitTests
                 ["bar"] = true,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<TestResource>(data);
 
             resource.Foo.Should().Be("bar!");
@@ -58,7 +58,7 @@ namespace Okta.Sdk.UnitTests
                 ["nothing"] = null,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<string>("foo").Should().Be("abc");
@@ -70,7 +70,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripStringProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<string>("foo").Should().BeNull();
@@ -89,7 +89,7 @@ namespace Okta.Sdk.UnitTests
                 ["nothing"] = null,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<bool?>("yes").Should().BeTrue();
@@ -101,7 +101,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripBooleanProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<bool?>("foo").Should().BeNull();
@@ -120,7 +120,7 @@ namespace Okta.Sdk.UnitTests
                 ["nothing"] = null,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<int?>("min").Should().Be(int.MinValue);
@@ -132,7 +132,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripIntProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<int?>("foo").Should().BeNull();
@@ -151,7 +151,7 @@ namespace Okta.Sdk.UnitTests
                 ["nothing"] = null,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<long?>("min").Should().Be(long.MinValue);
@@ -163,7 +163,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripLongProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<long?>("foo").Should().BeNull();
@@ -182,7 +182,7 @@ namespace Okta.Sdk.UnitTests
                 ["nothing"] = null,
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<DateTimeOffset?>("dto").Should().Be(new DateTimeOffset(2015, 12, 27, 20, 15, 00, TimeSpan.FromHours(-6)));
@@ -194,7 +194,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripDateTimeProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<DateTimeOffset?>("foo").Should().BeNull();
@@ -211,7 +211,7 @@ namespace Okta.Sdk.UnitTests
                 ["things"] = new List<object>() { "foo", "bar", "baz" },
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             var things = resource.GetArrayProperty<string>("things");
@@ -221,7 +221,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripListProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetArrayProperty<string>("foo").Should().BeNull();
@@ -243,7 +243,7 @@ namespace Okta.Sdk.UnitTests
                 ["status4"] = "something",
             };
 
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(data);
 
             resource.GetProperty<UserStatus>("status1").Should().Be(UserStatus.Active);
@@ -255,7 +255,7 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RoundtripEnumProperty()
         {
-            var factory = new ResourceFactory();
+            var factory = new ResourceFactory(null, null);
             var resource = factory.CreateNew<Resource>(null);
 
             resource.GetProperty<UserStatus>("foo").Should().BeNull();

--- a/src/Okta.Sdk.UnitTests/UrlFormatterShould.cs
+++ b/src/Okta.Sdk.UnitTests/UrlFormatterShould.cs
@@ -136,7 +136,7 @@ namespace Okta.Sdk.UnitTests
             var request = new HttpRequest
             {
                 Uri = "/foobar",
-                QueryParams = new Dictionary<string, object>()
+                QueryParameters = new Dictionary<string, object>()
                 {
                     ["strings"] = "things",
                     ["other"] = null,

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -18,22 +18,26 @@ namespace Okta.Sdk
     {
         private readonly IDataStore _dataStore;
         private readonly HttpRequest _initialRequest;
+        private readonly RequestContext _requestContext;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CollectionClient{T}"/> class.
         /// </summary>
         /// <param name="dataStore">The <see cref="IDataStore">DataStore</see>.</param>
         /// <param name="initialRequest">The initial HTTP request options.</param>
+        /// <param name="requestContext">The request context.</param>
         public CollectionClient(
             IDataStore dataStore,
-            HttpRequest initialRequest)
+            HttpRequest initialRequest,
+            RequestContext requestContext)
         {
             _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
             _initialRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
+            _requestContext = requestContext;
         }
 
         /// <inheritdoc/>
         public IAsyncEnumerator<T> GetEnumerator()
-            => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest);
+            => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
     }
 }

--- a/src/Okta.Sdk/Generated/Group.Generated.cs
+++ b/src/Okta.Sdk/Generated/Group.Generated.cs
@@ -40,10 +40,10 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public Task RemoveUserAsync(string userId, CancellationToken cancellationToken = default(CancellationToken))
-            => new GroupClient(GetDataStore()).RemoveGroupUserAsync(Id, userId, cancellationToken);
+            => GetClient().Groups.RemoveGroupUserAsync(Id, userId, cancellationToken);
 
         /// <inheritdoc />
         public IAsyncEnumerable<User> ListUsers(string after = null, int? limit = -1, CancellationToken cancellationToken = default(CancellationToken))
-            => new GroupClient(GetDataStore()).ListGroupUsers(Id, after, limit);
+            => GetClient().Groups.ListGroupUsers(Id, after, limit);
     }
 }

--- a/src/Okta.Sdk/Generated/GroupClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupClient.Generated.cs
@@ -11,20 +11,26 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Okta.Sdk.Configuration;
 using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
     public sealed partial class GroupClient : OktaClient, IGroupClient
     {
-        public GroupClient(IDataStore dataStore)
-            : base(dataStore)
+        // Remove parameterless constructor
+        private GroupClient()
+        {
+        }
+
+        internal GroupClient(IDataStore dataStore, OktaClientConfiguration configuration, RequestContext requestContext)
+            : base(dataStore, configuration, requestContext)
         {
         }
         
         /// <inheritdoc />
         public IAsyncEnumerable<Group> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null)
-            => new CollectionClient<Group>(DataStore, new HttpRequest
+            => GetCollectionClient<Group>(new HttpRequest
         {
             Uri = "/api/v1/groups",
             
@@ -48,7 +54,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<GroupRule> ListRules(int? limit = -1, string after = null)
-            => new CollectionClient<GroupRule>(DataStore, new HttpRequest
+            => GetCollectionClient<GroupRule>(new HttpRequest
         {
             Uri = "/api/v1/groups/rules",
             
@@ -173,7 +179,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<User> ListGroupUsers(string groupId, string after = null, int? limit = -1)
-            => new CollectionClient<User>(DataStore, new HttpRequest
+            => GetCollectionClient<User>(new HttpRequest
         {
             Uri = "/api/v1/groups/{groupId}/users",
             

--- a/src/Okta.Sdk/Generated/GroupRule.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupRule.Generated.cs
@@ -52,10 +52,10 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public Task ActivateAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new GroupClient(GetDataStore()).ActivateRuleAsync(Id, cancellationToken);
+            => GetClient().Groups.ActivateRuleAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task DeactivateAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new GroupClient(GetDataStore()).DeactivateRuleAsync(Id, cancellationToken);
+            => GetClient().Groups.DeactivateRuleAsync(Id, cancellationToken);
     }
 }

--- a/src/Okta.Sdk/Generated/User.Generated.cs
+++ b/src/Okta.Sdk/Generated/User.Generated.cs
@@ -56,66 +56,66 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<AppLink> ListAppLinks(bool? showAll = false, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ListAppLinks(Id, showAll);
+            => GetClient().Users.ListAppLinks(Id, showAll);
 
         /// <inheritdoc />
         public IAsyncEnumerable<Role> ListRoles(string expand = null, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ListAssignedRoles(Id, expand);
+            => GetClient().Users.ListAssignedRoles(Id, expand);
 
         /// <inheritdoc />
         public Task RemoveRoleAsync(string roleId, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).RemoveRoleFromUserAsync(Id, roleId, cancellationToken);
+            => GetClient().Users.RemoveRoleFromUserAsync(Id, roleId, cancellationToken);
 
         /// <inheritdoc />
         public IAsyncEnumerable<Group> ListGroupTargetsForRole(string roleId, string after = null, int? limit = -1, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ListGroupTargetsForRole(Id, roleId, after, limit);
+            => GetClient().Users.ListGroupTargetsForRole(Id, roleId, after, limit);
 
         /// <inheritdoc />
         public Task RemoveGroupTargetFromRoleAsync(string roleId, string groupId, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).RemoveGroupTargetFromRoleAsync(Id, roleId, groupId, cancellationToken);
+            => GetClient().Users.RemoveGroupTargetFromRoleAsync(Id, roleId, groupId, cancellationToken);
 
         /// <inheritdoc />
         public Task AddGroupTargetToRoleAsync(string roleId, string groupId, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).AddGroupTargetToRoleAsync(Id, roleId, groupId, cancellationToken);
+            => GetClient().Users.AddGroupTargetToRoleAsync(Id, roleId, groupId, cancellationToken);
 
         /// <inheritdoc />
         public IAsyncEnumerable<Group> ListGroups(string after = null, int? limit = -1, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ListUserGroups(Id, after, limit);
+            => GetClient().Users.ListUserGroups(Id, after, limit);
 
         /// <inheritdoc />
         public Task<UserActivationToken> ActivateAsync(bool? sendEmail, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ActivateUserAsync(Id, sendEmail, cancellationToken);
+            => GetClient().Users.ActivateUserAsync(Id, sendEmail, cancellationToken);
 
         /// <inheritdoc />
         public Task DeactivateAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).DeactivateUserAsync(Id, cancellationToken);
+            => GetClient().Users.DeactivateUserAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task SuspendAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).SuspendUserAsync(Id, cancellationToken);
+            => GetClient().Users.SuspendUserAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task UnsuspendAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).UnsuspendUserAsync(Id, cancellationToken);
+            => GetClient().Users.UnsuspendUserAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task<ResetPasswordToken> ResetPasswordAsync(string provider = null, bool? sendEmail = null, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ResetPasswordAsync(Id, provider, sendEmail, cancellationToken);
+            => GetClient().Users.ResetPasswordAsync(Id, provider, sendEmail, cancellationToken);
 
         /// <inheritdoc />
         public Task<TempPassword> ExpirePasswordAsync(bool? tempPassword = false, CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ExpirePasswordAsync(Id, tempPassword, cancellationToken);
+            => GetClient().Users.ExpirePasswordAsync(Id, tempPassword, cancellationToken);
 
         /// <inheritdoc />
         public Task UnlockAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).UnlockUserAsync(Id, cancellationToken);
+            => GetClient().Users.UnlockUserAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task ResetFactorsAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).ResetAllFactorsAsync(Id, cancellationToken);
+            => GetClient().Users.ResetAllFactorsAsync(Id, cancellationToken);
 
         /// <inheritdoc />
         public Task AddToGroupAsync(string groupId, CancellationToken cancellationToken = default(CancellationToken))
-            => new GroupClient(GetDataStore()).AddUserToGroupAsync(groupId, Id, cancellationToken);
+            => GetClient().Groups.AddUserToGroupAsync(groupId, Id, cancellationToken);
     }
 }

--- a/src/Okta.Sdk/Generated/UserClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UserClient.Generated.cs
@@ -11,20 +11,26 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Okta.Sdk.Configuration;
 using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
     public sealed partial class UserClient : OktaClient, IUserClient
     {
-        public UserClient(IDataStore dataStore)
-            : base(dataStore)
+        // Remove parameterless constructor
+        private UserClient()
+        {
+        }
+
+        internal UserClient(IDataStore dataStore, OktaClientConfiguration configuration, RequestContext requestContext)
+            : base(dataStore, configuration, requestContext)
         {
         }
         
         /// <inheritdoc />
         public IAsyncEnumerable<User> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null)
-            => new CollectionClient<User>(DataStore, new HttpRequest
+            => GetCollectionClient<User>(new HttpRequest
         {
             Uri = "/api/v1/users",
             
@@ -91,7 +97,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<AppLink> ListAppLinks(string userId, bool? showAll = false)
-            => new CollectionClient<AppLink>(DataStore, new HttpRequest
+            => GetCollectionClient<AppLink>(new HttpRequest
         {
             Uri = "/api/v1/users/{userId}/appLinks",
             
@@ -147,7 +153,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<Group> ListUserGroups(string userId, string after = null, int? limit = -1)
-            => new CollectionClient<Group>(DataStore, new HttpRequest
+            => GetCollectionClient<Group>(new HttpRequest
         {
             Uri = "/api/v1/users/{userId}/groups",
             
@@ -273,7 +279,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<Role> ListAssignedRoles(string userId, string expand = null)
-            => new CollectionClient<Role>(DataStore, new HttpRequest
+            => GetCollectionClient<Role>(new HttpRequest
         {
             Uri = "/api/v1/users/{userId}/roles",
             
@@ -314,7 +320,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc />
         public IAsyncEnumerable<Group> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1)
-            => new CollectionClient<Group>(DataStore, new HttpRequest
+            => GetCollectionClient<Group>(new HttpRequest
         {
             Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups",
             

--- a/src/Okta.Sdk/IOktaClient.cs
+++ b/src/Okta.Sdk/IOktaClient.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Okta.Sdk.Configuration;
 using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
@@ -14,6 +15,15 @@ namespace Okta.Sdk
     /// </summary>
     public interface IOktaClient
     {
+        /// <summary>
+        /// Gets the configuration passed to this <see cref="IOktaClient">OktaClient</see>.
+        /// </summary>
+        /// <value>
+        /// The client configuration.
+        /// </value>
+        /// <remarks>The configuration is immutable after the client is initialized. This property references a copy of the configuration.</remarks>
+        OktaClientConfiguration Configuration { get; }
+
         /// <summary>
         /// Gets a <see cref="UserClient"/> that interacts with the Okta Users API.
         /// </summary>
@@ -29,6 +39,14 @@ namespace Okta.Sdk
         /// A <see cref="GroupClient"/> that interacts with the Okta Groups API.
         /// </value>
         GroupClient Groups { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="IOktaClient">OktaClient</see> scoped to the given request context.
+        /// </summary>
+        /// <param name="requestContext">The request context</param>
+        /// <remarks>This method is used to temporarily create a copy of the client in order to pass information about the current request to the Okta API.</remarks>
+        /// <returns>The new client.</returns>
+        IOktaClient CreatedScoped(RequestContext requestContext);
 
         /// <summary>
         /// Gets a resource by URL and deserializes it to a <see cref="Resource"/> type.

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -20,6 +20,7 @@ namespace Okta.Sdk.Internal
         where T : Resource, new()
     {
         private readonly IDataStore _dataStore;
+        private readonly RequestContext _requestContext;
 
         private bool _initialized = false;
         private T[] _localPage;
@@ -33,12 +34,15 @@ namespace Okta.Sdk.Internal
         /// </summary>
         /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>
         /// <param name="initialRequest">The initial HTTP request options.</param>
+        /// <param name="requestContext">The request context.</param>
         public CollectionAsyncEnumerator(
             IDataStore dataStore,
-            HttpRequest initialRequest)
+            HttpRequest initialRequest,
+            RequestContext requestContext)
         {
             _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
             _nextRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
+            _requestContext = requestContext;
         }
 
         /// <inheritdoc/>
@@ -62,6 +66,7 @@ namespace Okta.Sdk.Internal
 
             var nextPage = await _dataStore.GetArrayAsync<T>(
                 _nextRequest,
+                _requestContext,
                 cancellationToken).ConfigureAwait(false);
 
             _initialized = true;

--- a/src/Okta.Sdk/Internal/HttpRequest.cs
+++ b/src/Okta.Sdk/Internal/HttpRequest.cs
@@ -46,5 +46,14 @@ namespace Okta.Sdk.Internal
         /// </value>
         public IEnumerable<KeyValuePair<string, object>> PathParameters { get; set; }
             = Enumerable.Empty<KeyValuePair<string, object>>();
+
+        /// <summary>
+        /// Gets or sets the headers to send with the request.
+        /// </summary>
+        /// <value>
+        /// The headers to send with the request.
+        /// </value>
+        public IDictionary<string, string> Headers { get; set; }
+            = new Dictionary<string, string>();
     }
 }

--- a/src/Okta.Sdk/Internal/IDataStore.cs
+++ b/src/Okta.Sdk/Internal/IDataStore.cs
@@ -35,10 +35,11 @@ namespace Okta.Sdk.Internal
         /// </summary>
         /// <typeparam name="T">The <see cref="Resource"/> type to deserialize the returned data to.</typeparam>
         /// <param name="request">The HTTP request options.</param>
+        /// <param name="requestContext">Information about the upstream request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized resource and <see cref="HttpResponse"/> data.</returns>
         /// <exception cref="OktaApiException">An API error occurred.</exception>
-        Task<HttpResponse<T>> GetAsync<T>(HttpRequest request, CancellationToken cancellationToken)
+        Task<HttpResponse<T>> GetAsync<T>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
             where T : Resource, new();
 
         /// <summary>
@@ -46,10 +47,11 @@ namespace Okta.Sdk.Internal
         /// </summary>
         /// <typeparam name="T">The <see cref="Resource"/> type to deserialize the returned data to.</typeparam>
         /// <param name="request">The HTTP request options.</param>
+        /// <param name="requestContext">Information about the upstream request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>An array of deserialized resources and <see cref="HttpResponse"/> data.</returns>
         /// <exception cref="OktaApiException">An API error occurred.</exception>
-        Task<HttpResponse<IEnumerable<T>>> GetArrayAsync<T>(HttpRequest request, CancellationToken cancellationToken)
+        Task<HttpResponse<IEnumerable<T>>> GetArrayAsync<T>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
             where T : Resource, new();
 
         /// <summary>
@@ -57,10 +59,11 @@ namespace Okta.Sdk.Internal
         /// </summary>
         /// <typeparam name="TResponse">The <see cref="Resource"/> type to deserialize the returned data to.</typeparam>
         /// <param name="request">The HTTP request options.</param>
+        /// <param name="requestContext">Information about the upstream request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized response resource and <see cref="HttpResponse"/> data.</returns>
         /// <exception cref="OktaApiException">An API error occurred.</exception>
-        Task<HttpResponse<TResponse>> PostAsync<TResponse>(HttpRequest request, CancellationToken cancellationToken)
+        Task<HttpResponse<TResponse>> PostAsync<TResponse>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
             where TResponse : Resource, new();
 
         /// <summary>
@@ -68,18 +71,20 @@ namespace Okta.Sdk.Internal
         /// </summary>
         /// <typeparam name="TResponse">The <see cref="Resource"/> type to deserialize the returned data to.</typeparam>
         /// <param name="request">The HTTP request options.</param>
+        /// <param name="requestContext">Information about the upstream request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized response resource and <see cref="HttpResponse"/> data.</returns>
         /// <exception cref="OktaApiException">An API error occurred.</exception>
-        Task<HttpResponse<TResponse>> PutAsync<TResponse>(HttpRequest request, CancellationToken cancellationToken)
+        Task<HttpResponse<TResponse>> PutAsync<TResponse>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
             where TResponse : Resource, new();
 
         /// <summary>
         /// Deletes a resource.
         /// </summary>
         /// <param name="request">The HTTP request options.</param>
+        /// <param name="requestContext">Information about the upstream request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="HttpResponse"/> data.</returns>
-        Task<HttpResponse> DeleteAsync(HttpRequest request, CancellationToken cancellationToken);
+        Task<HttpResponse> DeleteAsync(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken);
     }
 }

--- a/src/Okta.Sdk/Internal/IRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/IRequestExecutor.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,40 +14,42 @@ namespace Okta.Sdk.Internal
     /// </summary>
     public interface IRequestExecutor
     {
-        string OrgUrl { get; }
-        
         /// <summary>
         /// Sends a GET request to the specified <paramref name="href"/>.
         /// </summary>
         /// <param name="href">The request URL.</param>
+        /// <param name="headers">The HTTP headers to add to the request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The HTTP response.</returns>
-        Task<HttpResponse<string>> GetAsync(string href, CancellationToken cancellationToken);
+        Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends a POST request to the specified <paramref name="href"/>.
         /// </summary>
         /// <param name="href">The request URL.</param>
+        /// <param name="headers">The HTTP headers to add to the request.</param>
         /// <param name="body">The serialized request body.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The HTTP response.</returns>
-        Task<HttpResponse<string>> PostAsync(string href, string body, CancellationToken cancellationToken);
+        Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends a PUT request to the specified <paramref name="href"/>.
         /// </summary>
         /// <param name="href">The request URL.</param>
+        /// <param name="headers">The HTTP headers to add to the request.</param>
         /// /// <param name="body">The serialized request body.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The HTTP response.</returns>
-        Task<HttpResponse<string>> PutAsync(string href, string body, CancellationToken cancellationToken);
+        Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified <paramref name="href"/>.
         /// </summary>
         /// <param name="href">The request URL.</param>
+        /// <param name="headers">The HTTP headers to add to the request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The HTTP response.</returns>
-        Task<HttpResponse<string>> DeleteAsync(string href, CancellationToken cancellationToken);
+        Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken);
     }
 }

--- a/src/Okta.Sdk/Internal/ResourceFactory.cs
+++ b/src/Okta.Sdk/Internal/ResourceFactory.cs
@@ -18,18 +18,18 @@ namespace Okta.Sdk.Internal
     {
         private static readonly TypeInfo ResourceTypeInfo = typeof(Resource).GetTypeInfo();
 
-        private readonly IDataStore _dataStore;
+        private readonly IOktaClient _client;
         private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceFactory"/> class.
         /// </summary>
-        /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>
+        /// <param name="client">The client.</param>
         /// <param name="logger">The logging interface.</param>
-        public ResourceFactory(IDataStore dataStore = null, ILogger logger = null)
+        public ResourceFactory(IOktaClient client, ILogger logger)
         {
-            _dataStore = dataStore;
-            _logger = logger ?? NullLogger.Instance;
+            _client = client;
+            _logger = logger;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Okta.Sdk.Internal
             }
 
             var resource = Activator.CreateInstance<T>() as Resource;
-            resource.Initialize(_dataStore, this, existingDictionary, _logger);
+            resource.Initialize(_client, this, existingDictionary, _logger);
             return (T)(object)resource;
         }
 
@@ -84,7 +84,7 @@ namespace Okta.Sdk.Internal
 
             var resource = Activator.CreateInstance<T>() as Resource;
             var dictionary = NewDictionary(resource.DictionaryType, data);
-            resource.Initialize(_dataStore, this, dictionary, _logger);
+            resource.Initialize(_client, this, dictionary, _logger);
             return (T)(object)resource;
         }
     }

--- a/src/Okta.Sdk/Internal/UserAgentBuilder.cs
+++ b/src/Okta.Sdk/Internal/UserAgentBuilder.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="UserAgentBuilder.cs" company="Okta, Inc">
+// Copyright (c) 2014-2017 Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Okta.Sdk.Internal
+{
+    /// <summary>
+    /// A User-Agent string generator that uses reflection to detect the current assembly version.
+    /// </summary>
+    public sealed class UserAgentBuilder
+    {
+        /// <summary>
+        /// The standard User-Agent token of the Okta SDK.
+        /// </summary>
+        public const string OktaSdkUserAgentName = "okta-sdk-dotnet";
+
+        // Lazy ensures this only runs once and is cached.
+        private readonly Lazy<string> _cachedUserAgent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserAgentBuilder"/> class.
+        /// </summary>
+        public UserAgentBuilder()
+        {
+            _cachedUserAgent = new Lazy<string>(Generate);
+        }
+
+        /// <summary>
+        /// Constructs a User-Agent string.
+        /// </summary>
+        /// <returns>A User-Agent string with the default tokens, and any additional tokens.</returns>
+        public string GetUserAgent() => _cachedUserAgent.Value;
+
+        private string Generate()
+        {
+            var sdkToken = $"{OktaSdkUserAgentName}/{GetSdkVersion()}";
+
+            var runtimeToken = $"runtime/{RuntimeInformation.FrameworkDescription}";
+
+            var operatingSystemToken = $"os/{RuntimeInformation.OSDescription}";
+
+            return string.Join(
+                " ",
+                sdkToken,
+                runtimeToken,
+                operatingSystemToken)
+            .Trim();
+        }
+
+        private static string GetSdkVersion()
+        {
+            var sdkVersion = typeof(OktaClient).GetTypeInfo()
+                .Assembly.GetName().Version;
+
+            return $"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Build}";
+        }
+    }
+}

--- a/src/Okta.Sdk/RequestContext.cs
+++ b/src/Okta.Sdk/RequestContext.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="RequestContext.cs" company="Okta, Inc">
+// Copyright (c) 2014-2017 Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Contains information about the downstream request from a client or browser to the application.
+    /// </summary>
+    /// <remarks>
+    /// This class is used to pass request details (like the X-Forwarded-For header) from the client request
+    /// through to the Okta API. Null properties are ignored.
+    /// </remarks>
+    public class RequestContext
+    {
+        /// <summary>
+        /// Gets or sets the User-Agent of the downstream client.
+        /// </summary>
+        /// <value>
+        /// The User-Agent value.
+        /// </value>
+        public string UserAgent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the X-Forwarded-For value that should be sent to the Okta API.
+        /// </summary>
+        /// <value>
+        /// The X-Forwarded-For value.
+        /// </value>
+        public string XForwardedFor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the X-Forwarded-Proto value that should be sent to the Okta API.
+        /// </summary>
+        /// <value>
+        /// The X-Forwarded-Proto value.
+        /// </value>
+        public string XForwardedProto { get; set; }
+
+        /// <summary>
+        /// Gets or sets the X-Forwarded-Port value that should be sent to the Okta API.
+        /// </summary>
+        /// <value>
+        /// The X-Forwarded-Port value.
+        /// </value>
+        public string XForwardedPort { get; set; }
+    }
+}

--- a/src/Okta.Sdk/Resource.cs
+++ b/src/Okta.Sdk/Resource.cs
@@ -21,7 +21,7 @@ namespace Okta.Sdk
         private static readonly TypeInfo StringEnumTypeInfo = typeof(StringEnum).GetTypeInfo();
 
         private readonly ResourceBehavior _dictionaryType;
-        private IDataStore _dataStore;
+        private IOktaClient _client;
         private ResourceFactory _resourceFactory;
         private ILogger _logger;
         private IDictionary<string, object> _data;
@@ -48,24 +48,20 @@ namespace Okta.Sdk
         internal ResourceBehavior DictionaryType => _dictionaryType;
 
         internal void Initialize(
-            IDataStore dataStore,
+            IOktaClient client,
             ResourceFactory resourceFactory,
             IDictionary<string, object> data,
             ILogger logger)
         {
-            _dataStore = dataStore;
-            _resourceFactory = resourceFactory ?? new ResourceFactory(dataStore, logger);
+            _client = client;
+            _resourceFactory = resourceFactory ?? new ResourceFactory(client, logger);
             _data = data ?? _resourceFactory.NewDictionary(_dictionaryType, null);
             _logger = logger ?? NullLogger.Instance;
         }
 
-        /// <summary>
-        /// Gets the <see cref="IDataStore">DataStore</see> used by this resource.
-        /// </summary>
-        /// <returns>The <see cref="IDataStore">DataStore</see> used by this resource.</returns>
-        protected IDataStore GetDataStore()
+        protected IOktaClient GetClient()
         {
-            return _dataStore ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object can call server-side methods.");
+            return _client ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object cna call server-side methods.");
         }
 
         /// <summary>

--- a/src/Okta.Sdk/User.cs
+++ b/src/Okta.Sdk/User.cs
@@ -15,7 +15,7 @@ namespace Okta.Sdk
     {
         /// <inheritdoc/>
         public Task DeactivateOrDeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => new UserClient(GetDataStore()).DeactivateOrDeleteUserAsync(Id, cancellationToken);
+            => GetClient().Users.DeactivateOrDeleteUserAsync(Id, cancellationToken);
 
         // TODO add custom methods here.
     }

--- a/src/OktaSdk.ruleset
+++ b/src/OktaSdk.ruleset
@@ -90,6 +90,7 @@
     <Rule Id="SA1133" Action="Error" />
     <Rule Id="SA1201" Action="None"/>
     <Rule Id="SA1202" Action="None"/>
+    <Rule Id="SA1204" Action="None"/>
     <Rule Id="SA1300" Action="Error" />
     <Rule Id="SA1302" Action="Error" />
     <Rule Id="SA1303" Action="Error" />

--- a/templates/Client.cs.hbs
+++ b/templates/Client.cs.hbs
@@ -11,14 +11,20 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Okta.Sdk.Configuration;
 using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
     public sealed partial class {{tag}}Client : OktaClient, I{{tag}}Client
     {
-        public {{tag}}Client(IDataStore dataStore)
-            : base(dataStore)
+        // Remove parameterless constructor
+        private {{tag}}Client()
+        {
+        }
+
+        internal {{tag}}Client(IDataStore dataStore, OktaClientConfiguration configuration, RequestContext requestContext)
+            : base(dataStore, configuration, requestContext)
         {
         }
         {{nbsp 0}}
@@ -60,7 +66,7 @@ namespace Okta.Sdk
                 {{~nbsp 0}})
     {{nbsp 0}}
             {{~#if isArray}}
-        => new CollectionClient<{{operation.responseModel}}>(DataStore, new HttpRequest
+        => GetCollectionClient<{{operation.responseModel}}>(new HttpRequest
         {
             Uri = "{{path}}",
             {{#if bodyModel}}Payload = {{camelCase bodyModel}},{{/if}}

--- a/templates/Model.cs.hbs
+++ b/templates/Model.cs.hbs
@@ -86,7 +86,7 @@ namespace Okta.Sdk
             {{~/each}}
             {{~nbsp 0}}CancellationToken cancellationToken = default(CancellationToken))
             {{nbsp 0}}
-            {{~nbsp 0}}=> new {{pascalCase operation.tags.[0]}}Client(GetDataStore()).{{pascalCase operation.operationId}}
+            {{~nbsp 0}}=> GetClient().{{pascalCase operation.tags.[0]}}s.{{pascalCase operation.operationId}}
             {{~#unless operation.isArray}}Async{{/unless}}
             {{~nbsp 0}}(
                 {{~#if operation.bodyModel}}this, {{/if}}


### PR DESCRIPTION
Internal refactoring to support:
* Generating a User-Agent string for the SDK based on the assembly version (closes #46)
* The concept of a RequestContext, which is data about the client (downstream request) that should be passed through the SDK to the Okta API
* This made it possible to properly forward X-Forwarded headers (closes #72, closes #97)
* Along the same lines, appending a client's User-Agent tokens to the SDK User-Agent string

All tests still green.


Closes #46 
Closes #72 
Closes #97 