### PR TITLE
Multitarget .NET frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: csharp
 mono: 6.6.0 # Use specific mono version due to a cake failure: https://github.com/cake-build/cake/issues/2695
 sudo: required
 dist: xenial
-dotnet: 3.1
+dotnet: 
+  - 2.2
+  - 3.1
 
 script:
   - if [[ $TRAVIS_EVENT_TYPE = 'push' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: csharp
 mono: 6.6.0 # Use specific mono version due to a cake failure: https://github.com/cake-build/cake/issues/2695
 sudo: required
 dist: xenial
-dotnet: 
-  - 2.2
-  - 3.1
-
+dotnet: 3.1
+addons:
+  apt:
+    packages:
+    - dotnet-sdk-2.2
 script:
   - if [[ $TRAVIS_EVENT_TYPE = 'push' ]]; then
         ./build.sh --target DefaultIT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: 6.6.0 # Use specific mono version due to a cake failure: https://github.com/cake-build/cake/issues/2695
 sudo: required
 dist: xenial
-dotnet: 2.2
+dotnet: 3.1
 
 script:
   - if [[ $TRAVIS_EVENT_TYPE = 'push' ]]; then

--- a/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
@@ -472,7 +472,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var appList = await client.Applications.ToArray();
+                var appList = await client.Applications.ToArrayAsync();
                 appList.SingleOrDefault(a => a.Id == createdApp.Id).Should().NotBeNull();
             }
             finally
@@ -504,10 +504,10 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var appList = await client.Applications.ListApplications().OfType<IBookmarkApplication>().ToArray();
+                var appList = await client.Applications.ListApplications().OfType<IBookmarkApplication>().ToArrayAsync();
                 appList.Should().HaveCount(1);
 
-                var bookmarkApp = await client.Applications.ListApplications().OfType<IBookmarkApplication>().FirstOrDefault();
+                var bookmarkApp = await client.Applications.ListApplications().OfType<IBookmarkApplication>().FirstOrDefaultAsync();
                 bookmarkApp.Should().NotBeNull();
                 bookmarkApp.SignOnMode.Should().Be(ApplicationSignOnMode.Bookmark);
             }
@@ -995,7 +995,7 @@ namespace Okta.Sdk.IntegrationTests
                 var createdAppUser1 = await client.Applications.AssignUserToApplicationAsync(assignUserOptions1);
                 var createdAppUser2 = await client.Applications.AssignUserToApplicationAsync(assignUserOptions2);
 
-                var appUserList = await createdApp.ListApplicationUsers().ToList();
+                var appUserList = await createdApp.ListApplicationUsers().ToListAsync();
 
                 appUserList.Should().NotBeNullOrEmpty();
                 appUserList.Should().HaveCount(2);
@@ -1128,7 +1128,7 @@ namespace Okta.Sdk.IntegrationTests
 
                 await client.Applications.DeleteApplicationUserAsync(createdApp.Id, createdUser.Id);
 
-                var appUserList = await createdApp.ListApplicationUsers().ToList<IAppUser>();
+                var appUserList = await createdApp.ListApplicationUsers().ToListAsync<IAppUser>();
                 appUserList.Should().BeNullOrEmpty();
             }
             finally
@@ -1271,7 +1271,7 @@ namespace Okta.Sdk.IntegrationTests
                 var createdAppGroup1 = await client.Applications.CreateApplicationGroupAssignmentAsync(groupAssignmentOptions1);
                 var createdAppGroup2 = await client.Applications.CreateApplicationGroupAssignmentAsync(groupAssignmentOptions2);
 
-                var groupAssignmentList = await createdApp.ListGroupAssignments().ToList<IApplicationGroupAssignment>();
+                var groupAssignmentList = await createdApp.ListGroupAssignments().ToListAsync<IApplicationGroupAssignment>();
 
                 groupAssignmentList.Should().NotBeNullOrEmpty();
                 groupAssignmentList.Should().HaveCount(2);
@@ -1324,7 +1324,7 @@ namespace Okta.Sdk.IntegrationTests
 
                 await client.Applications.DeleteApplicationGroupAssignmentAsync(createdApp.Id, createdGroup.Id);
 
-                var appGroupAssignmentList = await createdApp.ListGroupAssignments().ToList<IApplicationGroupAssignment>();
+                var appGroupAssignmentList = await createdApp.ListGroupAssignments().ToListAsync<IApplicationGroupAssignment>();
                 appGroupAssignmentList.Should().BeNullOrEmpty();
             }
             finally
@@ -1353,7 +1353,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var appKeys = await createdApp.ListKeys().ToList();
+                var appKeys = await createdApp.ListKeys().ToListAsync();
                 // A key is created by default
                 appKeys.Should().NotBeNull();
                 appKeys.Should().HaveCount(1);
