### PR TITLE
Fixes a couple broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains the Okta management SDK for .NET. This SDK can be used 
 We also publish these other libraries for .NET:
  
 * [Okta ASP.NET middleware](https://github.com/okta/okta-aspnet)
+* [Okta .NET Authentication SDK](https://github.com/okta/okta-auth-dotnet)
  
 You can learn more on the [Okta + .NET][lang-landing] page in our documentation.
 
@@ -411,6 +412,6 @@ We're happy to accept contributions and PRs! Please see the [contribution guide]
 [devforum]: https://devforum.okta.com/
 [dotnetdocs]: https://developer.okta.com/okta-sdk-dotnet/latest/
 [lang-landing]: https://developer.okta.com/code/dotnet/
-[github-issues]: https://developer.okta.com/okta-sdk-dotnet/issues
-[github-releases]: https://developer.okta.com/okta-sdk-dotnet/releases
+[github-issues]: https://github.com/okta/okta-sdk-dotnet/issues
+[github-releases]: https://github.com/okta/okta-sdk-dotnet/releases
 [Rate Limiting at Okta]: https://developer.okta.com/docs/api/getting_started/rate-limits


### PR DESCRIPTION
2 links in the readme have been broken for a while, pointing to a 404 on Okta.com when they should be pointing at this github releases and issues pages.

Also adds Okta .NET Authentication SDK to the "We also publish these other libraries for .NET" section of the readme