### PR TITLE
Manual pagination support

### DIFF
--- a/openapi/processClients.js
+++ b/openapi/processClients.js
@@ -75,7 +75,7 @@ Creates the context that the handlebars template is bound to:
       isCollection: true,
       returnType = {
         memberName: 'IUser,
-        literal = 'CollectionClient<IUser>',
+        literal = 'ICollectionClient<IUser>',
         documentationLiteral = 'A collection of <see cref="IUser"/> that can be enumerated asynchronously.'
       },
       methodSignatureLiteral: 'string q = null, string after = null, int? limit = -1',
@@ -138,7 +138,7 @@ function createContextForClient(tag, operations) {
     };
 
     if (operation.isArray) {
-      operationContext.returnType.literal = `CollectionClient<I${operationContext.returnType.memberName}>`;
+      operationContext.returnType.literal = `ICollectionClient<I${operationContext.returnType.memberName}>`;
       operationContext.returnType.documentationLiteral = `A collection of <see cref="I${operationContext.returnType.memberName}"/> that can be enumerated asynchronously.`;
     } else if (operation.responseModel) {
       operationContext.returnType.literal = `Task<I${operationContext.returnType.memberName}>`;

--- a/openapi/processClients.js
+++ b/openapi/processClients.js
@@ -75,7 +75,7 @@ Creates the context that the handlebars template is bound to:
       isCollection: true,
       returnType = {
         memberName: 'IUser,
-        literal = 'IAsyncEnumerable<IUser>',
+        literal = 'CollectionClient<IUser>',
         documentationLiteral = 'A collection of <see cref="IUser"/> that can be enumerated asynchronously.'
       },
       methodSignatureLiteral: 'string q = null, string after = null, int? limit = -1',
@@ -138,7 +138,7 @@ function createContextForClient(tag, operations) {
     };
 
     if (operation.isArray) {
-      operationContext.returnType.literal = `IAsyncEnumerable<I${operationContext.returnType.memberName}>`;
+      operationContext.returnType.literal = `CollectionClient<I${operationContext.returnType.memberName}>`;
       operationContext.returnType.documentationLiteral = `A collection of <see cref="I${operationContext.returnType.memberName}"/> that can be enumerated asynchronously.`;
     } else if (operation.responseModel) {
       operationContext.returnType.literal = `Task<I${operationContext.returnType.memberName}>`;

--- a/openapi/processModels.js
+++ b/openapi/processModels.js
@@ -192,7 +192,7 @@ function createContextForModel(model, strictModelList, errFunc) {
     }
     
     if (method.operation.isArray) {
-      methodContext.returnTypeLiteral = `IAsyncEnumerable<I${method.operation.responseModel}>`;
+      methodContext.returnTypeLiteral = `CollectionClient<I${method.operation.responseModel}>`;
     } else if (method.operation.responseModel) {
       methodContext.returnTypeLiteral = `Task<I${method.operation.responseModel}>`;
     } else {

--- a/openapi/processModels.js
+++ b/openapi/processModels.js
@@ -192,7 +192,7 @@ function createContextForModel(model, strictModelList, errFunc) {
     }
     
     if (method.operation.isArray) {
-      methodContext.returnTypeLiteral = `CollectionClient<I${method.operation.responseModel}>`;
+      methodContext.returnTypeLiteral = `ICollectionClient<I${method.operation.responseModel}>`;
     } else if (method.operation.responseModel) {
       methodContext.returnTypeLiteral = `Task<I${method.operation.responseModel}>`;
     } else {

--- a/openapi/templates/Client.cs.hbs
+++ b/openapi/templates/Client.cs.hbs
@@ -33,7 +33,7 @@ namespace Okta.Sdk
         public {{#unless isCollection}}async {{/unless}}{{{returnType.literal}}} {{memberName}}(
             {{~#if bodyModel}}I{{bodyModel.type.memberName}} {{bodyModel.parameterName}}, {{/if}}
             {{~nbsp 0}}{{{methodSignatureLiteral}}})
-            {{#if isCollection}}=> GetCollectionClient<{{returnType.memberName}}>(new HttpRequest
+            {{#if isCollection}}=> GetCollectionClient<I{{returnType.memberName}}>(new HttpRequest
             {
                 Uri = "{{path}}",
                 {{#if bodyModel}}Payload = {{bodyModel.parameterName}},{{/if}}

--- a/src/Okta.Sdk.IntegrationTests/CollectionScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/CollectionScenarios.cs
@@ -1,0 +1,93 @@
+﻿// <copyright file="CollectionScenarios.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Okta.Sdk.IntegrationTests
+{
+    [Collection(nameof(CollectionScenarios))]
+    public class CollectionScenarios : IClassFixture<LoggingFixture>
+    {
+        private readonly LoggingFixture _logger;
+
+        public CollectionScenarios(LoggingFixture logger)
+        {
+            _logger = logger;
+        }
+
+        [Fact]
+        public async Task EnumerateCollectionWithLinq()
+        {
+            var client = TestClient.Create();
+
+            var createdUsers = new ConcurrentBag<IUser>();
+
+            try
+            {
+                // Create 10 users (in parallel)
+                var tasks = new List<Task>();
+                for (var i = 0; i < 10; i++)
+                {
+                    tasks.Add(CreateRandomUser());
+                }
+
+                async Task CreateRandomUser()
+                {
+                    var randomGuid = Guid.NewGuid();
+
+                    var user = await client.Users.CreateUserAsync(new CreateUserWithoutCredentialsOptions
+                    {
+                        Profile = new UserProfile
+                        {
+                            FirstName = $"Jack-{randomGuid}",
+                            LastName = "CollectionEnumeration",
+                            Email = $"collection-enumeration-{randomGuid}@example.com",
+                            Login = $"collection-enumeration-{randomGuid}@example.com",
+                        },
+                        Activate = false,
+                    });
+
+                    createdUsers.Add(user);
+                }
+
+                await Task.WhenAll(tasks);
+
+                // Alright, all set up. Try enumerating users by pages of 2:
+                var users = client.Users.ListUsers(limit: 2);
+                (await users.Count()).Should().BeGreaterOrEqualTo(10); // Because of parallelization, it might be >10
+            }
+            catch (Exception e)
+            {
+                _logger.LogMessage($"Exception while running test: {e.Message}");
+            }
+            finally
+            {
+                // Remove the users
+                var tasks = createdUsers.Select(x => DeleteUser(x));
+
+                await Task.WhenAll(tasks);
+
+                async Task DeleteUser(IUser user)
+                {
+                    try
+                    {
+                        await user.DeactivateAsync();
+                        await user.DeactivateOrDeleteAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogMessage($"Exception while cleaning up test: {e.Message}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Okta.Sdk.IntegrationTests/LoggingFixture.cs
+++ b/src/Okta.Sdk.IntegrationTests/LoggingFixture.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="LoggingFixture.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Okta.Sdk.IntegrationTests
+{
+    public class LoggingFixture
+    {
+        private readonly IMessageSink _messageSink;
+
+        public LoggingFixture(IMessageSink messageSink)
+        {
+            _messageSink = messageSink;
+            _messageSink.OnMessage(new DiagnosticMessage("hello world"));
+        }
+
+        public void LogMessage(string message)
+        {
+            _messageSink.OnMessage(new DiagnosticMessage(message));
+        }
+    }
+}

--- a/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
+++ b/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Polly" Version="5.2.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 

--- a/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
@@ -26,6 +26,25 @@ namespace Okta.Sdk.UnitTests
         };
 
         [Fact]
+        public async Task GetAllItems()
+        {
+            var mockRequestExecutor = new MockedCollectionRequestExecutor<User>(pageSize: 2, items: TestUsers);
+            var dataStore = new DefaultDataStore(
+                mockRequestExecutor,
+                new DefaultSerializer(),
+                new ResourceFactory(null, null),
+                NullLogger.Instance);
+
+            var collection = new CollectionClient<User>(
+                dataStore,
+                new HttpRequest { Uri = "http://mock-collection.dev" },
+                new RequestContext());
+
+            var all = await collection.ToArrayAsync();
+            all.Count.Should().Be(5);
+        }
+
+        [Fact]
         public async Task CountCollectionAsynchronously()
         {
             var mockRequestExecutor = new MockedCollectionRequestExecutor<IUser>(pageSize: 2, items: TestUsers);

--- a/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
@@ -85,10 +85,7 @@ namespace Okta.Sdk.UnitTests
             var enumerator = collection.GetPagedEnumerator();
             while (await enumerator.MoveNextAsync())
             {
-                for (var i = 0; i < enumerator.CurrentPage.Items.Length; i++)
-                {
-                    items.Add(enumerator.CurrentPage.Items[i]);
-                }
+                items.AddRange(enumerator.CurrentPage.Items);
             }
 
             items.Count.Should().Be(5);

--- a/src/Okta.Sdk.UnitTests/LinkHeaderParserShould.cs
+++ b/src/Okta.Sdk.UnitTests/LinkHeaderParserShould.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -13,6 +14,30 @@ namespace Okta.Sdk.UnitTests
 {
     public class LinkHeaderParserShould
     {
+        [Fact]
+        public void ParseEmptyArray()
+        {
+            var links = LinkHeaderParser.Parse(new string[0]);
+
+            links.Count().Should().Be(0);
+        }
+
+        [Fact]
+        public void ParseEmptyString()
+        {
+            var links = LinkHeaderParser.Parse(string.Empty);
+
+            links.Count().Should().Be(0);
+        }
+
+        [Fact]
+        public void ParseNull()
+        {
+            var links = LinkHeaderParser.Parse((IEnumerable<string>)null);
+
+            links.Count().Should().Be(0);
+        }
+
         [Fact]
         public void ParseLink()
         {

--- a/src/Okta.Sdk.UnitTests/ResourceFactoryShould.cs
+++ b/src/Okta.Sdk.UnitTests/ResourceFactoryShould.cs
@@ -106,10 +106,23 @@ namespace Okta.Sdk.UnitTests
             var fakeData = new Dictionary<string, object>();
             fakeData.Add("signOnMode", ApplicationSignOnMode.BasicAuth);
 
-            var app = factory.CreateFromExistingData<Application>(fakeData);
+            var app = factory.CreateFromExistingData<IApplication>(fakeData);
 
             app.Should().NotBeNull();
             app.Should().BeOfType<BasicAuthApplication>();
+        }
+
+        [Fact]
+        public void CreateSecurityQuestionFactor()
+        {
+            var factory = new ResourceFactory(null, null);
+            var fakeData = new Dictionary<string, object>();
+            fakeData.Add("factorType", FactorType.Question);
+
+            var app = factory.CreateFromExistingData<IFactor>(fakeData);
+
+            app.Should().NotBeNull();
+            app.Should().BeOfType<SecurityQuestionFactor>();
         }
     }
 }

--- a/src/Okta.Sdk.UnitTests/WebLinkShould.cs
+++ b/src/Okta.Sdk.UnitTests/WebLinkShould.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="WebLinkShould.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using FluentAssertions;
+using Xunit;
+
+namespace Okta.Sdk.UnitTests
+{
+    public class WebLinkShould
+    {
+        [Fact]
+        public void ReturnTargetForToString()
+        {
+            var link = new WebLink("target://foo", "self");
+
+            link.ToString().Should().Be(link.Target);
+        }
+    }
+}

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -9,16 +9,9 @@ using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
-    /// <summary>
-    /// A collection of <see cref="Resource">Resources</see> that can be enumerated asynchronously.
-    /// </summary>
-    /// <remarks>
-    /// Using this object with LINQ will automatically enumerate a paginated Okta collection.
-    /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
-    /// </remarks>
-    /// <typeparam name="T">The <see cref="Resource"/> type in the collection.</typeparam>
-    public sealed class CollectionClient<T> : IAsyncEnumerable<T>
-        where T : Resource, new()
+    /// <inheritdoc/>
+    public sealed class CollectionClient<T> : ICollectionClient<T>
+        where T : IResource
     {
         private readonly IDataStore _dataStore;
         private readonly HttpRequest _initialRequest;
@@ -44,15 +37,8 @@ namespace Okta.Sdk
         public IAsyncEnumerator<T> GetEnumerator()
             => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
 
-        /// <summary>
-        /// Returns an enumerator that can be used to retrieve items from an Okta collection page-by-page.
-        /// Use this only if you need to enumerate collections manually; otherwise, use LINQ.
-        /// </summary>
-        /// <remarks>
-        /// /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
-        /// </remarks>
-        /// <returns>An enumerator that retrieves items from an Okta collection page-by-page.</returns>
-        public PagedCollectionEnumerator<T> GetPagedEnumerator()
+        /// <inheritdoc/>
+        public IPagedCollectionEnumerator<T> GetPagedEnumerator()
             => new PagedCollectionEnumerator<T>(_dataStore, _initialRequest, _requestContext);
     }
 }

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -10,8 +10,12 @@ using Okta.Sdk.Internal;
 namespace Okta.Sdk
 {
     /// <summary>
-    /// A remote collection of <see cref="Resource">Resources</see> that can be enumerated asynchronously.
+    /// A collection of <see cref="Resource">Resources</see> that can be enumerated asynchronously.
     /// </summary>
+    /// <remarks>
+    /// Using this object with LINQ will automatically enumerate a paginated Okta collection.
+    /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
+    /// </remarks>
     /// <typeparam name="T">The <see cref="Resource"/> type in the collection.</typeparam>
     public sealed class CollectionClient<T> : IAsyncEnumerable<T>
         where T : Resource, new()
@@ -39,5 +43,16 @@ namespace Okta.Sdk
         /// <inheritdoc/>
         public IAsyncEnumerator<T> GetEnumerator()
             => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
+
+        /// <summary>
+        /// Returns an enumerator that can be used to retrieve items from an Okta collection page-by-page.
+        /// Use this only if you need to enumerate collections manually; otherwise, use LINQ.
+        /// </summary>
+        /// <remarks>
+        /// /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
+        /// </remarks>
+        /// <returns>An enumerator that retrieves items from an Okta collection page-by-page.</returns>
+        public PagedCollectionEnumerator<T> GetPagedEnumerator()
+            => new PagedCollectionEnumerator<T>(_dataStore, _initialRequest, _requestContext);
     }
 }

--- a/src/Okta.Sdk/CollectionPage{T}.cs
+++ b/src/Okta.Sdk/CollectionPage{T}.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="CollectionPage{T}.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Represents a page of resources in an Okta API collection.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
+    /// <typeparam name="T">The resource type of this collection.</typeparam>
+    public class CollectionPage<T>
+    {
+        /// <summary>
+        /// Gets or sets the items in this page.
+        /// </summary>
+        /// <value>
+        /// The items in this page.
+        /// </value>
+        public T[] Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP response returned from the Okta API when fetching this page.
+        /// </summary>
+        /// <value>
+        /// The HTTP response returned from the Okta API when fetching this page.
+        /// </value>
+        public HttpResponse<IEnumerable<T>> Response { get; set; }
+
+        /// <summary>
+        /// Gets or sets the link to get the next page of results, if any.
+        /// </summary>
+        /// <value>
+        /// The link to get the next page of results. If there is no next page, this will be <c>null</c>.
+        /// </value>
+        public WebLink NextLink { get; set; }
+    }
+}

--- a/src/Okta.Sdk/CollectionPage{T}.cs
+++ b/src/Okta.Sdk/CollectionPage{T}.cs
@@ -20,7 +20,7 @@ namespace Okta.Sdk
         /// <value>
         /// The items in this page.
         /// </value>
-        public T[] Items { get; set; }
+        public IEnumerable<T> Items { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP response returned from the Okta API when fetching this page.

--- a/src/Okta.Sdk/Generated/Application.Generated.cs
+++ b/src/Okta.Sdk/Generated/Application.Generated.cs
@@ -103,7 +103,7 @@ namespace Okta.Sdk
             => GetClient().Applications.DeactivateApplicationAsync(Id, cancellationToken);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
+        public CollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
             => GetClient().Applications.ListApplicationUsers(Id, q, query_scope, after, limit, filter, expand);
         
         /// <inheritdoc />
@@ -131,11 +131,11 @@ namespace Okta.Sdk
             => GetClient().Applications.GetApplicationKeyAsync(Id, keyId, cancellationToken);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null)
+        public CollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null)
             => GetClient().Applications.ListApplicationGroupAssignments(Id, q, after, limit, expand);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IJsonWebKey> ListKeys()
+        public CollectionClient<IJsonWebKey> ListKeys()
             => GetClient().Applications.ListApplicationKeys(Id);
         
     }

--- a/src/Okta.Sdk/Generated/Application.Generated.cs
+++ b/src/Okta.Sdk/Generated/Application.Generated.cs
@@ -103,7 +103,7 @@ namespace Okta.Sdk
             => GetClient().Applications.DeactivateApplicationAsync(Id, cancellationToken);
         
         /// <inheritdoc />
-        public CollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
+        public ICollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
             => GetClient().Applications.ListApplicationUsers(Id, q, query_scope, after, limit, filter, expand);
         
         /// <inheritdoc />
@@ -131,11 +131,11 @@ namespace Okta.Sdk
             => GetClient().Applications.GetApplicationKeyAsync(Id, keyId, cancellationToken);
         
         /// <inheritdoc />
-        public CollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null)
+        public ICollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null)
             => GetClient().Applications.ListApplicationGroupAssignments(Id, q, after, limit, expand);
         
         /// <inheritdoc />
-        public CollectionClient<IJsonWebKey> ListKeys()
+        public ICollectionClient<IJsonWebKey> ListKeys()
             => GetClient().Applications.ListApplicationKeys(Id);
         
     }

--- a/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
@@ -29,8 +29,8 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public CollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false)
-            => GetCollectionClient<Application>(new HttpRequest
+        public ICollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false)
+            => GetCollectionClient<IApplication>(new HttpRequest
             {
                 Uri = "/api/v1/apps",
                 
@@ -98,8 +98,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IJsonWebKey> ListApplicationKeys(string appId)
-            => GetCollectionClient<JsonWebKey>(new HttpRequest
+        public ICollectionClient<IJsonWebKey> ListApplicationKeys(string appId)
+            => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys",
                 
@@ -140,8 +140,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null)
-            => GetCollectionClient<ApplicationGroupAssignment>(new HttpRequest
+        public ICollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null)
+            => GetCollectionClient<IApplicationGroupAssignment>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups",
                 
@@ -226,8 +226,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
-            => GetCollectionClient<AppUser>(new HttpRequest
+        public ICollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
+            => GetCollectionClient<IAppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users",
                 

--- a/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false)
+        public CollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false)
             => GetCollectionClient<Application>(new HttpRequest
             {
                 Uri = "/api/v1/apps",
@@ -98,7 +98,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IJsonWebKey> ListApplicationKeys(string appId)
+        public CollectionClient<IJsonWebKey> ListApplicationKeys(string appId)
             => GetCollectionClient<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys",
@@ -140,7 +140,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null)
+        public CollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null)
             => GetCollectionClient<ApplicationGroupAssignment>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups",
@@ -226,7 +226,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
+        public CollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null)
             => GetCollectionClient<AppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users",

--- a/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
@@ -29,8 +29,8 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public CollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null)
-            => GetCollectionClient<Group>(new HttpRequest
+        public ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null)
+            => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/groups",
                 
@@ -53,8 +53,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "")
-            => GetCollectionClient<GroupRule>(new HttpRequest
+        public ICollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "")
+            => GetCollectionClient<IGroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules",
                 
@@ -183,8 +183,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all")
-            => GetCollectionClient<User>(new HttpRequest
+        public ICollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all")
+            => GetCollectionClient<IUser>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/users",
                 

--- a/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null)
+        public CollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null)
             => GetCollectionClient<Group>(new HttpRequest
             {
                 Uri = "/api/v1/groups",
@@ -53,7 +53,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "")
+        public CollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "")
             => GetCollectionClient<GroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules",
@@ -183,7 +183,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all")
+        public CollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all")
             => GetCollectionClient<User>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/users",

--- a/src/Okta.Sdk/Generated/IApplication.Generated.cs
+++ b/src/Okta.Sdk/Generated/IApplication.Generated.cs
@@ -47,7 +47,7 @@ namespace Okta.Sdk
 
         Task DeactivateAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        IAsyncEnumerable<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
+        CollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
 
         Task<IAppUser> AssignUserToApplicationAsync(AppUser appUser, CancellationToken cancellationToken = default(CancellationToken));
 
@@ -61,9 +61,9 @@ namespace Okta.Sdk
 
         Task<IJsonWebKey> GetApplicationKeyAsync(string keyId, CancellationToken cancellationToken = default(CancellationToken));
 
-        IAsyncEnumerable<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null);
+        CollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null);
 
-        IAsyncEnumerable<IJsonWebKey> ListKeys();
+        CollectionClient<IJsonWebKey> ListKeys();
 
     }
 }

--- a/src/Okta.Sdk/Generated/IApplication.Generated.cs
+++ b/src/Okta.Sdk/Generated/IApplication.Generated.cs
@@ -47,7 +47,7 @@ namespace Okta.Sdk
 
         Task DeactivateAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        CollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
+        ICollectionClient<IAppUser> ListApplicationUsers(string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
 
         Task<IAppUser> AssignUserToApplicationAsync(AppUser appUser, CancellationToken cancellationToken = default(CancellationToken));
 
@@ -61,9 +61,9 @@ namespace Okta.Sdk
 
         Task<IJsonWebKey> GetApplicationKeyAsync(string keyId, CancellationToken cancellationToken = default(CancellationToken));
 
-        CollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null);
+        ICollectionClient<IApplicationGroupAssignment> ListGroupAssignments(string q = null, string after = null, int? limit = -1, string expand = null);
 
-        CollectionClient<IJsonWebKey> ListKeys();
+        ICollectionClient<IJsonWebKey> ListKeys();
 
     }
 }

--- a/src/Okta.Sdk/Generated/IApplicationsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IApplicationsClient.Generated.cs
@@ -24,7 +24,7 @@ namespace Okta.Sdk
         /// <param name="expand">Traverses users link relationship and optionally embeds Application User resource</param>
         /// <param name="includeNonDeleted"></param>
         /// <returns>A collection of <see cref="IApplication"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false);
+        CollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false);
 
         /// <summary>
         /// Adds a new application to your Okta organization.
@@ -66,7 +66,7 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="appId"></param>
         /// <returns>A collection of <see cref="IJsonWebKey"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IJsonWebKey> ListApplicationKeys(string appId);
+        CollectionClient<IJsonWebKey> ListApplicationKeys(string appId);
 
         /// <summary>
         /// Gets a specific [application key credential](#application-key-credential-model) by &#x60;kid&#x60;
@@ -96,7 +96,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of results for a page</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IApplicationGroupAssignment"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null);
+        CollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null);
 
         /// <summary>
         /// Removes a group assignment from an application.
@@ -154,7 +154,7 @@ namespace Okta.Sdk
         /// <param name="filter"></param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IAppUser"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
+        CollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
 
         /// <summary>
         /// Assigns an user to an application with [credentials](#application-user-credentials-object) and an app-specific [profile](#application-user-profile-object). Profile mappings defined for the application are first applied before applying any profile properties specified in the request.

--- a/src/Okta.Sdk/Generated/IApplicationsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IApplicationsClient.Generated.cs
@@ -24,7 +24,7 @@ namespace Okta.Sdk
         /// <param name="expand">Traverses users link relationship and optionally embeds Application User resource</param>
         /// <param name="includeNonDeleted"></param>
         /// <returns>A collection of <see cref="IApplication"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false);
+        ICollectionClient<IApplication> ListApplications(string q = null, string after = null, int? limit = -1, string filter = null, string expand = null, bool? includeNonDeleted = false);
 
         /// <summary>
         /// Adds a new application to your Okta organization.
@@ -66,7 +66,7 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="appId"></param>
         /// <returns>A collection of <see cref="IJsonWebKey"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IJsonWebKey> ListApplicationKeys(string appId);
+        ICollectionClient<IJsonWebKey> ListApplicationKeys(string appId);
 
         /// <summary>
         /// Gets a specific [application key credential](#application-key-credential-model) by &#x60;kid&#x60;
@@ -96,7 +96,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of results for a page</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IApplicationGroupAssignment"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null);
+        ICollectionClient<IApplicationGroupAssignment> ListApplicationGroupAssignments(string appId, string q = null, string after = null, int? limit = -1, string expand = null);
 
         /// <summary>
         /// Removes a group assignment from an application.
@@ -154,7 +154,7 @@ namespace Okta.Sdk
         /// <param name="filter"></param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IAppUser"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
+        ICollectionClient<IAppUser> ListApplicationUsers(string appId, string q = null, string query_scope = null, string after = null, int? limit = -1, string filter = null, string expand = null);
 
         /// <summary>
         /// Assigns an user to an application with [credentials](#application-user-credentials-object) and an app-specific [profile](#application-user-profile-object). Profile mappings defined for the application are first applied before applying any profile properties specified in the request.

--- a/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
@@ -23,7 +23,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of group results in a page</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null);
+        ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null);
 
         /// <summary>
         /// Adds a new group with &#x60;OKTA_GROUP&#x60; type to your organization.
