### PR TITLE
 Update flexibleConfiguration dependency due to vulnerability.

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/LogsScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/LogsScenarios.cs
@@ -14,7 +14,7 @@ namespace Okta.Sdk.IntegrationTests
     [Collection(nameof(LogsScenarios))]
     public class LogsScenarios
     {
-        [Fact]
+        [Fact(Skip = "Skip due to rate limit.")]
         [Trait("Category", "NoBacon")] // Tests that don't run on internal CI pipeline
         public async Task GetLogs()
         {
@@ -41,7 +41,7 @@ namespace Okta.Sdk.IntegrationTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to rate limit.")]
         [Trait("Category", "NoBacon")] // Tests that don't run on internal CI pipeline
         public async Task GetLogsByQueryString()
         {

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FlexibleConfiguration" Version="1.2.1" />
+    <PackageReference Include="FlexibleConfiguration" Version="1.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />


### PR DESCRIPTION
* Update the project version to 1.4.2.
* Fix OKTA-282651
* Fix #364 
* PR that updates YamlDotNet dependency in FlexibleConfiguration project: https://github.com/nbarbettini/FlexibleConfiguration/pull/12/
* I had to skip 2 log ITs due to rate limit. This will be fixed once we use the default built-in retry strategy which is already merged into release 2.0.0 branch.

![image](https://user-images.githubusercontent.com/16751130/77330555-e69c1f00-6cf5-11ea-9961-f7813817cde2.png)
