### PR TITLE
:seedling: Adds support for handling API-rate limiting

### DIFF
--- a/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
+++ b/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
@@ -54,6 +54,14 @@ namespace Okta.Sdk.Configuration
         /// <remarks>An API token can be generated from the Okta developer dashboard.</remarks>
         public string Token { get; set; }
 
+        /// <summary>
+        /// Gets or sets the amount of times the client will retry after experiencing an API rate-limit
+        /// </summary>
+        /// <value>
+        /// The number of times to retry after experiencing an API rate-limit
+        /// </value>
+        public int MaximumRateLimitRetryAttempts { get; set; } = 8;
+
         /// <inheritdoc/>
         public OktaClientConfiguration DeepClone()
             => new OktaClientConfiguration
@@ -61,6 +69,7 @@ namespace Okta.Sdk.Configuration
                 ConnectionTimeout = ConnectionTimeout.HasValue ? this.ConnectionTimeout.Value : (int?)null,
                 OrgUrl = this.OrgUrl,
                 Proxy = this.Proxy?.DeepClone(),
+                MaximumRateLimitRetryAttempts = this.MaximumRateLimitRetryAttempts,
             };
     }
 }

--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Authentication;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -21,10 +23,12 @@ namespace Okta.Sdk.Internal
     public sealed class DefaultRequestExecutor : IRequestExecutor
     {
         private const string OktaClientUserAgentName = "oktasdk-dotnet";
+        private static Random randomNumberGenerator = new Random();
 
         private readonly string _orgUrl;
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
+        private readonly int _retryLimit = 8;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRequestExecutor"/> class.
@@ -45,6 +49,7 @@ namespace Okta.Sdk.Internal
 
             _orgUrl = EnsureCorrectOrgUrl(configuration.OrgUrl);
             _logger = logger;
+            _retryLimit = configuration.MaximumRateLimitRetryAttempts;
 
             _httpClient = CreateClient(
                 _orgUrl,
@@ -126,28 +131,105 @@ namespace Okta.Sdk.Internal
         }
 
         private async Task<HttpResponse<string>> SendAsync(
-            HttpRequestMessage request,
+            Func<HttpRequestMessage> requestFactory,
             CancellationToken cancellationToken)
         {
-            _logger.LogTrace($"{request.Method} {request.RequestUri}");
+            int attemptCount = 1;
 
-            using (var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
+            while (true)
             {
-                _logger.LogTrace($"{(int)response.StatusCode} {request.RequestUri.PathAndQuery}");
+                HttpRequestMessage request = requestFactory.Invoke();
 
-                string stringContent = null;
-                if (response.Content != null)
+                _logger.LogTrace($"{request.Method} {request.RequestUri}");
+
+                using (var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
-                    stringContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    _logger.LogTrace($"{(int)response.StatusCode} {request.RequestUri.PathAndQuery}");
+
+                    if (await this.ShouldRetryOperationAsync(cancellationToken, response, attemptCount).ConfigureAwait(false))
+                    {
+                        attemptCount++;
+                        continue;
+                    }
+
+                    string stringContent = null;
+                    if (response.Content != null)
+                    {
+                        stringContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+
+                    return new HttpResponse<string>
+                    {
+                        Headers = ExtractHeaders(response),
+                        StatusCode = (int)response.StatusCode,
+                        Payload = stringContent,
+                    };
                 }
-
-                return new HttpResponse<string>
-                {
-                    Headers = ExtractHeaders(response),
-                    StatusCode = (int)response.StatusCode,
-                    Payload = stringContent,
-                };
             }
+        }
+
+        private async Task<bool> ShouldRetryOperationAsync(CancellationToken cancellationToken, HttpResponseMessage response, int attemptCount)
+        {
+            if (response.StatusCode != (System.Net.HttpStatusCode)429)
+            {
+                return false;
+            }
+
+            long? rateLimitReset = DefaultRequestExecutor.GetHeaderValue<long?>(response.Headers, "X-Rate-Limit-Reset");
+            int? rateLimitLimit = DefaultRequestExecutor.GetHeaderValue<int?>(response.Headers, "X-Rate-Limit-Limit");
+            int? rateLimitRemaining = DefaultRequestExecutor.GetHeaderValue<int?>(response.Headers, "X-Rate-Limit-Remaining");
+
+            if (rateLimitReset == null || rateLimitLimit == null || rateLimitRemaining == null)
+            {
+                _logger.LogTrace($"Rate limit exceeded, but expected rate-limit headers were missing");
+                return false;
+            }
+
+            DateTimeOffset rateLimitResetTime = DateTimeOffset.FromUnixTimeSeconds(rateLimitReset.Value);
+
+            _logger.LogTrace($"Rate limit exceeded. Limit {rateLimitLimit}, remaining {rateLimitRemaining}, reset time {rateLimitResetTime}, attempt count {attemptCount}");
+
+            if (attemptCount >= _retryLimit)
+            {
+                _logger.LogTrace($"Retry limit exceeded");
+                return false;
+            }
+
+            int delay = 0;
+
+            if (rateLimitLimit == 0 && rateLimitRemaining == 0)
+            {
+                // Concurrent rate limit has been hit. Perform exponential back-off
+                delay = (attemptCount * 1000) + randomNumberGenerator.Next(1000);
+                _logger.LogTrace($"Backing off request attempt {attemptCount} for {delay} milliseconds");
+            }
+            else
+            {
+                // Org-wide rate limit has been hit. Wait until the limit reset time
+                TimeSpan delaySpan = rateLimitResetTime.Subtract(DateTimeOffset.UtcNow);
+                _logger.LogTrace($"Delaying request attempt {attemptCount} for {delaySpan} before retrying");
+                delay = (int)delaySpan.TotalMilliseconds + (attemptCount * 1000) + randomNumberGenerator.Next(1000);
+            }
+
+            delay = Math.Max(delay, 1000);
+
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+            return true;
+        }
+
+        private static T GetHeaderValue<T>(HttpResponseHeaders headers, string name)
+        {
+            string valueString = headers.FirstOrDefault(t => t.Key == name).Value?.FirstOrDefault();
+
+            if (valueString == null)
+            {
+                return default(T);
+            }
+
+            TypeConverter converter = TypeDescriptor.GetConverter(typeof(T));
+
+            return (T)converter.ConvertFromString(null, CultureInfo.InvariantCulture, valueString);
         }
 
         private static void ApplyHeadersToRequest(HttpRequestMessage request, IEnumerable<KeyValuePair<string, string>> headers)
@@ -171,10 +253,13 @@ namespace Okta.Sdk.Internal
         {
             var path = EnsureRelativeUrl(href);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(path, UriKind.Relative));
-            ApplyHeadersToRequest(request, headers);
-
-            return SendAsync(request, cancellationToken);
+            return SendAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(path, UriKind.Relative));
+                    ApplyHeadersToRequest(request, headers);
+                    return request;
+                }, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -182,14 +267,18 @@ namespace Okta.Sdk.Internal
         {
             var path = EnsureRelativeUrl(href);
 
-            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(path, UriKind.Relative));
-            ApplyHeadersToRequest(request, headers);
+            return SendAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, new Uri(path, UriKind.Relative));
+                    ApplyHeadersToRequest(request, headers);
 