@@ -40,7 +40,7 @@ namespace Okta.Sdk
         /// <param name="after">Specifies the pagination cursor for the next page of rules</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IGroupRule"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "");
+        ICollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "");
 
         /// <summary>
         /// Creates a group rule to dynamically add users to the specified group if they match the condition
@@ -127,7 +127,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of user results in a page</param>
         /// <param name="managedBy"></param>
         /// <returns>A collection of <see cref="IUser"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all");
+        ICollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all");
 
         /// <summary>
         /// Removes a [user](users.html#user-model) from a group with &#x60;OKTA_GROUP&#x60; type.

--- a/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
@@ -23,7 +23,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of group results in a page</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null);
+        CollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = -1, string expand = null);
 
         /// <summary>
         /// Adds a new group with &#x60;OKTA_GROUP&#x60; type to your organization.
@@ -40,7 +40,7 @@ namespace Okta.Sdk
         /// <param name="after">Specifies the pagination cursor for the next page of rules</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IGroupRule"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "");
+        CollectionClient<IGroupRule> ListRules(int? limit = -1, string after = null, string expand = "");
 
         /// <summary>
         /// Creates a group rule to dynamically add users to the specified group if they match the condition
@@ -127,7 +127,7 @@ namespace Okta.Sdk
         /// <param name="limit">Specifies the number of user results in a page</param>
         /// <param name="managedBy"></param>
         /// <returns>A collection of <see cref="IUser"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all");
