### PR TITLE
Add missing interface in IApplicationsClient

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
@@ -455,7 +455,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var appList = await client.Applications.ListApplications().ToArray();
+                var appList = await client.Applications.ToArray();
                 appList.SingleOrDefault(a => a.Id == createdApp.Id).Should().NotBeNull();
             }
             finally

--- a/src/Okta.Sdk/IApplicationsClient.cs
+++ b/src/Okta.Sdk/IApplicationsClient.cs
@@ -3,15 +3,13 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Okta.Sdk
 {
-    public partial interface IApplicationsClient
+    public partial interface IApplicationsClient : IAsyncEnumerable<IApplication>
     {
         Task<T> GetApplicationAsync<T>(string appId, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IApplication;


### PR DESCRIPTION
Implement `IAsyncEnumerable` to allow using this syntax: client.Applications.ToArray().

Use new syntax in integration tests.