@@ -1381,7 +1381,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var defaultAppKey = await createdApp.ListKeys().FirstOrDefault();
+                var defaultAppKey = await createdApp.ListKeys().FirstOrDefaultAsync();
                 var retrievedAppKey = await createdApp.GetApplicationKeyAsync(defaultAppKey.Kid);
 
                 retrievedAppKey.Should().NotBeNull();

--- a/src/Okta.Sdk.IntegrationTests/CollectionScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/CollectionScenarios.cs
@@ -43,7 +43,7 @@ namespace Okta.Sdk.IntegrationTests
 
                 // Alright, all set up. Try enumerating users by pages of 2:
                 var users = client.Users.ListUsers(limit: 2, filter: "profile.lastName eq \"CollectionEnumeration\"");
-                var count = await users.Count();
+                var count = await users.CountAsync();
                 count.Should().Be(10);
             }
             catch (Exception e)

--- a/src/Okta.Sdk.IntegrationTests/DefaultRetryStrategyScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/DefaultRetryStrategyScenarios.cs
@@ -42,7 +42,7 @@ namespace Okta.Sdk.IntegrationTests
                             q: $"eventType eq \"user.lifecycle.create\" and target.id eq \"{t.Trim()}\"",
                             since: DateTime.Now.Add(TimeSpan.FromDays(-180d)).ToString("yyyy-MM-dd"))
                         .Select(ev => ev.Actor.AlternateId)
-                        .FirstOrDefault();
+                        .FirstOrDefaultAsync();
                     try
                     {
                         Assert.True(log.Result == null, "not found");

--- a/src/Okta.Sdk.IntegrationTests/FactorScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/FactorScenarios.cs
@@ -43,10 +43,10 @@ namespace Okta.Sdk.IntegrationTests
                     Answer = "mayonnaise",
                 });
 
-                var factors = await createdUser.ListFactors().ToArray();
+                var factors = await createdUser.ListFactors().ToArrayAsync();
                 factors.Count().Should().Be(1);
 
-                var securityQuestionFactor = await createdUser.ListFactors().OfType<ISecurityQuestionFactor>().FirstOrDefault();
+                var securityQuestionFactor = await createdUser.ListFactors().OfType<ISecurityQuestionFactor>().FirstOrDefaultAsync();
                 securityQuestionFactor.Should().NotBeNull();
                 securityQuestionFactor.Profile.Question.Should().Be("disliked_food");
                 securityQuestionFactor.Profile.QuestionText.Should().NotBeNullOrEmpty();
@@ -86,10 +86,10 @@ namespace Okta.Sdk.IntegrationTests
                     PhoneNumber = "+16284001133‬",
                 });
 
-                var factors = await createdUser.ListFactors().ToArray();
+                var factors = await createdUser.ListFactors().ToArrayAsync();
                 factors.Count().Should().Be(1);
 
-                var smsFactor = await createdUser.ListFactors().OfType<ISmsFactor>().FirstOrDefault();
+                var smsFactor = await createdUser.ListFactors().OfType<ISmsFactor>().FirstOrDefaultAsync();
                 smsFactor.Should().NotBeNull();
                 smsFactor.FactorType.Should().Be(FactorType.Sms);
             }
@@ -123,7 +123,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var factors = await createdUser.Factors.ToArray();
+                var factors = await createdUser.Factors.ToArrayAsync();
                 factors.Count().Should().Be(0);
             }
             finally

--- a/src/Okta.Sdk.IntegrationTests/GroupScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/GroupScenarios.cs
@@ -53,7 +53,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var groupList = await client.Groups.ListGroups().ToArray();
+                var groupList = await client.Groups.ListGroups().ToArrayAsync();
                 groupList.SingleOrDefault(g => g.Id == createdGroup.Id).Should().NotBeNull();
             }
             finally
@@ -81,7 +81,7 @@ namespace Okta.Sdk.IntegrationTests
             {
                 var groupList = await client.Groups
                     .ListGroups(createdGroup.Profile.GetProperty<string>("name"))
-                    .ToArray();
+                    .ToArrayAsync();
                 groupList.SingleOrDefault(g => g.Id == createdGroup.Id).Should().NotBeNull();
             }
             finally
@@ -155,10 +155,10 @@ namespace Okta.Sdk.IntegrationTests
 
                 var retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
                 retrievedGroup.Should().NotBeNull();
-                var groupUsersList = await retrievedGroup.Users.ToList();
+                var groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(1);
 
-                var retrievedUser = await retrievedGroup.Users.First(x => x.Id == createdUser.Id);
+                var retrievedUser = await retrievedGroup.Users.FirstAsync(x => x.Id == createdUser.Id);
                 retrievedUser.Should().NotBeNull();
             }
             finally
