### PR TITLE
Upgrades dotnet core version to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: csharp
-dotnet: 2.1.3 # .NET Core
 mono: latest
-dist: trusty
+sudo: required
+dist: xenial
+dotnet: 2.2
+
 script:
   - if [[ $TRAVIS_EVENT_TYPE = 'push' ]]; then
         ./build.sh --target DefaultIT;


### PR DESCRIPTION
* dotnet 2.1 version is failing to install on travis
* As per this [thread](https://travis-ci.community/t/dotnet-core-2-2/1216/11), we need to switch to `xenial` dist