+        CollectionClient<IUser> ListGroupUsers(string groupId, string after = null, int? limit = -1, string managedBy = "all");
 
         /// <summary>
         /// Removes a [user](users.html#user-model) from a group with &#x60;OKTA_GROUP&#x60; type.

--- a/src/Okta.Sdk/Generated/ILogsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/ILogsClient.Generated.cs
@@ -25,7 +25,7 @@ namespace Okta.Sdk
         /// <param name="sortOrder"></param>
         /// <param name="after"></param>
         /// <returns>A collection of <see cref="ILogEvent"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null);
+        ICollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null);
 
     }
 }

--- a/src/Okta.Sdk/Generated/ILogsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/ILogsClient.Generated.cs
@@ -25,7 +25,7 @@ namespace Okta.Sdk
         /// <param name="sortOrder"></param>
         /// <param name="after"></param>
         /// <returns>A collection of <see cref="ILogEvent"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null);
+        CollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null);
 
     }
 }

--- a/src/Okta.Sdk/Generated/IUser.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUser.Generated.cs
@@ -57,11 +57,11 @@ namespace Okta.Sdk
 
         Task<IFactor> AddFactorAsync(Factor factor, bool? updatePhone = false, string templateId = null, int? tokenLifetimeSeconds = 300, bool? activate = false, CancellationToken cancellationToken = default(CancellationToken));
 
