### PR TITLE
Fix SslProtocol crash on .NET 4.6.1

### DIFF
--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -84,7 +84,6 @@ namespace Okta.Sdk.Internal
             var handler = new HttpClientHandler
             {
                 AllowAutoRedirect = false,
-                SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
             };
 
             if (proxyConfiguration != null)

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <Version>1.0.0-alpha4</Version>
+    <Version>1.0.0-alpha5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.20.0" />
+    <package id="Cake" version="0.21.1" />
 </packages>


### PR DESCRIPTION
As reported in #172, referencing the `SslProtocol` member causes a `PlatformNotSupportedException` in .NET Framework <4.7.2. This is a known gap in .NET Framework (see the Stack Overflow discussion linked from the issue).

For now we can just remove the offending line, since TLS 1.2 is supported by .NET Framework 4.6+ (netstandard1.3) by default. 

Down the road, we should investigate exposing a way for the consumer of this library to configure the `HttpHandler` themselves so they can override the default settings.