@@ -201,15 +201,15 @@ namespace Okta.Sdk.IntegrationTests
 
                 var retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
                 retrievedGroup.Should().NotBeNull();
-                var groupUsersList = await retrievedGroup.Users.ToList();
+                var groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(1);
 
-                var retrievedUser = await retrievedGroup.Users.First(x => x.Id == createdUser.Id);
+                var retrievedUser = await retrievedGroup.Users.FirstAsync(x => x.Id == createdUser.Id);
                 retrievedUser.Should().NotBeNull();
 
                 await retrievedGroup.RemoveUserAsync(retrievedUser.Id);
                 retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
-                groupUsersList = await retrievedGroup.Users.ToList();
+                groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(0);
             }
             finally
@@ -252,17 +252,17 @@ namespace Okta.Sdk.IntegrationTests
 
                 var retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
                 retrievedGroup.Should().NotBeNull();
-                var groupUsersList = await retrievedGroup.Users.ToList();
+                var groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(1);
 
-                var retrievedUser = await retrievedGroup.Users.First(x => x.Id == createdUser.Id);
+                var retrievedUser = await retrievedGroup.Users.FirstAsync(x => x.Id == createdUser.Id);
                 retrievedUser.Should().NotBeNull();
 
                 await createdUser.DeactivateAsync();
                 await createdUser.DeactivateOrDeleteAsync();
 
                 retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
-                groupUsersList = await retrievedGroup.Users.ToList();
+                groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(0);
             }
             finally
@@ -303,14 +303,14 @@ namespace Okta.Sdk.IntegrationTests
 
                 var retrievedGroup = await client.Groups.GetGroupAsync(createdGroup.Id);
                 retrievedGroup.Should().NotBeNull();
-                var groupUsersList = await retrievedGroup.Users.ToList();
+                var groupUsersList = await retrievedGroup.Users.ToListAsync();
                 groupUsersList.Should().HaveCount(1);
 
-                var retrievedUser = await retrievedGroup.Users.First(x => x.Id == createdUser.Id);
+                var retrievedUser = await retrievedGroup.Users.FirstAsync(x => x.Id == createdUser.Id);
                 retrievedUser.Should().NotBeNull();
 
                 await client.Groups.DeleteGroupAsync(createdGroup.Id);
-                var retrievedGroupsList = await client.Groups.ToList();
+                var retrievedGroupsList = await client.Groups.ToListAsync();
                 retrievedGroupsList.FirstOrDefault(x => x.Id == createdGroup.Id).Should().BeNull();
 
                 retrievedUser = await client.Users.GetUserAsync(createdUser.Id);

--- a/src/Okta.Sdk.IntegrationTests/LogsScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/LogsScenarios.cs
@@ -30,7 +30,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var logs = await client.Logs.GetLogs().ToList();
+                var logs = await client.Logs.GetLogs().ToListAsync();
 
                 logs.Should().NotBeNullOrEmpty();
             }
@@ -60,7 +60,7 @@ namespace Okta.Sdk.IntegrationTests
             try
             {
                 var query = $"dotnet-sdk: GetLogsByQueryString";
-                var logs = await client.Logs.GetLogs(null, null, null, query).ToList();
+                var logs = await client.Logs.GetLogs(null, null, null, query).ToListAsync();
 
                 logs.Should().NotBeNullOrEmpty();
             }
@@ -88,7 +88,7 @@ namespace Okta.Sdk.IntegrationTests
             try
             {
                 var filter = "eventType eq \"directory.app_user_profile.bootstrap\"";
-                var logs = await client.Logs.GetLogs(null, null, filter).ToList();
+                var logs = await client.Logs.GetLogs(null, null, filter).ToListAsync();
 
                 logs.Should().NotBeNullOrEmpty();
             }
@@ -117,7 +117,7 @@ namespace Okta.Sdk.IntegrationTests
             {
                 var until = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
                 var since = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ");
-                var logs = await client.Logs.GetLogs(until, since).ToList();
+                var logs = await client.Logs.GetLogs(until, since).ToListAsync();
 
                 logs.Should().NotBeNullOrEmpty();
             }

--- a/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
+++ b/src/Okta.Sdk.IntegrationTests/Okta.Sdk.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Okta.Sdk.IntegrationTests/PoliciesScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/PoliciesScenarios.cs
@@ -192,12 +192,12 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var signOnPolicies = await client.Policies.ListPolicies(PolicyType.OktaSignOn).ToList();
+                var signOnPolicies = await client.Policies.ListPolicies(PolicyType.OktaSignOn).ToListAsync();
                 signOnPolicies.Should().NotBeNullOrEmpty();
                 signOnPolicies.First(x => x.Id == createdPolicy1.Id).Should().NotBeNull();
                 signOnPolicies.FirstOrDefault(x => x.Id == createdPolicy2.Id).Should().BeNull();
 