-        CollectionClient<IFactor> ListSupportedFactors();
+        ICollectionClient<IFactor> ListSupportedFactors();
 
-        CollectionClient<IFactor> ListFactors();
+        ICollectionClient<IFactor> ListFactors();
 
-        CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions();
+        ICollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions();
 
         Task<IFactor> GetFactorAsync(string factorId, CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Okta.Sdk/Generated/IUser.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUser.Generated.cs
@@ -57,11 +57,11 @@ namespace Okta.Sdk
 
         Task<IFactor> AddFactorAsync(Factor factor, bool? updatePhone = false, string templateId = null, int? tokenLifetimeSeconds = 300, bool? activate = false, CancellationToken cancellationToken = default(CancellationToken));
 
-        IAsyncEnumerable<IFactor> ListSupportedFactors();
+        CollectionClient<IFactor> ListSupportedFactors();
 
-        IAsyncEnumerable<IFactor> ListFactors();
+        CollectionClient<IFactor> ListFactors();
 
-        IAsyncEnumerable<ISecurityQuestion> ListSupportedSecurityQuestions();
+        CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions();
 
         Task<IFactor> GetFactorAsync(string factorId, CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Okta.Sdk/Generated/IUserFactorsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUserFactorsClient.Generated.cs
@@ -19,7 +19,7 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="IFactor"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IFactor> ListFactors(string userId);
+        CollectionClient<IFactor> ListFactors(string userId);
 
         /// <summary>
         /// Enrolls a user with a supported [factor](#list-factors-to-enroll)
@@ -39,14 +39,14 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="IFactor"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IFactor> ListSupportedFactors(string userId);
+        CollectionClient<IFactor> ListSupportedFactors(string userId);
 
         /// <summary>
         /// Enumerates all available security questions for a user&#x27;s &#x60;question&#x60; factor
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="ISecurityQuestion"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<ISecurityQuestion> ListSupportedSecurityQuestions(string userId);
+        CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId);
 
         /// <summary>
         /// Unenrolls an existing factor for the specified user, allowing the user to enroll a new factor.

--- a/src/Okta.Sdk/Generated/IUserFactorsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUserFactorsClient.Generated.cs
@@ -19,7 +19,7 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="IFactor"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IFactor> ListFactors(string userId);
+        ICollectionClient<IFactor> ListFactors(string userId);
 
         /// <summary>
         /// Enrolls a user with a supported [factor](#list-factors-to-enroll)
@@ -39,14 +39,14 @@ namespace Okta.Sdk
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="IFactor"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IFactor> ListSupportedFactors(string userId);
+        ICollectionClient<IFactor> ListSupportedFactors(string userId);
 
         /// <summary>
         /// Enumerates all available security questions for a user&#x27;s &#x60;question&#x60; factor
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>A collection of <see cref="ISecurityQuestion"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId);
+        ICollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId);
 
         /// <summary>
         /// Unenrolls an existing factor for the specified user, allowing the user to enroll a new factor.

