### PR TITLE
Do not skip empty arrays in serialization

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -150,8 +150,10 @@ namespace Okta.Sdk.IntegrationTests
             }
         }
 
-        [Fact]
-        public async Task UpdateUserProfile()
+        [Theory]
+        [InlineData("Batman")]
+        [InlineData("")]
+        public async Task UpdateUserProfile(string nickName)
         {
             var client = TestClient.Create();
             var guid = Guid.NewGuid();
@@ -173,13 +175,13 @@ namespace Okta.Sdk.IntegrationTests
             try
             {
                 // Update profile
-                createdUser.Profile["nickName"] = "Batman";
+                createdUser.Profile["nickName"] = nickName;
 
                 var updatedUser = await createdUser.UpdateAsync();
                 var retrievedUpdatedUser = await client.Users.GetUserAsync(createdUser.Id);
 
-                updatedUser.Profile.GetProperty<string>("nickName").Should().Be("Batman");
-                retrievedUpdatedUser.Profile.GetProperty<string>("nickName").Should().Be("Batman");
+                updatedUser.Profile.GetProperty<string>("nickName").Should().Be(nickName);
+                retrievedUpdatedUser.Profile.GetProperty<string>("nickName").Should().Be(nickName);
             }
             finally
             {

--- a/src/Okta.Sdk.UnitTests/ResourceSerializingConverterShould.cs
+++ b/src/Okta.Sdk.UnitTests/ResourceSerializingConverterShould.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="ResourceSerializingConverterShould.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Okta.Sdk.Internal;
+using Xunit;
+
+namespace Okta.Sdk.UnitTests
+{
+    public class ResourceSerializingConverterShould
+    {
+        [Fact]
+        public void RemoveNullPropertiesInSerialization()
+        {
+            var user = new User()
+            {
+                Profile = new UserProfile()
+                {
+                    FirstName = "John",
+                },
+            };
+
+            user.Profile["foo"] = "fooValue";
+            user.Profile["bar"] = null;
+            user.Profile["baz"] = new List<string>() { "1", "2" };
+
+            var serializer = new DefaultSerializer();
+            var serializedUser = serializer.Serialize(user);
+
+            serializedUser.Trim().Should().Contain("\"foo\":\"fooValue\"");
+            serializedUser.Trim().Should().NotContain("\"bar\":");
+            serializedUser.Trim().Should().Contain("\"baz\":[\"1\",\"2\"]");
+        }
+
+        [Fact]
+        public void AllowEmptyArraysInSerialization()
+        {
+            var user = new User()
+            {
+                Profile = new UserProfile()
+                {
+                    FirstName = "John",
+                },
+            };
+
+            user.Profile["foo"] = "fooValue";
+            user.Profile["baz"] = new List<string>();
+
+            var serializer = new DefaultSerializer();
+            var serializedUser = serializer.Serialize(user);
+
+            serializedUser.Trim().Should().Contain("\"foo\":\"fooValue\"");
+            serializedUser.Trim().Should().Contain("\"baz\":[]");
+        }
+    }
+}

--- a/src/Okta.Sdk/Internal/ResourceSerializingConverter.cs
+++ b/src/Okta.Sdk/Internal/ResourceSerializingConverter.cs
@@ -60,7 +60,7 @@ namespace Okta.Sdk.Internal
                         child = RemoveEmptyChildren(child);
                     }
 
-                    if (!IsEmpty(child))
+                    if (!IsNull(child))
                     {
                         copy.Add(prop.Name, child);
                     }
@@ -73,9 +73,8 @@ namespace Okta.Sdk.Internal
         }
 
 #pragma warning disable SA1503 // Braces must not be omitted
-        private static bool IsEmpty(JToken token)
+        private static bool IsNull(JToken token)
         {
-            if (token.Type == JTokenType.Array) return !token.HasValues;
             if (token.Type == JTokenType.Object) return !token.HasValues;
             if (token.Type == JTokenType.Null) return true;
 


### PR DESCRIPTION
Fixes OKTA-229987.

Okta .NET SDK: UpdateAsync() does not add the empty array profile attributes, leading to profile update failures when attributes are mastered by another IdP.

