### PR TITLE
:seedling: Adds support for skinny_users endpoint

### DIFF
--- a/src/Okta.Sdk/Group.cs
+++ b/src/Okta.Sdk/Group.cs
@@ -16,6 +16,9 @@ namespace Okta.Sdk
         public IAsyncEnumerable<IUser> Users
             => GetClient().Groups.ListGroupUsers(Id);
 
+        public IAsyncEnumerable<IUser> UsersSkinny
+            => GetClient().Groups.ListGroupUsersSkinny(Id);
+
         /// <inheritdoc/>
         public Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
             => GetClient().Groups.DeleteGroupAsync(Id, cancellationToken);

--- a/src/Okta.Sdk/GroupsClient.cs
+++ b/src/Okta.Sdk/GroupsClient.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
@@ -31,5 +32,21 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public IAsyncEnumerator<IGroup> GetEnumerator() => ListGroups().GetEnumerator();
+
+        public IAsyncEnumerable<IUser> ListGroupUsersSkinny(string groupId, string after = null, int? limit = -1)
+            => GetCollectionClient<User>(new HttpRequest
+            {
+                Uri = "/api/v1/groups/{groupId}/skinny_users",
+
+                PathParameters = new Dictionary<string, object>()
+                {
+                    ["groupId"] = groupId,
+                },
+                QueryParameters = new Dictionary<string, object>()
+                {
+                    ["after"] = after,
+                    ["limit"] = limit,
+                },
+            });
     }
 }

--- a/src/Okta.Sdk/IGroup.cs
+++ b/src/Okta.Sdk/IGroup.cs
@@ -19,6 +19,12 @@ namespace Okta.Sdk
         IAsyncEnumerable<IUser> Users { get; }
 
         /// <summary>
+        /// Gets the collection of <see cref="IUser">Users</see> in this Group.
+        /// </summary>
+        /// <value>The colletion of Users in this Group.</value>
+        IAsyncEnumerable<IUser> UsersSkinny { get; }
+
+        /// <summary>
         /// Deletes the group.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Okta.Sdk/IGroupsClient.cs
+++ b/src/Okta.Sdk/IGroupsClient.cs
@@ -19,5 +19,7 @@ namespace Okta.Sdk
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The <see cref="IGroup"/> response.</returns>
         Task<IGroup> CreateGroupAsync(CreateGroupOptions options, CancellationToken cancellationToken = default(CancellationToken));
+
+        IAsyncEnumerable<IUser> ListGroupUsersSkinny(string groupId, string after = null, int? limit = -1);
     }
 }


### PR DESCRIPTION
Adds support for calling the skinny_users endpoint to get a smaller representation of the users who are a member of a group as documented in the following guide https://www.okta.com/sites/default/files/Okta_Security-Analytics_Partner-Integration-Guide.pdf