--- a/src/Okta.Sdk/Generated/IUsersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUsersClient.Generated.cs
@@ -25,7 +25,7 @@ namespace Okta.Sdk
         /// <param name="search">Searches for users with a supported filtering  expression for most properties</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IUser"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null);
+        ICollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null);
 
         /// <summary>
         /// Creates a new user in your Okta organization with or without credentials.
@@ -69,7 +69,7 @@ namespace Okta.Sdk
         /// <param name="userId"></param>
         /// <param name="showAll"></param>
         /// <returns>A collection of <see cref="IAppLink"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false);
+        ICollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false);
 
         /// <summary>
         /// Changes a user&#x27;s password by validating the user&#x27;s current password.  This operation can only be performed on users in &#x60;STAGED&#x60;, &#x60;ACTIVE&#x60;, &#x60;PASSWORD_EXPIRED&#x60;, or &#x60;RECOVERY&#x60; status that have a valid [password credential](#password-object)
@@ -96,7 +96,7 @@ namespace Okta.Sdk
         /// <param name="after"></param>
         /// <param name="limit"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1);
+        ICollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1);
 
         /// <summary>
         /// Activates a user.  This operation can only be performed on users with a &#x60;STAGED&#x60; status.  Activation of a user is an asynchronous operation.  The user will have the &#x60;transitioningToStatus&#x60; property with a value of &#x60;ACTIVE&#x60; during activation to indicate that the user hasn&#x27;t completed the asynchronous operation.  The user will have a status of &#x60;ACTIVE&#x60; when the activation process is complete.
@@ -172,7 +172,7 @@ namespace Okta.Sdk
         /// <param name="userId"></param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IRole"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IRole> ListAssignedRoles(string userId, string expand = null);
+        ICollectionClient<IRole> ListAssignedRoles(string userId, string expand = null);
 
         /// <summary>
         /// Unassigns a role from a user.
@@ -191,7 +191,7 @@ namespace Okta.Sdk
         /// <param name="after"></param>
         /// <param name="limit"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        CollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1);
+        ICollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1);
 
         /// <summary>
         /// 

--- a/src/Okta.Sdk/Generated/IUsersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IUsersClient.Generated.cs
@@ -25,7 +25,7 @@ namespace Okta.Sdk
         /// <param name="search">Searches for users with a supported filtering  expression for most properties</param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IUser"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null);
+        CollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null);
 
         /// <summary>
         /// Creates a new user in your Okta organization with or without credentials.
@@ -69,7 +69,7 @@ namespace Okta.Sdk
         /// <param name="userId"></param>
         /// <param name="showAll"></param>
         /// <returns>A collection of <see cref="IAppLink"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IAppLink> ListAppLinks(string userId, bool? showAll = false);
+        CollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false);
 
         /// <summary>
         /// Changes a user&#x27;s password by validating the user&#x27;s current password.  This operation can only be performed on users in &#x60;STAGED&#x60;, &#x60;ACTIVE&#x60;, &#x60;PASSWORD_EXPIRED&#x60;, or &#x60;RECOVERY&#x60; status that have a valid [password credential](#password-object)
@@ -96,7 +96,7 @@ namespace Okta.Sdk
         /// <param name="after"></param>
         /// <param name="limit"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1);
+        CollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1);
 
         /// <summary>
         /// Activates a user.  This operation can only be performed on users with a &#x60;STAGED&#x60; status.  Activation of a user is an asynchronous operation.  The user will have the &#x60;transitioningToStatus&#x60; property with a value of &#x60;ACTIVE&#x60; during activation to indicate that the user hasn&#x27;t completed the asynchronous operation.  The user will have a status of &#x60;ACTIVE&#x60; when the activation process is complete.
@@ -172,7 +172,7 @@ namespace Okta.Sdk
         /// <param name="userId"></param>
         /// <param name="expand"></param>
         /// <returns>A collection of <see cref="IRole"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IRole> ListAssignedRoles(string userId, string expand = null);
+        CollectionClient<IRole> ListAssignedRoles(string userId, string expand = null);
 
         /// <summary>
         /// Unassigns a role from a user.
@@ -191,7 +191,7 @@ namespace Okta.Sdk
         /// <param name="after"></param>
         /// <param name="limit"></param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1);
+        CollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1);
 
         /// <summary>
         /// 

--- a/src/Okta.Sdk/Generated/LogsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/LogsClient.Generated.cs
@@ -29,8 +29,8 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public CollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null)
-            => GetCollectionClient<LogEvent>(new HttpRequest
+        public ICollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null)
+            => GetCollectionClient<ILogEvent>(new HttpRequest
             {
                 Uri = "/api/v1/logs",
                 

--- a/src/Okta.Sdk/Generated/LogsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/LogsClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public IAsyncEnumerable<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null)
+        public CollectionClient<ILogEvent> GetLogs(string until = null, string since = null, string filter = null, string q = null, int? limit = 100, string sortOrder = "ASCENDING", string after = null)
             => GetCollectionClient<LogEvent>(new HttpRequest
             {
                 Uri = "/api/v1/logs",

--- a/src/Okta.Sdk/Generated/User.Generated.cs
+++ b/src/Okta.Sdk/Generated/User.Generated.cs
@@ -98,15 +98,15 @@ namespace Okta.Sdk
             => GetClient().UserFactors.AddFactorAsync(factor, Id, updatePhone, templateId, tokenLifetimeSeconds, activate, cancellationToken);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IFactor> ListSupportedFactors()
+        public CollectionClient<IFactor> ListSupportedFactors()
             => GetClient().UserFactors.ListSupportedFactors(Id);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IFactor> ListFactors()
+        public CollectionClient<IFactor> ListFactors()
             => GetClient().UserFactors.ListFactors(Id);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<ISecurityQuestion> ListSupportedSecurityQuestions()
+        public CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions()
             => GetClient().UserFactors.ListSupportedSecurityQuestions(Id);
         
         /// <inheritdoc />

--- a/src/Okta.Sdk/Generated/User.Generated.cs
+++ b/src/Okta.Sdk/Generated/User.Generated.cs
@@ -98,15 +98,15 @@ namespace Okta.Sdk
             => GetClient().UserFactors.AddFactorAsync(factor, Id, updatePhone, templateId, tokenLifetimeSeconds, activate, cancellationToken);
         
         /// <inheritdoc />
-        public CollectionClient<IFactor> ListSupportedFactors()
+        public ICollectionClient<IFactor> ListSupportedFactors()
             => GetClient().UserFactors.ListSupportedFactors(Id);
         
         /// <inheritdoc />
-        public CollectionClient<IFactor> ListFactors()
+        public ICollectionClient<IFactor> ListFactors()
             => GetClient().UserFactors.ListFactors(Id);
         
         /// <inheritdoc />
-        public CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions()
+        public ICollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions()
             => GetClient().UserFactors.ListSupportedSecurityQuestions(Id);
         
         /// <inheritdoc />

--- a/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IFactor> ListFactors(string userId)
+        public CollectionClient<IFactor> ListFactors(string userId)
             => GetCollectionClient<Factor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors",
@@ -60,7 +60,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IFactor> ListSupportedFactors(string userId)
+        public CollectionClient<IFactor> ListSupportedFactors(string userId)
             => GetCollectionClient<Factor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/catalog",
@@ -72,7 +72,7 @@ namespace Okta.Sdk
             });
                     
         /// <inheritdoc />
-        public IAsyncEnumerable<ISecurityQuestion> ListSupportedSecurityQuestions(string userId)
+        public CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId)
             => GetCollectionClient<SecurityQuestion>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/questions",

