### PR TITLE
:seedling: Adds support for disabling server certificate validation

### DIFF
--- a/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
+++ b/src/Okta.Sdk/Configuration/OktaClientConfiguration.cs
@@ -54,6 +54,14 @@ namespace Okta.Sdk.Configuration
         /// <remarks>An API token can be generated from the Okta developer dashboard.</remarks>
         public string Token { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the server's TLS certificate is validated. Warning this should only be used for debugging purposes and never used in production.
+        /// </summary>
+        /// <value>
+        /// A value indicating whether the server's TLS certificate is validated
+        /// </value>
+        public bool DisableServerCertificateValidation { get; set; }
+
         /// <inheritdoc/>
         public OktaClientConfiguration DeepClone()
             => new OktaClientConfiguration
@@ -61,6 +69,7 @@ namespace Okta.Sdk.Configuration
                 ConnectionTimeout = ConnectionTimeout.HasValue ? this.ConnectionTimeout.Value : (int?)null,
                 OrgUrl = this.OrgUrl,
                 Proxy = this.Proxy?.DeepClone(),
+                DisableServerCertificateValidation = this.DisableServerCertificateValidation,
             };
     }
 }

--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -51,7 +51,8 @@ namespace Okta.Sdk.Internal
                 configuration.Token,
                 configuration.ConnectionTimeout,
                 configuration.Proxy,
-                logger);
+                logger,
+                configuration.DisableServerCertificateValidation);
         }
 
         private static string EnsureCorrectOrgUrl(string orgUrl)
@@ -79,7 +80,8 @@ namespace Okta.Sdk.Internal
             string token,
             int? connectionTimeout,
             ProxyConfiguration proxyConfiguration,
-            ILogger logger)
+            ILogger logger,
+            bool disableServerCertificateValidation)
         {
             var handler = new HttpClientHandler
             {
@@ -89,6 +91,12 @@ namespace Okta.Sdk.Internal
             if (proxyConfiguration != null)
             {
                 handler.Proxy = new DefaultProxy(proxyConfiguration, logger);
+            }
+
+            if (disableServerCertificateValidation)
+            {
+                logger.LogWarning("Server certificate validation disabled");
+                handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, x509Certificate2, x509Chain, sslPolicyErrors) => true;
             }
 
             var client = new HttpClient(handler, true)


### PR DESCRIPTION
Adds support for disabling server certificate validation in the OktaClientConfiguration, which enables debugging scenarios using proxies such as fiddler.