### PR TITLE
Remove docs from build (for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,8 @@
 language: csharp
-mono: latest # Necessary for Cake and DocFx (for now)
 dotnet: 1.0.4 # .NET Core
 dist: trusty
 script:
   - ./build.sh
-  - if [[ $DEPLOY_DOCS ]]; then ./build.sh --target Docs; fi
-deploy:
-- provider: pages
-  skip_cleanup: true
-  github_token: "$GITHUB_TOKEN"
-  local_dir: docs/temp
-  email: deploy-dotnet@okta.com
-  name: ".NET Deployment Bot"
-  on:
-    condition: "$DEPLOY_DOCS = true"
-    tags: true
 env:
   global:
     secure: Nn2fgkaM5WjJiGtjAqPnFH2ULzef+lxemF8TgVaWysshgYWx3G8p70a1sm7tAzw15WQAeg7kGszSdpQqaVOd1fS7Hu7DoGexQcOJmHpoRZn6a50cxIc/2AFAcbW1Ar051Cl3KnNc+9b6L8KcOjAmDs4CMXHrg7BTsiqKbDoCuns=

--- a/build.cake
+++ b/build.cake
@@ -1,25 +1,3 @@
-#addin "nuget:?package=Cake.Git&version=0.15.0";
-#addin "nuget:?package=Cake.GitPackager&version=0.1.1";
-#addin "nuget:?package=Cake.DocFx&version=0.5.0";
-#addin "nuget:?package=Cake.FileHelpers&version=1.0.4";
-#tool "nuget:?package=docfx.console&version=2.26.3";
-
-
-// Helper method for setting a lot of file attributes at once
-public FilePath[] SetFileAttributes(FilePathCollection files, System.IO.FileAttributes fileAttributes)
-{
-    var results = new System.Collections.Concurrent.ConcurrentBag<FilePath>();
-
-    Parallel.ForEach(files, f =>
-    {
-        System.IO.File.SetAttributes(f.FullPath, fileAttributes);
-        results.Add(f);
-    });
-
-    return results.ToArray();
-}
-
-
 // Default MSBuild configuration arguments
 
 var configuration = Argument("configuration", "Release");
@@ -86,74 +64,6 @@ Task("Test")
     }
 });
 
-Task("BuildDocs")
-.IsDependentOn("Build")
-.Does(() =>
-{
-    FilePath artifactLocation = File("./src/Okta.Sdk/bin/Release/netstandard1.3/Okta.Sdk.dll");
-    DocFxMetadata(new DocFxMetadataSettings
-    {
-        OutputPath = MakeAbsolute(Directory("./docs/api/")),
-        Projects = new[] { artifactLocation }
-    });
-
-    DocFxBuild("./docs/docfx.json");
-    // Outputs to docs/_site
-});
-
-Task("CloneExistingDocs")
-.Does(() =>
-{
-    var tempDir = "./docs/temp";
-
-    if (DirectoryExists(tempDir))
-    {
-        // Some git files are read-only, so recursively remove any attributes:
-        SetFileAttributes(GetFiles(tempDir + "/**/*.*"), System.IO.FileAttributes.Normal);
-        
-        DeleteDirectory(tempDir, recursive: true);
-    }
-
-    GitClone("https://github.com/okta/okta-sdk-dotnet.git",
-            tempDir,
-            new GitCloneSettings
-            {
-                BranchName = "gh-pages",
-            });
-});
-
-
-Task("CopyDocsToVersionedDirectories")
-.IsDependentOn("BuildDocs")
-.IsDependentOn("CloneExistingDocs")
-.Does(() =>
-{
-    DeleteDirectory("./docs/temp/latest", recursive: true);
-    Information("Copying docs to docs/temp/latest");
-    CopyDirectory("./docs/_site/", "./docs/temp/latest/");
-
-    var travisTag = EnvironmentVariable("TRAVIS_TAG");
-    if (string.IsNullOrEmpty(travisTag))
-    {
-        Console.WriteLine("TRAVIS_TAG not set, won't copy docs to a tagged directory");
-        return;
-    }
-
-    var taggedVersion = travisTag.TrimStart('v');
-    var tagDocsDirectory = string.Format("./docs/temp/{0}", taggedVersion);
-
-    Information("Copying docs to " + tagDocsDirectory);
-    CopyDirectory("./docs/_site/", tagDocsDirectory);
-});
-
-Task("CreateRootRedirector")
-.Does(() =>
-{
-    FileWriteText("./docs/temp/index.html",
-        @"<meta http-equiv=""refresh"" content=""0; url=https://developer.okta.com/okta-sdk-dotnet/latest/"">");
-});
-
-
 // Define top-level tasks
 
 Task("Default")
@@ -162,15 +72,6 @@ Task("Default")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
     .IsDependentOn("Pack");
-
-Task("Docs")
-    .IsDependentOn("BuildDocs")
-    .IsDependentOn("CloneExistingDocs")
-    .IsDependentOn("CopyDocsToVersionedDirectories")
-    .IsDependentOn("CreateRootRedirector");
-// Travis Github Pages deployment plugin takes the docs the rest of the way
-// (see .travis.yml)
-
 
 // Default task
 var target = Argument("target", "Default");


### PR DESCRIPTION
The cake build process used to build and deploy the [SDK reference documentation](https://developer.okta.com/okta-sdk-dotnet/latest/), but this is causing problems for deploying packages. The way we deploy docs will likely change soon too, so I'm removing this for now.