### PR TITLE
Small miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ This SDK provides a `DefaultSerializer` which has all the logic needed by this S
 
 ### Default Serializer Settings
 
-If you have date formatted strings among your Okta custom attributes and you want them not to be parsed to a date type and read them as strings, use the following code:
+In 2.x series all custom attributes are deserialized as strings by default. This was not true in previous versions where date formatted strings were deserialized as `DateTimeOffset`.
+
+If you are using an older version and you have date formatted strings among your Okta custom attributes and you don't want them to be parsed to a date type and read them as strings instead, use the following code:
 
 ```
 var serializer = new DefaultSerializer(new JsonSerializerSettings()

--- a/src/Okta.Sdk.UnitTests/DefaultDataStoreShould.cs
+++ b/src/Okta.Sdk.UnitTests/DefaultDataStoreShould.cs
@@ -165,6 +165,43 @@ namespace Okta.Sdk.UnitTests
         }
 
         [Fact]
+        public async Task DeserializeDateCustomPropertyAsString()
+        {
+            var mockResponse = @"{  
+               ""id"":""foo"",
+               ""status"":""ACTIVE"",
+               ""created"":""2019-05-09T15:37:44.000Z"",
+               ""activated"":""2019-05-09T15:37:44.000Z"",
+               ""statusChanged"":""2019-05-09T18:29:29.000Z"",
+               ""lastLogin"":""2019-08-09T07:49:51.000Z"",
+               ""lastUpdated"":""2019-08-09T17:20:28.000Z"",
+               ""passwordChanged"":""2019-05-09T18:29:29.000Z"",
+               ""profile"":{  
+                  ""firstName"":""John"",
+                  ""lastName"":""Coder"",
+                  ""mobilePhone"":null,
+                  ""userType"":""test"",
+                  ""login"":""john.coder@dotnettest.com"",
+                  ""startDate"":""2016-06-07T00:00:00.000"",
+                  ""email"":""john.coder@test.com"",
+                  ""employeeNumber"":""000012345"",
+                  ""type"":""null"",
+               },
+            }";
+
+            var mockRequestExecutor = Substitute.For<IRequestExecutor>();
+            mockRequestExecutor
+                .GetAsync(Arg.Any<string>(), Arg.Any<IEnumerable<KeyValuePair<string, string>>>(), Arg.Any<CancellationToken>())
+                .Returns(new HttpResponse<string>() { StatusCode = 200, Payload = mockResponse });
+
+            var dataStore = new DefaultDataStore(mockRequestExecutor, new DefaultSerializer(), new ResourceFactory(null, null), NullLogger.Instance);
+            var request = new HttpRequest { Uri = "https://foo.dev", Payload = new { } };
+            var response = await dataStore.GetAsync<User>(request, new RequestContext(), CancellationToken.None);
+            response.Payload.Profile["startDate"].GetType().Should().Be(typeof(string));
+            response.Payload.Profile["startDate"].Should().Be("2016-06-07T00:00:00.000");
+        }
+
+        [Fact]
         public async Task DelegatePutToRequestExecutor()
         {
             var mockRequestExecutor = Substitute.For<IRequestExecutor>();

--- a/src/Okta.Sdk.UnitTests/DefaultSerializerShould.cs
+++ b/src/Okta.Sdk.UnitTests/DefaultSerializerShould.cs
@@ -51,6 +51,23 @@ namespace Okta.Sdk.UnitTests
         }
 
         [Fact]
+        public void DeserializeDateAsString()
+        {
+            var date = DateTimeOffset.UtcNow;
+
+            var json = $@"
+            {{
+              ""foo"": ""{date}"",
+            }}";
+
+            var serializer = new DefaultSerializer();
+            var dict = serializer.Deserialize(json);
+
+            dict["foo"].Should().Be(date.ToString());
+            dict["foo"].GetType().Should().Be(typeof(string));
+        }
+
+        [Fact]
         public void DeserializeNullInput()
         {
             var serializer = new DefaultSerializer();

--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -154,7 +154,16 @@ namespace Okta.Sdk.Internal
         }
 
         private static IEnumerable<KeyValuePair<string, IEnumerable<string>>> ExtractHeaders(HttpResponseMessage response)
-            => response.Headers.Concat(response.Content.Headers);
+        {
+            if (response.Content != null && response.Content.Headers != null)
+            {
+                return response.Headers?.Concat(response.Content.Headers);
+            }
+            else
+            {
+                return response.Headers;
+            }
+        }
 
         /// <inheritdoc/>
         public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)

--- a/src/Okta.Sdk/Internal/DefaultSerializer.cs
+++ b/src/Okta.Sdk/Internal/DefaultSerializer.cs
@@ -36,6 +36,7 @@ namespace Okta.Sdk.Internal
                 {
                     NullValueHandling = NullValueHandling.Ignore,
                     DefaultValueHandling = DefaultValueHandling.Ignore,
+                    DateParseHandling = DateParseHandling.None,
                     ContractResolver = new DefaultContractResolver(),
                 };
             }

--- a/src/Okta.Sdk/Resource.cs
+++ b/src/Okta.Sdk/Resource.cs
@@ -255,7 +255,8 @@ namespace Okta.Sdk
         protected DateTimeOffset? GetDateTimeProperty(string name)
         {
             var raw = GetStringProperty(name);
-            if (raw == null)
+
+            if (string.IsNullOrEmpty(raw))
             {
                 return null;
             }


### PR DESCRIPTION
This PR includes 3 minor fixes that are isolated in separate commits:

1- Check if string is null or empty before converting to date in `Resource` class. 
2- Add null checking before "concat" response headers in `DefaultRequestExecutor` class.
3- Deserialize custom attributes formatted as date strings as strings by default. Previously, this was the only case that wasn't deserialized as string.  