-            request.Content = string.IsNullOrEmpty(body)
-                ? null
-                : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                    request.Content = string.IsNullOrEmpty(body)
+                        ? null
+                        : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
 
-            return SendAsync(request, cancellationToken);
+                    return request;
+                }, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -197,14 +286,18 @@ namespace Okta.Sdk.Internal
         {
             var path = EnsureRelativeUrl(href);
 
-            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(path, UriKind.Relative));
-            ApplyHeadersToRequest(request, headers);
+            return SendAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Put, new Uri(path, UriKind.Relative));
+                    ApplyHeadersToRequest(request, headers);
 
-            request.Content = string.IsNullOrEmpty(body)
-                ? null
-                : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                    request.Content = string.IsNullOrEmpty(body)
+                        ? null
+                        : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
 
-            return SendAsync(request, cancellationToken);
+                    return request;
+                }, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -212,10 +305,14 @@ namespace Okta.Sdk.Internal
         {
             var path = EnsureRelativeUrl(href);
 
-            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(path, UriKind.Relative));
-            ApplyHeadersToRequest(request, headers);
 
-            return SendAsync(request, cancellationToken);
+            return SendAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(path, UriKind.Relative));
+                    ApplyHeadersToRequest(request, headers);
+                    return request;
+                }, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Adds support for detecting rate-limit errors and retrying operations. The code detects reset times provided by the API, and uses an exponential back-off algorithm. The code distinguishes from org-wide rate limits, as well as concurrent operation limits, handling both appropriately. In order to implement the retry functionality, calls to SendAsync were modified to pass in a HttpRequestMessage factory, rather than a HttpRequestMessage itself, as the HttpRequestMessage can only be used once. The OktaClientConfiguration object can be used to specify the number of retry operations permitted (default is 8)

Resolves: #156