-                var passwordPolicies = await client.Policies.ListPolicies(PolicyType.Password).ToList();
+                var passwordPolicies = await client.Policies.ListPolicies(PolicyType.Password).ToListAsync();
                 passwordPolicies.Should().NotBeNullOrEmpty();
                 passwordPolicies.First(x => x.Id == createdPolicy2.Id).Should().NotBeNull();
                 passwordPolicies.FirstOrDefault(x => x.Id == createdPolicy1.Id).Should().BeNull();
@@ -879,7 +879,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var policyRules = await createdPolicy.ListPolicyRules().ToList();
+                var policyRules = await createdPolicy.ListPolicyRules().ToListAsync();
 
                 policyRules.Should().NotBeNullOrEmpty();
                 policyRules.Should().HaveCount(1);
@@ -954,7 +954,7 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var policyRules = await createdPolicy.ListPolicyRules().OfType<IPasswordPolicyRule>().ToList();
+                var policyRules = await createdPolicy.ListPolicyRules().OfType<IPasswordPolicyRule>().ToListAsync();
 
                 policyRules.Should().NotBeNullOrEmpty();
                 policyRules.Should().HaveCount(1);

--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -50,7 +50,7 @@ namespace Okta.Sdk.IntegrationTests
                 {
                     var foundUsers = await client.Users
                         .ListUsers(search: $"profile.nickName eq \"{createdUser.Profile.GetProperty<string>("nickName")}\"")
-                        .ToArray();
+                        .ToArrayAsync();
 
                     foundUsers.Length.Should().Be(1);
                     foundUsers.Single().Id.Should().Be(createdUser.Id);
@@ -139,7 +139,7 @@ namespace Okta.Sdk.IntegrationTests
                 await createdUser.ActivateAsync(sendEmail: false);
 
                 // Verify user exists in list of active users
-                var activeUsers = await client.Users.ListUsers(filter: "status eq \"ACTIVE\"").ToArray();
+                var activeUsers = await client.Users.ListUsers(filter: "status eq \"ACTIVE\"").ToArrayAsync();
                 activeUsers.Should().Contain(u => u.Id == createdUser.Id);
             }
             finally
@@ -297,12 +297,12 @@ namespace Okta.Sdk.IntegrationTests
             {
                 await createdUser.SuspendAsync();
 
-                var suspendedUsers = await client.Users.ListUsers(filter: "status eq \"SUSPENDED\"").ToArray();
+                var suspendedUsers = await client.Users.ListUsers(filter: "status eq \"SUSPENDED\"").ToArrayAsync();
                 suspendedUsers.Should().Contain(u => u.Id == createdUser.Id);
 
                 await createdUser.UnsuspendAsync();
 
-                var activeUsers = await client.Users.ListUsers(filter: "status eq \"ACTIVE\"").ToArray();
+                var activeUsers = await client.Users.ListUsers(filter: "status eq \"ACTIVE\"").ToArrayAsync();
                 activeUsers.Should().Contain(u => u.Id == createdUser.Id);
             }
             finally

--- a/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/CollectionClientShould.cs
@@ -42,7 +42,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var all = await collection.ToArray();
+            var all = await collection.ToArrayAsync();
             all.Length.Should().Be(0);
         }
 
@@ -61,7 +61,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var all = await collection.ToArray();
+            var all = await collection.ToArrayAsync();
             all.Length.Should().Be(5);
         }
 
@@ -106,7 +106,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var count = await collection.Count();
+            var count = await collection.CountAsync();
             count.Should().Be(5);
         }
 
@@ -125,7 +125,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var activeUsers = await collection.Where(x => x.Status == "ACTIVE").ToList();
+            var activeUsers = await collection.Where(x => x.Status == "ACTIVE").ToListAsync();
             activeUsers.Count.Should().Be(2);
         }
     }

--- a/src/Okta.Sdk.UnitTests/CollectionOfFactorsShould.cs
+++ b/src/Okta.Sdk.UnitTests/CollectionOfFactorsShould.cs
@@ -44,7 +44,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var retrievedItems = await collection.ToArray();
+            var retrievedItems = await collection.ToArrayAsync();
             var securityQuestionFactor = retrievedItems.OfType<SecurityQuestionFactor>().FirstOrDefault();
             securityQuestionFactor.Should().NotBeNull();
         }
@@ -64,7 +64,7 @@ namespace Okta.Sdk.UnitTests
                 new HttpRequest { Uri = "http://mock-collection.dev" },
                 new RequestContext());
 
-            var retrievedItems = await collection.ToArray();
+            var retrievedItems = await collection.ToArrayAsync();
             var securityQuestionFactor = retrievedItems.OfType<ISecurityQuestionFactor>().FirstOrDefault();
             securityQuestionFactor.Should().NotBeNull();
         }

