### PR TITLE
:seedling: Exposes the next link header as a continuation token

### DIFF
--- a/src/Okta.Sdk/GroupsClient.cs
+++ b/src/Okta.Sdk/GroupsClient.cs
@@ -7,6 +7,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json;
+
+using Okta.Sdk.Internal;
+
 namespace Okta.Sdk
 {
     /// <summary>
@@ -31,5 +35,59 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public IAsyncEnumerator<IGroup> GetEnumerator() => ListGroups().GetEnumerator();
+
+        /// <summary>
+        /// Lists the groups asynchronous.
+        /// </summary>
+        /// <param name="q">The q.</param>
+        /// <param name="after">The after.</param>
+        /// <param name="limit">The limit.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="search">The search.</param>
+        /// <param name="expand">The expand.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// page of groups.
+        /// </returns>
+        public async Task<PageOfResults<Group>> ListGroupsAsync(
+            string q = null,
+            string after = null,
+            int? limit = -1,
+            string filter = null,
+            string format = null,
+            string search = null,
+            string expand = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await GetPageOfResultsAsync<Group>(
+                new HttpRequest
+                {
+                    Uri = "/api/v1/groups",
+                    QueryParameters = new Dictionary<string, object>()
+                    {
+                        ["q"] = q,
+                        ["filter"] = filter,
+                        ["after"] = after,
+                        ["limit"] = limit,
+                        ["expand"] = expand,
+                    },
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Lists the groups asynchronous.
+        /// </summary>
+        /// <param name="serializedNextRequest">The serialized next request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// page of groups.
+        /// </returns>
+        public async Task<PageOfResults<Group>> ListGroupsContinuationAsync(string serializedNextRequest, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            HttpRequest req = JsonConvert.DeserializeObject<HttpRequest>(serializedNextRequest);
+            return await GetPageOfResultsAsync<Group>(req, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -164,6 +164,21 @@ namespace Okta.Sdk
             where T : Resource, new()
             => new CollectionClient<T>(_dataStore, initialRequest, _requestContext);
 
+        /// <summary>
+        /// Gets the paged collection client.
+        /// </summary>
+        /// <typeparam name="T">the collection client item type.</typeparam>
+        /// <param name="initialRequest">The initial request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The paged collection client.
+        /// </returns>
+        protected async Task<PageOfResults<T>> GetPageOfResultsAsync<T>(HttpRequest initialRequest, CancellationToken cancellationToken = default(CancellationToken))
+            where T : Resource, new()
+        {
+            return await PagedCollectionActionManager.GetPageOfResultsAsync<T>(_dataStore, initialRequest, _requestContext, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         public Task<T> GetAsync<T>(string href, CancellationToken cancellationToken = default(CancellationToken))
             where T : Resource, new()

--- a/src/Okta.Sdk/PageOfResults.cs
+++ b/src/Okta.Sdk/PageOfResults.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="PageOfResults.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Page of results
+    /// </summary>
+    /// <typeparam name="T">The type of the results</typeparam>
+    public class PageOfResults<T>
+    {
+        /// <summary>
+        /// Gets or sets the results.
+        /// </summary>
+        /// <value>
+        /// The results.
+        /// </value>
+        public IEnumerable<T> Results
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the continuation token.
+        /// </summary>
+        /// <value>
+        /// The continuation token.
+        /// </value>
+        public string ContinuationToken
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Okta.Sdk/PagedCollectionActionManager.cs
+++ b/src/Okta.Sdk/PagedCollectionActionManager.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="PagedCollectionActionManager.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+namespace Okta.Sdk.Internal
+{
+    /// <summary>
+    /// Enumerates an Okta API collection using the defined paging contract.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
+    public static class PagedCollectionActionManager
+    {
+        /// <summary>
+        /// Lists the users asynchronous.
+        /// </summary>
+        /// <typeparam name="T">The entity type.</typeparam>
+        /// <param name="dataStore">The data store.</param>
+        /// <param name="request">The request.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// list of type {T}
+        /// </returns>
+        public static async Task<PageOfResults<T>> GetPageOfResultsAsync<T>(
+            IDataStore dataStore,
+            HttpRequest request,
+            RequestContext context,
+            CancellationToken cancellationToken)
+            where T : Resource, new()
+        {
+            var currentPage = await dataStore.GetArrayAsync<T>(
+                request,
+                context,
+                cancellationToken).ConfigureAwait(false);
+
+            var nextRequest = GetNextLink(currentPage);
+
+            string serializedNextRequest = JsonConvert.SerializeObject(nextRequest);
+            return new PageOfResults<T>()
+            {
+                Results = currentPage.Payload,
+                ContinuationToken = serializedNextRequest,
+            };
+        }
+
+        private static HttpRequest GetNextLink(HttpResponse response)
+        {
+            var linkHeaders = response
+                .Headers
+                .Where(kvp => kvp.Key.Equals("Link", StringComparison.OrdinalIgnoreCase))
+                .Select(kvp => kvp.Value);
+            var nextUri = LinkHeaderParser
+                .Parse(linkHeaders.SelectMany(x => x))
+                .Where(x => x.Relation == "next")
+                .SingleOrDefault()
+                .Target;
+            return string.IsNullOrEmpty(nextUri)
+                ? null
+                : new HttpRequest { Uri = nextUri };
+        }
+    }
+}

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -8,6 +8,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json;
+
+using Okta.Sdk.Internal;
+
 namespace Okta.Sdk
 {
     /// <summary>
@@ -159,5 +163,62 @@ namespace Okta.Sdk
             bool? sendEmail = true,
             CancellationToken cancellationToken = default(CancellationToken))
             => ResetPasswordAsync(userId, null, sendEmail, cancellationToken);
+
+        /// <summary>
+        /// Lists the users asynchronous.
+        /// </summary>
+        /// <param name="q">The q.</param>
+        /// <param name="after">The after.</param>
+        /// <param name="limit">The limit.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="search">The search.</param>
+        /// <param name="expand">The expand.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// page of users.
+        /// </returns>
+        public async Task<PageOfResults<User>> ListUsersAsync(
+            string q = null,
+            string after = null,
+            int? limit = -1,
+            string filter = null,
+            string format = null,
+            string search = null,
+            string expand = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await GetPageOfResultsAsync<User>(
+                new HttpRequest
+                {
+                    Uri = "/api/v1/users",
+
+                    QueryParameters = new Dictionary<string, object>()
+                    {
+                        ["q"] = q,
+                        ["after"] = after,
+                        ["limit"] = limit,
+                        ["filter"] = filter,
+                        ["format"] = format,
+                        ["search"] = search,
+                        ["expand"] = expand,
+                    },
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Lists the users asynchronous.
+        /// </summary>
+        /// <param name="serializedNextRequest">The serialized next request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// page of users.
+        /// </returns>
+        public async Task<PageOfResults<User>> ListUsersContinuationAsync(string serializedNextRequest, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            HttpRequest req = JsonConvert.DeserializeObject<HttpRequest>(serializedNextRequest);
+            return await GetPageOfResultsAsync<User>(req, cancellationToken).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Exposes the next link header (https://developer.okta.com/docs/api/getting_started/design_principles#pagination) as a continuation token when listing users or groups