### PR TITLE
:bug: Fixes an issue with creating users with a specific provider

### DIFF
--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -109,7 +109,7 @@ namespace Okta.Sdk
                 },
             };
 
-            return CreateUserAsync(user, options.Activate, cancellationToken: cancellationToken);
+            return CreateUserAsync(user, options.Activate, true, cancellationToken);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes issue #187 where the CreateUserAsync overload that takes a CreateUserWithProviderOptions does not pass through the optional provider=true parameter to the underlying CreateUserAsync method