--- a/src/Okta.Sdk.UnitTests/LogsClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/LogsClientShould.cs
@@ -18,7 +18,7 @@ namespace Okta.Sdk.UnitTests
         {
             var mockRequestExecutor = new MockedStringRequestExecutor(GetLogsStubResponse());
             var client = new TestableOktaClient(mockRequestExecutor);
-            var logs = await client.Logs.GetLogs().ToList();
+            var logs = await client.Logs.GetLogs().ToListAsync();
             logs.Should().HaveCount(1);
 
             var log = logs.First();

--- a/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
+++ b/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
+++ b/src/Okta.Sdk.UnitTests/Okta.Sdk.UnitTests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <AdditionalFiles Include="..\stylecop.json" />

--- a/src/Okta.Sdk.UnitTests/OktaClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/OktaClientShould.cs
@@ -30,7 +30,7 @@ namespace Okta.Sdk.UnitTests
             var client = new TestableOktaClient(mockRequestExecutor);
 
             // Act
-            var items = await client.GetCollection<TestResource>("https://stuff").ToArray();
+            var items = await client.GetCollection<TestResource>("https://stuff").ToArrayAsync();
 
             // Assert
             items.Count().Should().Be(3);

--- a/src/Okta.Sdk/ApplicationsClient.cs
+++ b/src/Okta.Sdk/ApplicationsClient.cs
@@ -14,7 +14,7 @@ namespace Okta.Sdk
     public sealed partial class ApplicationsClient : OktaClient, IApplicationsClient, IAsyncEnumerable<IApplication>
     {
         /// <inheritdoc/>
-        public IAsyncEnumerator<IApplication> GetEnumerator() => ListApplications().GetEnumerator();
+       // public IAsyncEnumerator<IApplication> GetEnumerator() => ListApplications().GetEnumerator();
 
         /// <inheritdoc/>
         public async Task<T> GetApplicationAsync<T>(string appId, CancellationToken cancellationToken = default(CancellationToken))
@@ -427,5 +427,10 @@ namespace Okta.Sdk
         /// <inheritdoc />
         public async Task DeleteApplicationUserAsync(string appId, string userId)
             => await DeleteApplicationUserAsync(appId, userId, false, default(CancellationToken)).ConfigureAwait(false);
+
+        public IAsyncEnumerator<IApplication> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return ListApplications().GetAsyncEnumerator();
+        }
     }
 }

--- a/src/Okta.Sdk/ApplicationsClient.cs
+++ b/src/Okta.Sdk/ApplicationsClient.cs
@@ -14,7 +14,7 @@ namespace Okta.Sdk
     public sealed partial class ApplicationsClient : OktaClient, IApplicationsClient, IAsyncEnumerable<IApplication>
     {
         /// <inheritdoc/>
-       // public IAsyncEnumerator<IApplication> GetEnumerator() => ListApplications().GetEnumerator();
+        public IAsyncEnumerator<IApplication> GetAsyncEnumerator(CancellationToken cancellationToken = default) => ListApplications().GetAsyncEnumerator(cancellationToken);
 
         /// <inheritdoc/>
         public async Task<T> GetApplicationAsync<T>(string appId, CancellationToken cancellationToken = default(CancellationToken))
@@ -427,10 +427,5 @@ namespace Okta.Sdk
         /// <inheritdoc />
         public async Task DeleteApplicationUserAsync(string appId, string userId)
             => await DeleteApplicationUserAsync(appId, userId, false, default(CancellationToken)).ConfigureAwait(false);
-
-        public IAsyncEnumerator<IApplication> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            return ListApplications().GetAsyncEnumerator();
-        }
     }
 }

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -34,6 +34,7 @@ namespace Okta.Sdk
             _requestContext = requestContext;
         }
 
+        /// <inheritdoc/>
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
 

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
@@ -33,9 +34,8 @@ namespace Okta.Sdk
             _requestContext = requestContext;
         }
 
-        /// <inheritdoc/>
-        public IAsyncEnumerator<T> GetEnumerator()
-            => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
 
         /// <inheritdoc/>
         public IPagedCollectionEnumerator<T> GetPagedEnumerator()

--- a/src/Okta.Sdk/CollectionClient{T}.cs
+++ b/src/Okta.Sdk/CollectionClient{T}.cs
@@ -36,10 +36,10 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext);
+        => new CollectionAsyncEnumerator<T>(_dataStore, _initialRequest, _requestContext, cancellationToken);
 
         /// <inheritdoc/>
-        public IPagedCollectionEnumerator<T> GetPagedEnumerator()
-            => new PagedCollectionEnumerator<T>(_dataStore, _initialRequest, _requestContext);
+        public IPagedCollectionEnumerator<T> GetPagedEnumerator(CancellationToken cancellationToken = default)
+            => new PagedCollectionEnumerator<T>(_dataStore, _initialRequest, _requestContext, cancellationToken);
     }
 }