--- a/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
@@ -29,8 +29,8 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public CollectionClient<IFactor> ListFactors(string userId)
-            => GetCollectionClient<Factor>(new HttpRequest
+        public ICollectionClient<IFactor> ListFactors(string userId)
+            => GetCollectionClient<IFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors",
                 
@@ -60,8 +60,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IFactor> ListSupportedFactors(string userId)
-            => GetCollectionClient<Factor>(new HttpRequest
+        public ICollectionClient<IFactor> ListSupportedFactors(string userId)
+            => GetCollectionClient<IFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/catalog",
                 
@@ -72,8 +72,8 @@ namespace Okta.Sdk
             });
                     
         /// <inheritdoc />
-        public CollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId)
-            => GetCollectionClient<SecurityQuestion>(new HttpRequest
+        public ICollectionClient<ISecurityQuestion> ListSupportedSecurityQuestions(string userId)
+            => GetCollectionClient<ISecurityQuestion>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/questions",
                 

--- a/src/Okta.Sdk/Generated/UsersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UsersClient.Generated.cs
@@ -29,8 +29,8 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public CollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null)
-            => GetCollectionClient<User>(new HttpRequest
+        public ICollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null)
+            => GetCollectionClient<IUser>(new HttpRequest
             {
                 Uri = "/api/v1/users",
                 
@@ -97,8 +97,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false)
-            => GetCollectionClient<AppLink>(new HttpRequest
+        public ICollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false)
+            => GetCollectionClient<IAppLink>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/appLinks",
                 
@@ -137,8 +137,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1)
-            => GetCollectionClient<Group>(new HttpRequest
+        public ICollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1)
+            => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/groups",
                 
@@ -263,8 +263,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IRole> ListAssignedRoles(string userId, string expand = null)
-            => GetCollectionClient<Role>(new HttpRequest
+        public ICollectionClient<IRole> ListAssignedRoles(string userId, string expand = null)
+            => GetCollectionClient<IRole>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles",
                 
@@ -292,8 +292,8 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public CollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1)
-            => GetCollectionClient<Group>(new HttpRequest
+        public ICollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1)
+            => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups",
                 

--- a/src/Okta.Sdk/Generated/UsersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UsersClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null)
+        public CollectionClient<IUser> ListUsers(string q = null, string after = null, int? limit = -1, string filter = null, string format = null, string search = null, string expand = null)
             => GetCollectionClient<User>(new HttpRequest
             {
                 Uri = "/api/v1/users",
@@ -97,7 +97,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IAppLink> ListAppLinks(string userId, bool? showAll = false)
+        public CollectionClient<IAppLink> ListAppLinks(string userId, bool? showAll = false)
             => GetCollectionClient<AppLink>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/appLinks",
@@ -137,7 +137,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1)
+        public CollectionClient<IGroup> ListUserGroups(string userId, string after = null, int? limit = -1)
             => GetCollectionClient<Group>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/groups",
@@ -263,7 +263,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IRole> ListAssignedRoles(string userId, string expand = null)
+        public CollectionClient<IRole> ListAssignedRoles(string userId, string expand = null)
             => GetCollectionClient<Role>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles",
@@ -292,7 +292,7 @@ namespace Okta.Sdk
                 }, cancellationToken).ConfigureAwait(false);
         
         /// <inheritdoc />
-        public IAsyncEnumerable<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1)
+        public CollectionClient<IGroup> ListGroupTargetsForRole(string userId, string roleId, string after = null, int? limit = -1)
             => GetCollectionClient<Group>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups",

