### PR TITLE
Fixed README to use correct OktaClientConfiguration Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Construct a client instance by passing it your Okta domain name and API token:
 ``` csharp
 var client = new OktaClient(new OktaClientConfiguration
 {
-    OrgUrl = "https://{{yourOktaDomain}}",
+    OktaDomain = "https://{{yourOktaDomain}}",
     Token = "{{yourApiToken}}"
 });
 ```


### PR DESCRIPTION
Merge [third-party PR](https://github.com/okta/okta-sdk-dotnet/pull/284) into `origin`.