--- a/src/Okta.Sdk/GroupsClient.cs
+++ b/src/Okta.Sdk/GroupsClient.cs
@@ -29,7 +29,12 @@ namespace Okta.Sdk
             return CreateGroupAsync(newGroup, cancellationToken);
         }
 
+        public IAsyncEnumerator<IGroup> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return ListGroups().GetAsyncEnumerator();
+        }
+
         /// <inheritdoc/>
-        public IAsyncEnumerator<IGroup> GetEnumerator() => ListGroups().GetEnumerator();
+        //public IAsyncEnumerator<IGroup> GetEnumerator() => ListGroups().GetEnumerator();
     }
 }

--- a/src/Okta.Sdk/GroupsClient.cs
+++ b/src/Okta.Sdk/GroupsClient.cs
@@ -29,12 +29,7 @@ namespace Okta.Sdk
             return CreateGroupAsync(newGroup, cancellationToken);
         }
 
-        public IAsyncEnumerator<IGroup> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            return ListGroups().GetAsyncEnumerator();
-        }
-
         /// <inheritdoc/>
-        //public IAsyncEnumerator<IGroup> GetEnumerator() => ListGroups().GetEnumerator();
+        public IAsyncEnumerator<IGroup> GetAsyncEnumerator(CancellationToken cancellationToken = default) => ListGroups().GetAsyncEnumerator(cancellationToken);
     }
 }

--- a/src/Okta.Sdk/ICollectionClient{T}.cs
+++ b/src/Okta.Sdk/ICollectionClient{T}.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace Okta.Sdk
 {
@@ -27,7 +28,8 @@ namespace Okta.Sdk
         /// <remarks>
         /// /// See <a href="https://developer.okta.com/docs/api/getting_started/design_principles.html#pagination">the API documentation on pagination</a>.
         /// </remarks>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>An enumerator that retrieves items from an Okta collection page-by-page.</returns>
-        IPagedCollectionEnumerator<T> GetPagedEnumerator();
+        IPagedCollectionEnumerator<T> GetPagedEnumerator(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Okta.Sdk/IPagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/IPagedCollectionEnumerator{T}.cs
@@ -17,7 +17,7 @@ namespace Okta.Sdk
         where T : IResource
     {
         /// <summary>
-        /// Gets the current page of items, or <c>null</c> if <see cref="MoveNextAsync(CancellationToken)"/> has not yet been called.
+        /// Gets the current page of items, or <c>null</c> if <see cref="MoveNextAsync()"/> has not yet been called.
         /// </summary>
         /// <value>
         /// The current page of items, if any.
@@ -27,10 +27,9 @@ namespace Okta.Sdk
         /// <summary>
         /// Asynchronously retrieves the next page of results and updates <see cref="CurrentPage"/>. If there are no more pages, this method returns <see langword="false"/>.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
         /// <see langword="true"/> if <see cref="CurrentPage"/> has been updated with new items, <see langword="false"/> if the collection has been exhausted.
         /// </returns>
-        Task<bool> MoveNextAsync(CancellationToken cancellationToken = default);
+        Task<bool> MoveNextAsync();
     }
 }

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -81,7 +81,9 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
+#pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
         public ValueTask DisposeAsync()
+#pragma warning restore AvoidAsyncSuffix // Avoid Async suffix
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Okta.Sdk.Internal
@@ -31,12 +32,14 @@ namespace Okta.Sdk.Internal
         /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>
         /// <param name="initialRequest">The initial HTTP request options.</param>
         /// <param name="requestContext">The request context.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         public CollectionAsyncEnumerator(
             IDataStore dataStore,
             HttpRequest initialRequest,
-            RequestContext requestContext)
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
-            _pagedEnumerator = new PagedCollectionEnumerator<T>(dataStore, initialRequest, requestContext);
+            _pagedEnumerator = new PagedCollectionEnumerator<T>(dataStore, initialRequest, requestContext, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -3,10 +3,8 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Okta.Sdk.Internal
@@ -44,33 +42,6 @@ namespace Okta.Sdk.Internal
         /// <inheritdoc/>
         public T Current => _pagedEnumerator.CurrentPage.Items.ElementAt(_localPageIndex);
 
-#pragma warning disable UseAsyncSuffix // Must match interface
-        /// <inheritdoc/>
-        public async Task<bool> MoveNext(CancellationToken cancellationToken)
-#pragma warning restore UseAsyncSuffix // Must match interface
-        {
-            var hasMoreLocalItems = _initialized
-                && _pagedEnumerator.CurrentPage.Items.Any()
-                && (_localPageIndex + 1) < _pagedEnumerator.CurrentPage.Items.Count();
-
-            if (hasMoreLocalItems)
-            {
-                _localPageIndex++;
-                return true;
-            }
-
-            var movedNext = await _pagedEnumerator.MoveNextAsync(cancellationToken).ConfigureAwait(false);
-            if (!movedNext)
-            {
-                return false;
-            }
-
-            _initialized = true;
-            _localPageIndex = 0;
-
-            return _pagedEnumerator.CurrentPage.Items.Any();
-        }
-
         private void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -83,17 +54,6 @@ namespace Okta.Sdk.Internal
                 _disposedValue = true;
             }
         }
