### PR TITLE
Upgrade test projects to netcoreapp2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dotnet: 1.0.4 # .NET Core
+dotnet: 2.1.3 # .NET Core
 mono: latest
 dist: trusty
 script:

--- a/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
+++ b/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
+++ b/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.2" />
+    <package id="Cake" version="0.28.0" />
 </packages>


### PR DESCRIPTION
Chore: upgrade test projects to .NET Core 2.0. No code or test impact.