--- a/src/Okta.Sdk/HttpRequest.cs
+++ b/src/Okta.Sdk/HttpRequest.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Okta.Sdk.Internal
+namespace Okta.Sdk
 {
     /// <summary>
     /// Represents an HTTP request with a URI and optional payload and parameters.

--- a/src/Okta.Sdk/HttpResponse{T}.cs
+++ b/src/Okta.Sdk/HttpResponse{T}.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace Okta.Sdk.Internal
+namespace Okta.Sdk
 {
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name must match first type name

--- a/src/Okta.Sdk/ICollectionClient{T}.cs
+++ b/src/Okta.Sdk/ICollectionClient{T}.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ICollectionClient{T}.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// A collection of <see cref="Resource">Resources</see> that can be enumerated asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// Using this object with LINQ will automatically enumerate a paginated Okta collection.
+    /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
+    /// </remarks>
+    /// <typeparam name="T">The <see cref="Resource"/> type in the collection.</typeparam>
+    public interface ICollectionClient<T> : IAsyncEnumerable<T>
+        where T : IResource
+    {
+        /// <summary>
+        /// Returns an enumerator that can be used to retrieve items from an Okta collection page-by-page.
+        /// Use this only if you need to enumerate collections manually; otherwise, use LINQ.
+        /// </summary>
+        /// <remarks>
+        /// /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
+        /// </remarks>
+        /// <returns>An enumerator that retrieves items from an Okta collection page-by-page.</returns>
+        IPagedCollectionEnumerator<T> GetPagedEnumerator();
+    }
+}

--- a/src/Okta.Sdk/IOktaClient.cs
+++ b/src/Okta.Sdk/IOktaClient.cs
@@ -111,7 +111,7 @@ namespace Okta.Sdk
         /// <typeparam name="T">The <see cref="Resource"/> type of the collection.</typeparam>
         /// <param name="href">The collection URL.</param>
         /// <returns>A collection that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<T> GetCollection<T>(string href)
+        CollectionClient<T> GetCollection<T>(string href)
             where T : Resource, new();
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Okta.Sdk
         /// <typeparam name="T">The <see cref="Resource"/> type of the collection.</typeparam>
         /// <param name="request">The request options.</param>
         /// <returns>A collection that can be enumerated asynchronously.</returns>
-        IAsyncEnumerable<T> GetCollection<T>(HttpRequest request)
+        CollectionClient<T> GetCollection<T>(HttpRequest request)
             where T : Resource, new();
 
         /// <summary>

--- a/src/Okta.Sdk/IOktaClient.cs
+++ b/src/Okta.Sdk/IOktaClient.cs
@@ -112,7 +112,7 @@ namespace Okta.Sdk
         /// <param name="href">The collection URL.</param>
         /// <returns>A collection that can be enumerated asynchronously.</returns>
         CollectionClient<T> GetCollection<T>(string href)
-            where T : Resource, new();
+            where T : IResource;
 
         /// <summary>
         /// Gets a collection of resources from the Okta API by URL.
@@ -121,7 +121,7 @@ namespace Okta.Sdk
         /// <param name="request">The request options.</param>
         /// <returns>A collection that can be enumerated asynchronously.</returns>
         CollectionClient<T> GetCollection<T>(HttpRequest request)
-            where T : Resource, new();
+            where T : IResource;
 
         /// <summary>
         /// Posts data to an endpoint by URL.

--- a/src/Okta.Sdk/IPagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/IPagedCollectionEnumerator{T}.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="IPagedCollectionEnumerator{T}.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Enumerates an Okta collection by retrieving pages of results.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    public interface IPagedCollectionEnumerator<T>
+        where T : IResource
+    {
+        /// <summary>
+        /// Gets the current page of items, or <c>null</c> if <see cref="MoveNextAsync(CancellationToken)"/> has not yet been called.
+        /// </summary>
+        /// <value>
+        /// The current page of items, if any.
+        /// </value>
+        CollectionPage<T> CurrentPage { get; }
+
+        /// <summary>
+        /// Asynchronously retrieves the next page of results and updates <see cref="CurrentPage"/>. If there are no more pages, this method returns <see langword="false"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// <see langword="true"/> if <see cref="CurrentPage"/> has been updated with new items, <see langword="false"/> if the collection has been exhausted.
+        /// </returns>
+        Task<bool> MoveNextAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -18,7 +18,7 @@ namespace Okta.Sdk.Internal
     /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
     /// <typeparam name="T">The type of items in the collection.</typeparam>
     public sealed class CollectionAsyncEnumerator<T> : IAsyncEnumerator<T>
-        where T : Resource, new()
+        where T : IResource
     {
         private readonly PagedCollectionEnumerator<T> _pagedEnumerator;
 

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -12,20 +12,18 @@ using System.Threading.Tasks;
 namespace Okta.Sdk.Internal
 {
     /// <summary>
-    /// Enumerates an Okta API collection using the defined paging contract.
+    /// Enumerates an Okta API collection for use with LINQ.
+    /// This is an internal class; use <see cref="PagedCollectionEnumerator{T}"/> if you need to page collections yourself.
     /// </summary>
     /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
     /// <typeparam name="T">The type of items in the collection.</typeparam>
     public sealed class CollectionAsyncEnumerator<T> : IAsyncEnumerator<T>
         where T : Resource, new()
     {
-        private readonly IDataStore _dataStore;
-        private readonly RequestContext _requestContext;
+        private readonly PagedCollectionEnumerator<T> _pagedEnumerator;
 
         private bool _initialized = false;
-        private T[] _localPage;
         private int _localPageIndex;
-        private HttpRequest _nextRequest;
 
         private bool _disposedValue = false; // To detect redundant calls
 
@@ -40,65 +38,36 @@ namespace Okta.Sdk.Internal
             HttpRequest initialRequest,
             RequestContext requestContext)
         {
-            _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
-            _nextRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
-            _requestContext = requestContext;
+            _pagedEnumerator = new PagedCollectionEnumerator<T>(dataStore, initialRequest, requestContext);
         }
 
         /// <inheritdoc/>
-        public T Current => _localPage[_localPageIndex++];
+        public T Current => _pagedEnumerator.CurrentPage.Items[_localPageIndex++];
 
 #pragma warning disable UseAsyncSuffix // Must match interface
         /// <inheritdoc/>
         public async Task<bool> MoveNext(CancellationToken cancellationToken)
 #pragma warning restore UseAsyncSuffix // Must match interface
         {
-            var hasMoreLocalItems = _initialized && _localPage.Length != 0 && _localPageIndex < _localPage.Length;
+            var hasMoreLocalItems = _initialized
+                && _pagedEnumerator.CurrentPage.Items.Any()
+                && _localPageIndex < _pagedEnumerator.CurrentPage.Items.Length;
+
             if (hasMoreLocalItems)
             {
                 return true;
             }
 
-            if (_nextRequest == null)
+            var movedNext = await _pagedEnumerator.MoveNextAsync(cancellationToken).ConfigureAwait(false);
+            if (!movedNext)
             {
                 return false;
             }
 
-            var nextPage = await _dataStore.GetArrayAsync<T>(
-                _nextRequest,
-                _requestContext,
-                cancellationToken).ConfigureAwait(false);
-
             _initialized = true;
-
-            _localPage = nextPage.Payload.ToArray();
             _localPageIndex = 0;
 
-            _nextRequest = GetNextLink(nextPage);
-
-            return _localPage.Any();
-        }
-
-        private static HttpRequest GetNextLink(HttpResponse response)
-        {
-            var linkHeaders = response
-                .Headers?
-                .Where(kvp => kvp.Key.Equals("Link", StringComparison.OrdinalIgnoreCase))
-                .Select(kvp => kvp.Value);
-
-            var nextUri = string.Empty;
-            if (linkHeaders != null)
-            {
-                nextUri = LinkHeaderParser
-                .Parse(linkHeaders.SelectMany(x => x))
-                .Where(x => x.Relation == "next")
-                .SingleOrDefault()
-                .Target;
-            }
-
-            return string.IsNullOrEmpty(nextUri)
-                ? null
-                : new HttpRequest { Uri = nextUri };
+            return _pagedEnumerator.CurrentPage.Items.Any();
         }
 
         private void Dispose(bool disposing)

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -42,7 +42,7 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
-        public T Current => _pagedEnumerator.CurrentPage.Items[_localPageIndex++];
+        public T Current => _pagedEnumerator.CurrentPage.Items.ElementAt(_localPageIndex++);
 
 #pragma warning disable UseAsyncSuffix // Must match interface
         /// <inheritdoc/>
@@ -51,7 +51,7 @@ namespace Okta.Sdk.Internal
         {
             var hasMoreLocalItems = _initialized
                 && _pagedEnumerator.CurrentPage.Items.Any()
-                && _localPageIndex < _pagedEnumerator.CurrentPage.Items.Length;
+                && _localPageIndex < _pagedEnumerator.CurrentPage.Items.Count();
 
             if (hasMoreLocalItems)
             {

--- a/src/Okta.Sdk/Internal/DefaultDataStore.cs
+++ b/src/Okta.Sdk/Internal/DefaultDataStore.cs
@@ -185,7 +185,7 @@ namespace Okta.Sdk.Internal
 
         /// <inheritdoc/>
         public async Task<HttpResponse<IEnumerable<T>>> GetArrayAsync<T>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
-            where T : Resource, new()
+            where T : IResource
         {
             PrepareRequest(request, requestContext);
 

--- a/src/Okta.Sdk/Internal/IDataStore.cs
+++ b/src/Okta.Sdk/Internal/IDataStore.cs
@@ -52,7 +52,7 @@ namespace Okta.Sdk.Internal
         /// <returns>An array of deserialized resources and <see cref="HttpResponse"/> data.</returns>
         /// <exception cref="OktaApiException">An API error occurred.</exception>
         Task<HttpResponse<IEnumerable<T>>> GetArrayAsync<T>(HttpRequest request, RequestContext requestContext, CancellationToken cancellationToken)
-            where T : Resource, new();
+            where T : IResource;
 
         /// <summary>
         /// Posts data to an endpoint and deserializes the response to a <see cref="Resource"/> type.

--- a/src/Okta.Sdk/Internal/LinkHeaderParser.cs
+++ b/src/Okta.Sdk/Internal/LinkHeaderParser.cs
@@ -78,8 +78,10 @@ namespace Okta.Sdk.Internal
         /// Parses a set of header values to <see cref="WebLink"/>s.
         /// </summary>
         /// <param name="headerValues">The HTTP header values to parse.</param>
-        /// <returns>Any Web Links found in the headers.</returns>
+        /// <returns>
+        /// Any Web Links found in the headers. If <paramref name="headerValues"/> is null, an empty enumerable is returned.
+        /// </returns>
         public static IEnumerable<WebLink> Parse(IEnumerable<string> headerValues)
-            => Parse(headerValues.ToArray());
+            => Parse(headerValues?.ToArray() ?? new string[0]);
     }
 }

--- a/src/Okta.Sdk/Internal/ResourceTypeResolverFactory.cs
+++ b/src/Okta.Sdk/Internal/ResourceTypeResolverFactory.cs
@@ -62,7 +62,10 @@ namespace Okta.Sdk.Internal
                 return possiblyInterface;
             }
 
-            var foundConcrete = AllTypes.FirstOrDefault(x => x.IsClass == true && typeInfo.IsAssignableFrom(x));
+            var foundConcrete = AllTypes.FirstOrDefault(x => 
+                x.IsClass == true
+                && typeInfo.IsAssignableFrom(x)
+                && x.BaseType == typeof(Resource));
             return foundConcrete?.AsType() ?? possiblyInterface;
         }
 

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Version>1.0.0</Version>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -170,7 +170,7 @@ namespace Okta.Sdk
         /// <param name="initialRequest">The initial HTTP request.</param>
         /// <returns>The collection client.</returns>
         protected CollectionClient<T> GetCollectionClient<T>(HttpRequest initialRequest)
-            where T : Resource, new()
+            where T : IResource
             => new CollectionClient<T>(_dataStore, initialRequest, _requestContext);
 
         /// <inheritdoc/>

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -188,7 +188,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public CollectionClient<T> GetCollection<T>(string href)
-            where T : Resource, new()
+            where T : IResource
             => GetCollection<T>(new HttpRequest
             {
                 Uri = href,
@@ -196,7 +196,7 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public CollectionClient<T> GetCollection<T>(HttpRequest request)
-            where T : Resource, new()
+            where T : IResource
             => GetCollectionClient<T>(request);
 
         /// <inheritdoc/>

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -187,7 +187,7 @@ namespace Okta.Sdk
         }
 
         /// <inheritdoc/>
-        public IAsyncEnumerable<T> GetCollection<T>(string href)
+        public CollectionClient<T> GetCollection<T>(string href)
             where T : Resource, new()
             => GetCollection<T>(new HttpRequest
             {
@@ -195,7 +195,7 @@ namespace Okta.Sdk
             });
 
         /// <inheritdoc/>
-        public IAsyncEnumerable<T> GetCollection<T>(HttpRequest request)
+        public CollectionClient<T> GetCollection<T>(HttpRequest request)
             where T : Resource, new()
             => GetCollectionClient<T>(request);
 

--- a/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
@@ -11,13 +11,9 @@ using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
-    /// <summary>
-    /// Enumerates an Okta collection by retrieving pages of results.
-    /// </summary>
-    /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
-    /// <typeparam name="T">The type of items in the collection.</typeparam>
-    public class PagedCollectionEnumerator<T>
-        where T : Resource, new()
+    /// <inheritdoc/>
+    public class PagedCollectionEnumerator<T> : IPagedCollectionEnumerator<T>
+        where T : IResource
     {
         private readonly IDataStore _dataStore;
         private readonly RequestContext _requestContext;
@@ -40,21 +36,10 @@ namespace Okta.Sdk
             _nextRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
         }
 
-        /// <summary>
-        /// Gets the current page of items, or <c>null</c> if <see cref="MoveNextAsync(CancellationToken)"/> has not yet been called.
-        /// </summary>
-        /// <value>
-        /// The current page of items, if any.
-        /// </value>
+        /// <inheritdoc/>
         public CollectionPage<T> CurrentPage { get; private set; }
 
-        /// <summary>
-        /// Asynchronously retrieves the next page of results and updates <see cref="CurrentPage"/>. If there are no more pages, this method returns <see langword="false"/>.
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// <see langword="true"/> if <see cref="CurrentPage"/> has been updated with new items, <see langword="false"/> if the collection has been exhausted.
-        /// </returns>
+        /// <inheritdoc/>
         public async Task<bool> MoveNextAsync(CancellationToken cancellationToken = default)
         {
             if (_nextRequest == null)

--- a/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
@@ -1,0 +1,108 @@
+﻿// <copyright file="PagedCollectionEnumerator{T}.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Okta.Sdk.Internal;
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Enumerates an Okta collection by retrieving pages of results.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.</remarks>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    public class PagedCollectionEnumerator<T>
+        where T : Resource, new()
+    {
+        private readonly IDataStore _dataStore;
+        private readonly RequestContext _requestContext;
+
+        private HttpRequest _nextRequest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagedCollectionEnumerator{T}"/> class.
+        /// </summary>
+        /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>
+        /// <param name="initialRequest">The initial HTTP request options.</param>
+        /// <param name="requestContext">The request context.</param>
+        public PagedCollectionEnumerator(
+            IDataStore dataStore,
+            HttpRequest initialRequest,
+            RequestContext requestContext)
+        {
+            _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
+            _requestContext = requestContext;
+            _nextRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
+        }
+
+        /// <summary>
+        /// Gets the current page of items, or <c>null</c> if <see cref="MoveNextAsync(CancellationToken)"/> has not yet been called.
+        /// </summary>
+        /// <value>
+        /// The current page of items, if any.
+        /// </value>
+        public CollectionPage<T> CurrentPage { get; private set; }
+
+        /// <summary>
+        /// Asynchronously retrieves the next page of results and updates <see cref="CurrentPage"/>. If there are no more pages, this method returns <see langword="false"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// <see langword="true"/> if <see cref="CurrentPage"/> has been updated with new items, <see langword="false"/> if the collection has been exhausted.
+        /// </returns>
+        public async Task<bool> MoveNextAsync(CancellationToken cancellationToken = default)
+        {
+            if (_nextRequest == null)
+            {
+                return false;
+            }
+
+            var response = await _dataStore.GetArrayAsync<T>(
+                _nextRequest,
+                _requestContext,
+                cancellationToken).ConfigureAwait(false);
+
+            var items = response?.Payload?.ToArray() ?? new T[0];
+
+            CurrentPage = new CollectionPage<T>
+            {
+                Items = items,
+                Response = response,
+                NextLink = GetNextLink(response),
+            };
+
+            _nextRequest = null;
+            if (!string.IsNullOrEmpty(CurrentPage.NextLink?.Target))
+            {
+                _nextRequest = new HttpRequest { Uri = CurrentPage.NextLink.Target };
+            }
+
+            return true;
+        }
+
+        private static WebLink GetNextLink(HttpResponse response)
+        {
+            if (response?.Headers == null)
+            {
+                return null;
+            }
+
+            var linkHeaders = response
+                .Headers
+                .Where(kvp => kvp.Key.Equals("Link", StringComparison.OrdinalIgnoreCase))
+                .Select(kvp => kvp.Value);
+
+            var nextLink = LinkHeaderParser
+                .Parse(linkHeaders.SelectMany(x => x))
+                .Where(x => x.Relation == "next")
+                .FirstOrDefault();
+
+            return nextLink;
+        }
+    }
+}

--- a/src/Okta.Sdk/WebLink.cs
+++ b/src/Okta.Sdk/WebLink.cs
@@ -36,5 +36,8 @@ namespace Okta.Sdk
         /// The link relation.
         /// </value>
         public string Relation { get; }
+
+        /// <inheritdoc/>
+        public override string ToString() => Target;
     }
 }

--- a/src/Okta.Sdk/WebLink.cs
+++ b/src/Okta.Sdk/WebLink.cs
@@ -3,15 +3,15 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace Okta.Sdk.Internal
+namespace Okta.Sdk
 {
     /// <summary>
     /// Represents an <a href="https://tools.ietf.org/html/rfc5988">RFC 5988</a> Web Link.
     /// </summary>
-    public struct WebLink
+    public class WebLink
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="WebLink"/> struct.
+        /// Initializes a new instance of the <see cref="WebLink"/> class.
         /// </summary>
         /// <param name="target">The link target.</param>
         /// <param name="relation">The link relation.</param>


### PR DESCRIPTION
Resolves #222 

- [x] Split up existing internal enumerator to separate LINQ support (internal) and manual pagination (available to consumers)
- [x] Integration test for collection enumeration using LINQ
- [x] Integration test for manual collection enumeration by retrieving pages and resuming enumeration on a specific page