-
-        /// <inheritdoc/>
-        //public void Dispose()
-        //{
-        //    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //    Dispose(true);
-        //}        //public void Dispose()
-        //{
-        //    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //    Dispose(true);
-        //}
 
         /// <inheritdoc/>
         public async ValueTask<bool> MoveNextAsync()

--- a/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
+++ b/src/Okta.Sdk/Internal/CollectionAsyncEnumerator{T}.cs
@@ -85,10 +85,48 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        //public void Dispose()
+        //{
+        //    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //    Dispose(true);
+        //}        //public void Dispose()
+        //{
+        //    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //    Dispose(true);
+        //}
+
+        /// <inheritdoc/>
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            var hasMoreLocalItems = _initialized
+                && _pagedEnumerator.CurrentPage.Items.Any()
+                && (_localPageIndex + 1) < _pagedEnumerator.CurrentPage.Items.Count();
+
+            if (hasMoreLocalItems)
+            {
+                _localPageIndex++;
+                return true;
+            }
+
+            var movedNext = await _pagedEnumerator.MoveNextAsync().ConfigureAwait(false);
+            if (!movedNext)
+            {
+                return false;
+            }
+
+            _initialized = true;
+            _localPageIndex = 0;
+
+            return _pagedEnumerator.CurrentPage.Items.Any();
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
+
+            return default(ValueTask);
         }
     }
 }

--- a/src/Okta.Sdk/LogsClient.cs
+++ b/src/Okta.Sdk/LogsClient.cs
@@ -11,15 +11,11 @@ namespace Okta.Sdk
     /// <inheritdoc/>
     public sealed partial class LogsClient : OktaClient, ILogsClient, IAsyncEnumerable<ILogEvent>
     {
-        public IAsyncEnumerator<ILogEvent> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            return GetLogs().GetAsyncEnumerator();
-        }
-
         /// <summary>
-        /// Gets the LogsClient enumerator
+        /// Gets the LogsClient enumerator.
         /// </summary>
-        /// <returns>A collection of <see cref="ILogEvent"/> that can be enumerated asynchronously</returns>
-        //public IAsyncEnumerator<ILogEvent> GetEnumerator() => GetLogs().GetEnumerator();
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A collection of <see cref="ILogEvent"/> that can be enumerated asynchronously.</returns>
+        public IAsyncEnumerator<ILogEvent> GetAsyncEnumerator(CancellationToken cancellationToken = default) => GetLogs().GetAsyncEnumerator(cancellationToken);
     }
 }

--- a/src/Okta.Sdk/LogsClient.cs
+++ b/src/Okta.Sdk/LogsClient.cs
@@ -4,16 +4,22 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Okta.Sdk
 {
     /// <inheritdoc/>
     public sealed partial class LogsClient : OktaClient, ILogsClient, IAsyncEnumerable<ILogEvent>
     {
+        public IAsyncEnumerator<ILogEvent> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return GetLogs().GetAsyncEnumerator();
+        }
+
         /// <summary>
         /// Gets the LogsClient enumerator
         /// </summary>
         /// <returns>A collection of <see cref="ILogEvent"/> that can be enumerated asynchronously</returns>
-        public IAsyncEnumerator<ILogEvent> GetEnumerator() => GetLogs().GetEnumerator();
+        //public IAsyncEnumerator<ILogEvent> GetEnumerator() => GetLogs().GetEnumerator();
     }
 }

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <Version>1.4.1</Version>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.4.1</Version>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.Interactive.Async" Version="3.1.1" />
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Version>1.4.1</Version>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
@@ -27,7 +27,7 @@
 
   <PropertyGroup>
     <Description>Official .NET SDK for the Okta API.</Description>
