### PR TITLE
OKTA-300462 account for user race condition

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/EventHooksClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/EventHooksClientScenarios.cs
@@ -12,7 +12,7 @@ using Xunit.Sdk;
 
 namespace Okta.Sdk.IntegrationTests
 {
-    public class EventHooksClientShould
+    public class EventHooksClientScenarios
     {
         private const string SdkPrefix = "dotnet_sdk";
         private const string EventType = "EVENT_TYPE";

--- a/src/Okta.Sdk.IntegrationTests/EventHooksClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/EventHooksClientScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventHooksClientShould.cs" company="Okta, Inc">
+﻿// <copyright file="EventHooksClientScenarios.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>

--- a/src/Okta.Sdk.IntegrationTests/FeaturesScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/FeaturesScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FeaturesScenarios.cs" company="Okta, Inc">
+﻿﻿// <copyright file="FeaturesScenarios.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>

--- a/src/Okta.Sdk.IntegrationTests/IdentityProvidersScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/IdentityProvidersScenarios.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -899,6 +900,8 @@ namespace Okta.Sdk.IntegrationTests
 
             var createdIdp = await client.IdentityProviders.CreateIdentityProviderAsync(idp);
             createdIdp.Name = $"dotnet-sdk:UpdateIdp{randomSuffix}-upd";
+
+            Thread.Sleep(3000); // allow for user replication prior to read attempt
 
             try
             {

--- a/src/Okta.Sdk.IntegrationTests/InlineHooksClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/InlineHooksClientScenarios.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Okta.Sdk.IntegrationTests
 {
-    public class InlineHooksClientShould
+    public class InlineHooksClientScenarios
     {
         private const string SdkPrefix = "dotnet_sdk";
 

--- a/src/Okta.Sdk.IntegrationTests/InlineHooksClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/InlineHooksClientScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InlineHooksClientShould.cs" company="Okta, Inc">
+﻿// <copyright file="InlineHooksClientScenarios.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>

--- a/src/Okta.Sdk.IntegrationTests/OAuthScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/OAuthScenarios.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
@@ -16,7 +17,7 @@ namespace Okta.Sdk.IntegrationTests
 {
     public class OAuthScenarios
     {
-        [Fact(Skip = "Investigate collateral errors (404 - CVDType) - OKTA-300462")]
+        [Fact]
         [Trait("Category", "NoBacon")] // Tests that don't run on internal CI pipeline
         public async Task ListUsers()
         {
@@ -57,14 +58,16 @@ namespace Okta.Sdk.IntegrationTests
                 LastName = "OAuth-List-Users",
                 Email = $"john-list-users-dotnet-sdk-{guid}@example.com",
                 Login = $"john-list-users-dotnet-sdk-{guid}@example.com",
+                ["nickName"] = "johny-list-users",
             };
-            profile["nickName"] = "johny-list-users";
 
             var createdUser = await client.Users.CreateUserAsync(new CreateUserWithPasswordOptions
             {
                 Profile = profile,
                 Password = "Abcd1234",
             });
+
+            Thread.Sleep(3500);
 
             try
             {
@@ -92,15 +95,17 @@ namespace Okta.Sdk.IntegrationTests
                                     ""qi"":""u1mS53N4BUSoMeOHFd0o4_n3QGH4izNUsiJVBIkv_UZUAk4LYudPEikTWRLqWsrcXmOyZYao5sSaZyt-B2XCkfdnkIhl-Q7b0_W0yt3Eh5XjAzH9oy5Dklog255lh-Y0yoWXvLjq-KEDs7Nd2uIT4gvKU4ymTqybvzazr2jY9qQ"",""dp"":""nCtPBsK1-9oFgJdoaWYApOAH8DBFipSXs3SQ-oTuW_S5coD4jAmniDuQB2p-6LblDXrDFKb8pZi6XL60UO-hUv7As4s4c8NVDb5X5SEBP9-Sv-koHgU-L4eQZY21ejY0SOS4dTFRNNKasQsxc_2XJIOTLc8T3_wPpD-cGQYN_dE"",""dq"":""ZWb4iZ0qICzFLW6N3gXIYrFi3ndQcC4m0jmTLdRs2o4RkRQ0RGj4vS7ex1G0MWI8MjZoMTe49Qs6Cunvr1bRo_YxI_1p7D6Tk9wZKTeFsqaBl1mUlo7jgXUJL5U9p9zAV-uVah7nWuBjo-vgg4wij2MZfZj9zuoWFWThk3LUKKU"",""n"":""mTjMc8AxU102LT1Jf-1qkGmaSiK4L7DDlC1SMvtyCRbDaiJDIagedfp1w8Pgud8YWOaS5FFx0S6JqGGP2U8OtpowzBcv5sYa-e5LHfnoueTJPj_jnI3fj5omZM1w-ofhFLPZoYEQ7DFYw0yLrzf8zaKB5-9BZ8yyOLhSKqxaOl2s7lw2TrwBRuQpPXmEir70oDPvazd8-An5ow6F5q7mzMtHAt61DJqrosRHiRwh4N37zIX_RNu-Tn1aMktCBl01rdoDyVq7Y4iwNH8ZAtT5thKK2eo8d-jb9TF9PH6LGffYCth157w-K4AZwXw74Ybo5NOux3XpIpKRbFTwvBLp1Q""
                                  }";
 
-                var configuration = new OktaClientConfiguration();
-                configuration.Scopes = new List<string> { "okta.users.read" };
-                configuration.ClientId = service.GetProperty<string>("client_id");
-                configuration.PrivateKey = new JsonWebKeyConfiguration(jsonPrivateKey);
-                configuration.AuthorizationMode = AuthorizationMode.PrivateKey;
+                var configuration = new OktaClientConfiguration
+                {
+                    Scopes = new List<string> { "okta.users.read" },
+                    ClientId = service.GetProperty<string>("client_id"),
+                    PrivateKey = new JsonWebKeyConfiguration(jsonPrivateKey),
+                    AuthorizationMode = AuthorizationMode.PrivateKey,
+                };
 
-                var oAuthClient = TestClient.Create(configuration);
+                var testOAuthClient = TestClient.Create(configuration);
 
-                var users = await oAuthClient.Users.ListUsers().ToArrayAsync();
+                var users = await testOAuthClient.Users.ListUsers().ToArrayAsync();
 
                 users.Should().NotBeEmpty();
             }

--- a/src/Okta.Sdk.IntegrationTests/UserTypesClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserTypesClientScenarios.cs
@@ -6,13 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
 namespace Okta.Sdk.IntegrationTests
 {
-    public class UserTypesClientShould
+    public class UserTypesClientScenarios
     {
         private const string SdkPrefix = "dotnet_sdk";
 
@@ -195,7 +196,7 @@ namespace Okta.Sdk.IntegrationTests
             ex.StatusCode.Should().Be(404);
         }
 
-        [Fact(Skip="Investigate collateral errors (404 - CVDType) - OKTA-300462")]
+        [Fact]
         public async Task ListAllUserTypes()
         {
             var testClient = TestClient.Create();
@@ -213,6 +214,8 @@ namespace Okta.Sdk.IntegrationTests
                 DisplayName = $"{nameof(ListAllUserTypes)} Test DisplayName (2)",
                 Name = $"{nameof(ListAllUserTypes)}_TestUserType_2_{TestClient.RandomString(6)}",
             });
+
+            Thread.Sleep(3000); // allow for user replication prior to read attempt
 
             try
             {

--- a/src/Okta.Sdk.IntegrationTests/UserTypesClientScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserTypesClientScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="UserTypesClientShould.cs" company="Okta, Inc">
+﻿// <copyright file="UserTypesClientScenarios.cs" company="Okta, Inc">
 // Copyright (c) 2014 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>

--- a/src/Okta.Sdk.UnitTests/FeaturesClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/FeaturesClientShould.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FeaturesClientShould.cs" company="Okta, Inc">
+﻿﻿// <copyright file="FeaturesClientShould.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>


### PR DESCRIPTION
# Account for eventual consistency

The primary change introduced here are Thread.Sleep additions on creation of new data.  Was seeing intermittent 404 responses when new data entries are made, likely due to GET requests going to read only data replicas.  This change waits a few seconds to allow for data replication prior to read attempts.