### PR TITLE
Copy configuration (closes #101)

### DIFF
--- a/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
+++ b/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
@@ -3,12 +3,15 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
+using Okta.Sdk.Internal;
+
 namespace Okta.Sdk.Configuration
 {
     /// <summary>
     /// Configuration for an <see cref="IOktaClient">OktaClient</see>.
     /// </summary>
-    public sealed class OktaClientConfiguration
+    public sealed class OktaClientConfiguration : IDeepCloneable<OktaClientConfiguration>
     {
         /// <summary>
         /// The default HTTP connection timeout in seconds.
@@ -50,5 +53,14 @@ namespace Okta.Sdk.Configuration
         /// </value>
         /// <remarks>An API token can be generated from the Okta developer dashboard.</remarks>
         public string Token { get; set; }
+
+        /// <inheritdoc/>
+        public OktaClientConfiguration DeepClone()
+            => new OktaClientConfiguration
+            {
+                ConnectionTimeout = ConnectionTimeout.HasValue ? this.ConnectionTimeout.Value : (int?)null,
+                OrgUrl = this.OrgUrl,
+                Proxy = this.Proxy.DeepClone(),
+            };
     }
 }

--- a/src/Okta.Sdk/Configuration/ProxyConfiguration.cs
+++ b/src/Okta.Sdk/Configuration/ProxyConfiguration.cs
@@ -3,12 +3,15 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
+using Okta.Sdk.Internal;
+
 namespace Okta.Sdk.Configuration
 {
     /// <summary>
     /// HTTP proxy configuration for an <see cref="IOktaClient">OktaClient</see>.
     /// </summary>
-    public sealed class ProxyConfiguration
+    public sealed class ProxyConfiguration : IDeepCloneable<ProxyConfiguration>
     {
         /// <summary>
         /// Gets or sets the proxy port.
@@ -41,5 +44,15 @@ namespace Okta.Sdk.Configuration
         /// The proxy password.
         /// </value>
         public string Password { get; set; }
+
+        /// <inheritdoc/>
+        public ProxyConfiguration DeepClone()
+            => new ProxyConfiguration
+            {
+                Port = Port.HasValue ? this.Port.Value : (int?)null,
+                Host = Host,
+                Username = Username,
+                Password = Password,
+            };
     }
 }

--- a/src/Okta.Sdk/Internal/IDeepCloneable.cs
+++ b/src/Okta.Sdk/Internal/IDeepCloneable.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="IDeepCloneable.cs" company="Okta, Inc">
+// Copyright (c) 2014-2017 Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.Sdk.Internal
+{
+    /// <summary>
+    /// An object that can be deep cloned.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    public interface IDeepCloneable<T>
+    {
+        /// <summary>
+        /// Returns a deep clone (copy) of this object.
+        /// </summary>
+        /// <returns>A deep clone (copy) of this object.</returns>
+        T DeepClone();
+    }
+}

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -48,7 +48,7 @@ namespace Okta.Sdk
             compiled.GetSection("okta").GetSection("client").Bind(config);
 
             ThrowIfInvalidConfiguration(config);
-            Configuration = config; // TODO config.DeepClone()
+            Configuration = config.DeepClone();
 
             logger = logger ?? NullLogger.Instance;
 


### PR DESCRIPTION
We expose the current configuration on the `IOktaClient`, but it should be immutable - the user should not be able to change it after startup. To enforce this, the configuration is cloned and the user only has access to a copy.