### PR TITLE
Fixed bug in DeepClone method.

### DIFF
--- a/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
+++ b/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
@@ -60,7 +60,7 @@ namespace Okta.Sdk.Configuration
             {
                 ConnectionTimeout = ConnectionTimeout.HasValue ? this.ConnectionTimeout.Value : (int?)null,
                 OrgUrl = this.OrgUrl,
-                Proxy = this.Proxy.DeepClone(),
+                Proxy = this.Proxy?.DeepClone(),
             };
     }
 }


### PR DESCRIPTION
:bug: fixes bug when Proxy is null

Checks to see if Proxy is null before calling it's DeepClone method

Resolves: #137 