-    <DocumentationFile>bin\Debug\netstandard1.3\Okta.Sdk.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netstandard2.1\Okta.Sdk.xml</DocumentationFile>
     <RepositoryUrl>https://github.com/okta/okta-sdk-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://github.com/okta/okta-sdk-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/okta/okta-sdk-dotnet/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Version>1.4.1</Version>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FlexibleConfiguration" Version="1.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
     <AdditionalFiles Include="..\stylecop.json" />
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="All" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
@@ -17,8 +17,9 @@ namespace Okta.Sdk
     {
         private readonly IDataStore _dataStore;
         private readonly RequestContext _requestContext;
+        private readonly CancellationToken _cancellationToken;
         private HttpRequest _nextRequest;
-        private CancellationToken _cancellationToken;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PagedCollectionEnumerator{T}"/> class.
         /// </summary>

--- a/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
+++ b/src/Okta.Sdk/PagedCollectionEnumerator{T}.cs
@@ -17,30 +17,32 @@ namespace Okta.Sdk
     {
         private readonly IDataStore _dataStore;
         private readonly RequestContext _requestContext;
-
         private HttpRequest _nextRequest;
-
+        private CancellationToken _cancellationToken;
         /// <summary>
         /// Initializes a new instance of the <see cref="PagedCollectionEnumerator{T}"/> class.
         /// </summary>
         /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>
         /// <param name="initialRequest">The initial HTTP request options.</param>
         /// <param name="requestContext">The request context.</param>
+        /// <param name="cancellationToken">The rcancellation token.</param>
         public PagedCollectionEnumerator(
             IDataStore dataStore,
             HttpRequest initialRequest,
-            RequestContext requestContext)
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
             _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
             _requestContext = requestContext;
             _nextRequest = initialRequest ?? throw new ArgumentNullException(nameof(initialRequest));
+            _cancellationToken = cancellationToken;
         }
 
         /// <inheritdoc/>
         public CollectionPage<T> CurrentPage { get; private set; }
 
         /// <inheritdoc/>
-        public async Task<bool> MoveNextAsync(CancellationToken cancellationToken = default)
+        public async Task<bool> MoveNextAsync()
         {
             if (_nextRequest == null)
             {
@@ -50,7 +52,7 @@ namespace Okta.Sdk
             var response = await _dataStore.GetArrayAsync<T>(
                 _nextRequest,
                 _requestContext,
-                cancellationToken).ConfigureAwait(false);
+                _cancellationToken).ConfigureAwait(false);
 
             var items = response?.Payload?.ToArray() ?? new T[0];
 

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -16,7 +16,7 @@ namespace Okta.Sdk
     public sealed partial class UsersClient : OktaClient, IUsersClient, IAsyncEnumerable<IUser>
     {
         /// <inheritdoc/>
-        public IAsyncEnumerator<IUser> GetEnumerator() => ListUsers().GetEnumerator();
+        //public IAsyncEnumerator<IUser> GetEnumerator() => ListUsers().GetEnumerator();
 
         /// <inheritdoc/>
         public Task<IUser> CreateUserAsync(CreateUserWithoutCredentialsOptions options, CancellationToken cancellationToken = default(CancellationToken))
@@ -175,5 +175,10 @@ namespace Okta.Sdk
         /// <inheritdoc />
         public Task<IUser> UpdateUserAsync(IUser user, string userId, CancellationToken cancellationToken = default)
             => UpdateUserAsync(user, userId, null, cancellationToken);
+
+        public IAsyncEnumerator<IUser> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return ListUsers().GetAsyncEnumerator();
+        }
     }
 }

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -16,7 +16,7 @@ namespace Okta.Sdk
     public sealed partial class UsersClient : OktaClient, IUsersClient, IAsyncEnumerable<IUser>
     {
         /// <inheritdoc/>
-        //public IAsyncEnumerator<IUser> GetEnumerator() => ListUsers().GetEnumerator();
+        public IAsyncEnumerator<IUser> GetAsyncEnumerator(CancellationToken cancellationToken = default) => ListUsers().GetAsyncEnumerator(cancellationToken);
 
         /// <inheritdoc/>
         public Task<IUser> CreateUserAsync(CreateUserWithoutCredentialsOptions options, CancellationToken cancellationToken = default(CancellationToken))
@@ -175,10 +175,5 @@ namespace Okta.Sdk
         /// <inheritdoc />
         public Task<IUser> UpdateUserAsync(IUser user, string userId, CancellationToken cancellationToken = default)
             => UpdateUserAsync(user, userId, null, cancellationToken);
-
-        public IAsyncEnumerator<IUser> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            return ListUsers().GetAsyncEnumerator();
-        }
     }
 }

--- a/src/OktaSdk.ruleset
+++ b/src/OktaSdk.ruleset
@@ -119,5 +119,6 @@
     <Rule Id="SA1636" Action="Error" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1643" Action="Error" />
+	<Rule Id="SA1629" Action="None" /> <!-- Not relevant -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
* Upgrade .NET Standard version to 2.0. 
* Add support for .NET Core 3.x via multitarget.
* Upgrade NuGet dependencies.
* Fix #348 
* Fix [OKTA-277647](https://oktainc.atlassian.net/browse/OKTA-277647)
* Also, in this PR I disabled [StyleCop rule # 1629](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md) since it doesn't add any value.
