### PR TITLE
PS: Require confirm when deleting multiple users

### DIFF
--- a/Okta.Core.Automation/Properties/AssemblyInfo.cs
+++ b/Okta.Core.Automation/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.3.0.0")]
-[assembly: AssemblyFileVersion("0.3.0.1852")] //"File version" attribute of the Properties -> Details tab
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.1852")] //"File version" attribute of the Properties -> Details tab
 [assembly: AssemblyInformationalVersion("0.2017.1.13")] //"Product version" attribute of the Properties -> Details tab
 

--- a/Okta.Core.Automation/Users/DeleteOktaUser.cs
+++ b/Okta.Core.Automation/Users/DeleteOktaUser.cs
@@ -8,7 +8,7 @@ using Okta.Core.Models;
 
 namespace Okta.Core.Automation
 {
-    [Cmdlet("Delete", "OktaUser")]
+    [Cmdlet("Delete", "OktaUser", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class DeleteOktaUser : OktaCmdlet
     {
         [Parameter(
@@ -68,6 +68,15 @@ namespace Okta.Core.Automation
                     users = usersEnum.ToList<User>();
                 }
 
+                if (users.Count > 1)
+                {
+                    if (!ShouldProcess($"Delete-OktaUser matched {users.Count} users, and will permanently delete them if confirmed", $"This action will permanently delete {users.Count} users.", "Are you sure you want to perform this action?"))
+                    {
+                        WriteVerbose("Operation canceled, no users deleted.");
+                        return;
+                    }
+                }
+
                 foreach (User user in users)
                 {
                     string strUserLogin = user.Profile.Login;
@@ -82,6 +91,10 @@ namespace Okta.Core.Automation
                         if (oex2.ErrorCode == OktaErrorCodes.ResourceNotFoundException)
                         {
                             bDeactivated = true;
+                        }
+                        else
+                        {
+                            throw; // Rethrow; will be handled by the outer try/catch
                         }
                     }
 

--- a/Okta.Core.Automation/chocolatey/okta.core.automation.nuspec
+++ b/Okta.Core.Automation/chocolatey/okta.core.automation.nuspec
@@ -3,17 +3,17 @@
   <metadata>
     <title>Okta PowerShell Module</title>
     <id>okta.core.automation</id>
-    <version>0.3.0.0</version>
+    <version>1.0.0.0</version>
     <authors>Okta, Inc</authors>
     <owners>Okta</owners>
-    <projectUrl>http://developer.okta.com/docs/sdk/core/api.html</projectUrl>
+    <projectUrl>https://github.com/okta/okta-sdk-dotnet/tree/legacy/Okta.Core.Automation</projectUrl>
     <iconUrl>https://www.okta.com/sites/all/themes/Okta/images/logo.png</iconUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <projectSourceUrl>https://github.com/okta/oktasdk-csharp/tree/master/Okta.Core.Automation</projectSourceUrl>
-    <packageSourceUrl>https://github.com/okta/oktasdk-csharp/tree/master/Okta.Core.Automation</packageSourceUrl>
-    <docsUrl>https://github.com/okta/oktasdk-csharp/blob/master/Okta.Core.Automation/README.md</docsUrl>
+    <projectSourceUrl>https://github.com/okta/okta-sdk-dotnet/tree/legacy/Okta.Core.Automation</projectSourceUrl>
+    <packageSourceUrl>https://github.com/okta/okta-sdk-dotnet/tree/legacy/Okta.Core.Automation</packageSourceUrl>
+    <docsUrl>https://github.com/okta/okta-sdk-dotnet/tree/legacy/Okta.Core.Automation/README.md</docsUrl>
     <mailingListUrl>mailto:developers@okta.com</mailingListUrl>
-    <bugTrackerUrl>https://github.com/okta/oktasdk-csharp/issues</bugTrackerUrl>
+    <bugTrackerUrl>https://github.com/okta/okta-sdk-dotnet/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Official PowerShell Module for Okta</summary>
     <description>


### PR DESCRIPTION
Resolves OKTA-132763

* Added a required confirmation when `Delete-OktaUser` will affect more than one account:

```posh
Connect-Okta -Token "<token>" -FullDomain "https://dev-341607.oktapreview.com"

Delete-OktaUser
Are you sure you want to perform this action?
This action will permanently delete 612 users.
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): n

# The confirmation can be explicitly bypassed if necessary:
Delete-OktaUser -Confirm:$false
Successfully deleted user: test3@example.com
Successfully deleted user: test4@example.com
```

* This does not apply if you pass an id or username, like `Delete-OktaUser joe123`, since this only affects 1 user.
* Bumped module/package version from 0.3.0 to 1.0.0 (this is a breaking change, I think semver applies).
* Fixed a small bug where some exceptions will be swallowed silently during deletion.
* Updated links in nuspec to point to new repo location.