### PR TITLE
Adds safe generation of user-agent string

### DIFF
--- a/src/Okta.Sdk/Internal/DefaultDataStore.cs
+++ b/src/Okta.Sdk/Internal/DefaultDataStore.cs
@@ -40,7 +40,7 @@ namespace Okta.Sdk.Internal
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _resourceFactory = resourceFactory ?? throw new ArgumentNullException(nameof(resourceFactory));
             _logger = logger;
-            _userAgentBuilder = new UserAgentBuilder();
+            _userAgentBuilder = new UserAgentBuilder(_logger);
         }
 
         /// <inheritdoc/>

--- a/src/Okta.Sdk/Internal/UserAgentBuilder.cs
+++ b/src/Okta.Sdk/Internal/UserAgentBuilder.cs
@@ -43,26 +43,43 @@ namespace Okta.Sdk.Internal
 
         private string Generate()
         {
+            string sdkToken = string.Empty;
+            string runtimeToken = string.Empty;
+            string operatingSystemToken = string.Empty;
+
             try
             {
-                var sdkToken = $"{OktaSdkUserAgentName}/{GetSdkVersion()}";
-
-                var runtimeToken = $"runtime/{Sanitize(RuntimeInformation.FrameworkDescription)}";
-
-                var operatingSystemToken = $"os/{Sanitize(RuntimeInformation.OSDescription)}";
-
-                return string.Join(
-                    " ",
-                    sdkToken,
-                    runtimeToken,
-                    operatingSystemToken)
-                .Trim();
+                sdkToken = $"{OktaSdkUserAgentName}/{GetSdkVersion()}";
             }
             catch (Exception ex)
             {
-                _logger.LogDebug($"An exception was thrown while generating the user agent string.  Exception: {ex.Message}");
-                return string.Empty;
+                _logger.LogDebug($"An error occurred generating the {nameof(sdkToken)} portion of the user-agent string.  Exception: {ex.Message}");
             }
+
+            try
+            {
+                runtimeToken = $"runtime/{Sanitize(RuntimeInformation.FrameworkDescription)}";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"An error occurred generating the {nameof(runtimeToken)} portion of the user-agent string.  Exception: {ex.Message}");
+            }
+
+            try
+            {
+                operatingSystemToken = $"os/{Sanitize(RuntimeInformation.OSDescription)}";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"An error occurred generating the {nameof(operatingSystemToken)} portion of the user-agent string.  Exception: {ex.Message}");
+            }
+
+            return string.Join(
+                " ",
+                sdkToken,
+                runtimeToken,
+                operatingSystemToken)
+            .Trim();
         }
 
         private static string GetSdkVersion()

--- a/src/Okta.Sdk/Internal/UserAgentBuilder.cs
+++ b/src/Okta.Sdk/Internal/UserAgentBuilder.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Okta.Sdk.Internal
 {
@@ -31,7 +32,7 @@ namespace Okta.Sdk.Internal
         /// <param name="logger">An optional logging interface</param>
         public UserAgentBuilder(ILogger logger = null)
         {
-            _logger = logger;
+            _logger = logger ?? NullLogger.Instance;
             _cachedUserAgent = new Lazy<string>(Generate);
         }
 
@@ -53,7 +54,7 @@ namespace Okta.Sdk.Internal
             }
             catch (Exception ex)
             {
-                _logger.LogDebug($"An error occurred generating the {nameof(sdkToken)} portion of the user-agent string.  Exception: {ex.Message}");
+                _logger.LogError($"An error occurred generating the {nameof(sdkToken)} portion of the user-agent string.  Exception: {ex.Message}");
             }
 
             try
@@ -62,7 +63,7 @@ namespace Okta.Sdk.Internal
             }
             catch (Exception ex)
             {
-                _logger.LogDebug($"An error occurred generating the {nameof(runtimeToken)} portion of the user-agent string.  Exception: {ex.Message}");
+                _logger.LogError($"An error occurred generating the {nameof(runtimeToken)} portion of the user-agent string.  Exception: {ex.Message}");
             }
 
             try
@@ -71,7 +72,7 @@ namespace Okta.Sdk.Internal
             }
             catch (Exception ex)
             {
-                _logger.LogDebug($"An error occurred generating the {nameof(operatingSystemToken)} portion of the user-agent string.  Exception: {ex.Message}");
+                _logger.LogError($"An error occurred generating the {nameof(operatingSystemToken)} portion of the user-agent string.  Exception: {ex.Message}");
             }
 
             return string.Join(


### PR DESCRIPTION
Fixes #296 

Here's my first PR to this project.  🎆 I'll sign the CLA when I'm in the office tomorrow.

A note on the code:  I added an optional `ILogger` in the event someone does want to troubleshoot why the user-agent string is empty.  This way it at least provides a way of digging into it more if they desire. 
 Not sure if I got the message level right though.