### PR TITLE
OKTA-302822 http POST support for list responses

### DIFF
--- a/openapi/processClients.js
+++ b/openapi/processClients.js
@@ -120,6 +120,7 @@ function createContextForClient(tag, operations) {
       isCollection: operation.isArray,
       path: operation.path,
       httpMethod: {
+        verbName: `${pascalCase(operation.method)}`, 
         memberName: `${pascalCase(operation.method)}Async`
       }
     }

--- a/openapi/templates/Client.cs.hbs
+++ b/openapi/templates/Client.cs.hbs
@@ -36,6 +36,7 @@ namespace Okta.Sdk
             {{#if isCollection}}=> GetCollectionClient<I{{returnType.memberName}}>(new HttpRequest
             {
                 Uri = "{{{path}}}",
+                Verb = HttpVerb.{{httpMethod.verbName}},
                 {{#if bodyModel}}Payload = {{bodyModel.parameterName}},{{/if}}
                 {{#if pathParameters}}
                 PathParameters = new Dictionary<string, object>()
@@ -57,6 +58,7 @@ namespace Okta.Sdk
             {{else}}=> await {{httpMethod.memberName}}{{#if returnType.memberName}}<{{returnType.memberName}}>{{/if}}(new HttpRequest
             {
                 Uri = "{{{path}}}",
+                Verb = HttpVerb.{{httpMethod.verbName}},
                 {{#if bodyModel}}Payload = {{bodyModel.parameterName}},{{/if}}
                 {{#if pathParameters}}
                 PathParameters = new Dictionary<string, object>()

--- a/src/Okta.Sdk.IntegrationTests/AuthorizationServersScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/AuthorizationServersScenarios.cs
@@ -887,7 +887,7 @@ namespace Okta.Sdk.IntegrationTests
             }
         }
 
-        [Fact(Skip = "ICollectionClient doesn't support POST - OKTA-302822")]
+        [Fact]
         public async Task RotateAuthorizationServerKeys()
         {
             var testClient = TestClient.Create();
@@ -899,12 +899,16 @@ namespace Okta.Sdk.IntegrationTests
                 Description = "Test Authorization Server",
                 Audiences = new string[] { "api://default" },
             };
+            var key = new JwkUse
+            {
+                Use = "sig"
+            };
 
             var createdAuthorizationServer = await testClient.AuthorizationServers.CreateAuthorizationServerAsync(testAuthorizationServer);
 
             try
             {
-                var keys = await createdAuthorizationServer.RotateKeys(new JwkUse()).ToListAsync();
+                var keys = await createdAuthorizationServer.RotateKeys(key).ToListAsync();
                 keys.Should().NotBeNull();
                 keys.Count.Should().BeGreaterThan(0);
             }

--- a/src/Okta.Sdk.IntegrationTests/AuthorizationServersScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/AuthorizationServersScenarios.cs
@@ -887,7 +887,7 @@ namespace Okta.Sdk.IntegrationTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "OKTA-303121: Api validation failed: com.saasure.framework.exception.KeyStoreLimitExceededException (400, E0000001): Unable to create new authorization server. You cannot create authorization servers because signing keys could not be generated. To fix this issue, contact support.")]
         public async Task RotateAuthorizationServerKeys()
         {
             var testClient = TestClient.Create();

--- a/src/Okta.Sdk.UnitTests/Internal/MockedCollectionRequestExecutor{T}.cs
+++ b/src/Okta.Sdk.UnitTests/Internal/MockedCollectionRequestExecutor{T}.cs
@@ -48,6 +48,23 @@ namespace Okta.Sdk.UnitTests.Internal
             return Task.FromResult(serializer.Serialize(itemData));
         }
 
+        public async Task<HttpResponse<string>> ExecuteRequestAsync(HttpRequest request, CancellationToken cancellationToken)
+        {
+            switch (request.Verb)
+            {
+                case HttpVerb.Get:
+                    return await GetAsync(request.Uri, request.Headers, cancellationToken);
+                case HttpVerb.Post:
+                    return await PostAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken);
+                case HttpVerb.Put:
+                    return await PutAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken);
+                case HttpVerb.Delete:
+                    return await DeleteAsync(request.Uri, request.Headers, cancellationToken);
+                default:
+                    return await GetAsync(request.Uri, request.Headers, cancellationToken);
+            }
+        }
+
         public async Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             var responseHeaders = new List<KeyValuePair<string, IEnumerable<string>>>

--- a/src/Okta.Sdk.UnitTests/Internal/MockedStringRequestExecutor.cs
+++ b/src/Okta.Sdk.UnitTests/Internal/MockedStringRequestExecutor.cs
@@ -28,6 +28,23 @@ namespace Okta.Sdk.UnitTests.Internal
             _statusCode = statusCode;
         }
 
+        public Task<HttpResponse<string>> ExecuteRequestAsync(HttpRequest request, CancellationToken cancellationToken)
+        {
+            switch (request.Verb)
+            {
+                case HttpVerb.Get:
+                    return GetAsync(request.Uri, request.Headers, cancellationToken);
+                case HttpVerb.Post:
+                    return PostAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken);
+                case HttpVerb.Put:
+                    return PutAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken);
+                case HttpVerb.Delete:
+                    return DeleteAsync(request.Uri, request.Headers, cancellationToken);
+                default:
+                    return GetAsync(request.Uri, request.Headers, cancellationToken);
+            }
+        }
+
         public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             ReceivedHref = href;

--- a/src/Okta.Sdk.UnitTests/Internal/TestDefaultRequestExecutor.cs
+++ b/src/Okta.Sdk.UnitTests/Internal/TestDefaultRequestExecutor.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Okta.Sdk.Configuration;
+using Okta.Sdk.Internal;
+
+namespace Okta.Sdk.UnitTests.Internal
+{
+    public class TestDefaultRequestExecutor : DefaultRequestExecutor
+    {
+        public TestDefaultRequestExecutor(OktaClientConfiguration configuration, HttpClient httpClient, ILogger logger, IRetryStrategy retryStrategy = null, IOAuthTokenProvider oAuthTokenProvider = null) : base(configuration, httpClient, logger, retryStrategy, oAuthTokenProvider)
+        {
+            VerbExecutionCounts = new Dictionary<HttpVerb, int>
+            {
+                {HttpVerb.Get, 0},
+                {HttpVerb.Post, 0},
+                {HttpVerb.Put, 0},
+                {HttpVerb.Delete, 0},
+            };
+        }
+
+        public Dictionary<HttpVerb, int> VerbExecutionCounts { get; set; }
+
+        public string ReceivedHref { get; set; }
+
+        public override Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
+        {
+            VerbExecutionCounts[HttpVerb.Get] += 1;
+            return Task.FromResult(GetTestResponse());
+        }
+
+        public override Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
+        {
+            VerbExecutionCounts[HttpVerb.Post] += 1;
+            return Task.FromResult(GetTestResponse());
+        }
+
+        public override Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
+        {
+            VerbExecutionCounts[HttpVerb.Put] += 1;
+            return Task.FromResult(GetTestResponse());
+        }
+
+        public override Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
+        {
+            VerbExecutionCounts[HttpVerb.Delete] += 1;
+            return Task.FromResult(GetTestResponse());
+        }
+
+        private HttpResponse<string> GetTestResponse()
+        {
+            return new HttpResponse<string>
+            {
+                StatusCode = 200,
+                Payload = "test", 
+            };
+        }
+    }
+}

--- a/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/ApplicationsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IApplication>(new HttpRequest
             {
                 Uri = "/api/v1/apps",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -50,6 +51,7 @@ namespace Okta.Sdk
             => await PostAsync<Application>(new HttpRequest
             {
                 Uri = "/api/v1/apps",
+                Verb = HttpVerb.Post,
                 Payload = application,
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -62,6 +64,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -74,6 +77,7 @@ namespace Okta.Sdk
             => await GetAsync<Application>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -90,6 +94,7 @@ namespace Okta.Sdk
             => await PutAsync<Application>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}",
+                Verb = HttpVerb.Put,
                 Payload = application,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -102,6 +107,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ICsr>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -114,6 +120,7 @@ namespace Okta.Sdk
             => await PostAsync<Csr>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs",
+                Verb = HttpVerb.Post,
                 Payload = metadata,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -126,6 +133,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -139,6 +147,7 @@ namespace Okta.Sdk
             => await GetAsync<Csr>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -152,6 +161,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -165,6 +175,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -178,6 +189,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -191,6 +203,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -204,6 +217,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -217,6 +231,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -229,6 +244,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys/generate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -245,6 +261,7 @@ namespace Okta.Sdk
             => await GetAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys/{keyId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -258,6 +275,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/credentials/keys/{keyId}/clone",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -275,6 +293,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/grants",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -291,6 +310,7 @@ namespace Okta.Sdk
             => await PostAsync<OAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/grants",
+                Verb = HttpVerb.Post,
                 Payload = oAuth2ScopeConsentGrant,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -303,6 +323,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/grants/{grantId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -316,6 +337,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/grants/{grantId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -333,6 +355,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IApplicationGroupAssignment>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -352,6 +375,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups/{groupId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -365,6 +389,7 @@ namespace Okta.Sdk
             => await GetAsync<ApplicationGroupAssignment>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups/{groupId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -382,6 +407,7 @@ namespace Okta.Sdk
             => await PutAsync<ApplicationGroupAssignment>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/groups/{groupId}",
+                Verb = HttpVerb.Put,
                 Payload = applicationGroupAssignment,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -395,6 +421,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -407,6 +434,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -419,6 +447,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/tokens",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -431,6 +460,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2Token>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/tokens",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -449,6 +479,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/tokens/{tokenId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -462,6 +493,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2Token>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/tokens/{tokenId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -479,6 +511,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IAppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -500,6 +533,7 @@ namespace Okta.Sdk
             => await PostAsync<AppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users",
+                Verb = HttpVerb.Post,
                 Payload = appUser,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -512,6 +546,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users/{userId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -529,6 +564,7 @@ namespace Okta.Sdk
             => await GetAsync<AppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users/{userId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -546,6 +582,7 @@ namespace Okta.Sdk
             => await PostAsync<AppUser>(new HttpRequest
             {
                 Uri = "/api/v1/apps/{appId}/users/{userId}",
+                Verb = HttpVerb.Post,
                 Payload = appUser,
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/AuthorizationServersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/AuthorizationServersClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IAuthorizationServer>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -47,6 +48,7 @@ namespace Okta.Sdk
             => await PostAsync<AuthorizationServer>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers",
+                Verb = HttpVerb.Post,
                 Payload = authorizationServer,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -55,6 +57,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -67,6 +70,7 @@ namespace Okta.Sdk
             => await GetAsync<AuthorizationServer>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -79,6 +83,7 @@ namespace Okta.Sdk
             => await PutAsync<AuthorizationServer>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}",
+                Verb = HttpVerb.Put,
                 Payload = authorizationServer,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -91,6 +96,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2Claim>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/claims",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -103,6 +109,7 @@ namespace Okta.Sdk
             => await PostAsync<OAuth2Claim>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/claims",
+                Verb = HttpVerb.Post,
                 Payload = oAuth2Claim,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -115,6 +122,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/claims/{claimId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -128,6 +136,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2Claim>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/claims/{claimId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -141,6 +150,7 @@ namespace Okta.Sdk
             => await PutAsync<OAuth2Claim>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/claims/{claimId}",
+                Verb = HttpVerb.Put,
                 Payload = oAuth2Claim,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -154,6 +164,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2Client>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/clients",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -166,6 +177,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -179,6 +191,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2RefreshToken>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -198,6 +211,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens/{tokenId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -212,6 +226,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2RefreshToken>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens/{tokenId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -230,6 +245,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/credentials/keys",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -242,6 +258,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/credentials/lifecycle/keyRotate",
+                Verb = HttpVerb.Post,
                 Payload = use,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -254,6 +271,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -266,6 +284,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -278,6 +297,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IPolicy>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/policies",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -290,6 +310,7 @@ namespace Okta.Sdk
             => await PostAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/policies",
+                Verb = HttpVerb.Post,
                 Payload = policy,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -302,6 +323,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/policies/{policyId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -315,6 +337,7 @@ namespace Okta.Sdk
             => await GetAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/policies/{policyId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -328,6 +351,7 @@ namespace Okta.Sdk
             => await PutAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/policies/{policyId}",
+                Verb = HttpVerb.Put,
                 Payload = policy,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -341,6 +365,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2Scope>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/scopes",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -360,6 +385,7 @@ namespace Okta.Sdk
             => await PostAsync<OAuth2Scope>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/scopes",
+                Verb = HttpVerb.Post,
                 Payload = oAuth2Scope,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -372,6 +398,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -385,6 +412,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2Scope>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -398,6 +426,7 @@ namespace Okta.Sdk
             => await PutAsync<OAuth2Scope>(new HttpRequest
             {
                 Uri = "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}",
+                Verb = HttpVerb.Put,
                 Payload = oAuth2Scope,
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/EventHooksClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/EventHooksClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IEventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks",
+                Verb = HttpVerb.Get,
                 
             });
                     
@@ -41,6 +42,7 @@ namespace Okta.Sdk
             => await PostAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks",
+                Verb = HttpVerb.Post,
                 Payload = eventHook,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -49,6 +51,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -61,6 +64,7 @@ namespace Okta.Sdk
             => await GetAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -73,6 +77,7 @@ namespace Okta.Sdk
             => await PutAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}",
+                Verb = HttpVerb.Put,
                 Payload = eventHook,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -85,6 +90,7 @@ namespace Okta.Sdk
             => await PostAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -97,6 +103,7 @@ namespace Okta.Sdk
             => await PostAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -109,6 +116,7 @@ namespace Okta.Sdk
             => await PostAsync<EventHook>(new HttpRequest
             {
                 Uri = "/api/v1/eventHooks/{eventHookId}/lifecycle/verify",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/FeaturesClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/FeaturesClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IFeature>(new HttpRequest
             {
                 Uri = "/api/v1/features",
+                Verb = HttpVerb.Get,
                 
             });
                     
@@ -41,6 +42,7 @@ namespace Okta.Sdk
             => await GetAsync<Feature>(new HttpRequest
             {
                 Uri = "/api/v1/features/{featureId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -53,6 +55,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IFeature>(new HttpRequest
             {
                 Uri = "/api/v1/features/{featureId}/dependencies",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -65,6 +68,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IFeature>(new HttpRequest
             {
                 Uri = "/api/v1/features/{featureId}/dependents",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -77,6 +81,7 @@ namespace Okta.Sdk
             => await PostAsync<Feature>(new HttpRequest
             {
                 Uri = "/api/v1/features/{featureId}/{lifecycle}",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/groups",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -48,6 +49,7 @@ namespace Okta.Sdk
             => await PostAsync<Group>(new HttpRequest
             {
                 Uri = "/api/v1/groups",
+                Verb = HttpVerb.Post,
                 Payload = group,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -56,6 +58,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IGroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -71,6 +74,7 @@ namespace Okta.Sdk
             => await PostAsync<GroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules",
+                Verb = HttpVerb.Post,
                 Payload = groupRule,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -79,6 +83,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules/{ruleId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -91,6 +96,7 @@ namespace Okta.Sdk
             => await GetAsync<GroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules/{ruleId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -107,6 +113,7 @@ namespace Okta.Sdk
             => await PutAsync<GroupRule>(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules/{ruleId}",
+                Verb = HttpVerb.Put,
                 Payload = groupRule,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -119,6 +126,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules/{ruleId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -131,6 +139,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/rules/{ruleId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -143,6 +152,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -155,6 +165,7 @@ namespace Okta.Sdk
             => await GetAsync<Group>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -167,6 +178,7 @@ namespace Okta.Sdk
             => await PutAsync<Group>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}",
+                Verb = HttpVerb.Put,
                 Payload = group,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -179,6 +191,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IApplication>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/apps",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -196,6 +209,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IRole>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -212,6 +226,7 @@ namespace Okta.Sdk
             => await PostAsync<Role>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles",
+                Verb = HttpVerb.Post,
                 Payload = assignRoleRequest,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -228,6 +243,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -241,6 +257,7 @@ namespace Okta.Sdk
             => await GetAsync<Role>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -254,6 +271,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IApplication>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -272,6 +290,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -286,6 +305,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -300,6 +320,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -315,6 +336,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -330,6 +352,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -348,6 +371,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups/{targetGroupId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -362,6 +386,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups/{targetGroupId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -376,6 +401,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IUser>(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/users",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -393,6 +419,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/users/{userId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -406,6 +433,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/groups/{groupId}/users/{userId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/IdentityProvidersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IdentityProvidersClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IIdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -48,6 +49,7 @@ namespace Okta.Sdk
             => await PostAsync<IdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps",
+                Verb = HttpVerb.Post,
                 Payload = identityProvider,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -56,6 +58,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/credentials/keys",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -69,6 +72,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/credentials/keys",
+                Verb = HttpVerb.Post,
                 Payload = jsonWebKey,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -77,6 +81,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/idps/credentials/keys/{keyId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -89,6 +94,7 @@ namespace Okta.Sdk
             => await GetAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/credentials/keys/{keyId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -101,6 +107,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -113,6 +120,7 @@ namespace Okta.Sdk
             => await GetAsync<IdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -125,6 +133,7 @@ namespace Okta.Sdk
             => await PutAsync<IdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}",
+                Verb = HttpVerb.Put,
                 Payload = identityProvider,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -137,6 +146,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ICsr>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -149,6 +159,7 @@ namespace Okta.Sdk
             => await PostAsync<Csr>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs",
+                Verb = HttpVerb.Post,
                 Payload = metadata,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -161,6 +172,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -174,6 +186,7 @@ namespace Okta.Sdk
             => await GetAsync<Csr>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -187,6 +200,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -200,6 +214,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -213,6 +228,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -226,6 +242,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -239,6 +256,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish",
+                Verb = HttpVerb.Post,
                 Payload = certificate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -252,6 +270,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IJsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/keys",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -264,6 +283,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/keys/generate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -280,6 +300,7 @@ namespace Okta.Sdk
             => await GetAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/keys/{keyId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -293,6 +314,7 @@ namespace Okta.Sdk
             => await PostAsync<JsonWebKey>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/credentials/keys/{keyId}/clone",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -310,6 +332,7 @@ namespace Okta.Sdk
             => await PostAsync<IdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -322,6 +345,7 @@ namespace Okta.Sdk
             => await PostAsync<IdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -334,6 +358,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IIdentityProviderApplicationUser>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/users",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -346,6 +371,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/users/{userId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -359,6 +385,7 @@ namespace Okta.Sdk
             => await GetAsync<IdentityProviderApplicationUser>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/users/{userId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -372,6 +399,7 @@ namespace Okta.Sdk
             => await PostAsync<IdentityProviderApplicationUser>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/users/{userId}",
+                Verb = HttpVerb.Post,
                 Payload = userIdentityProviderLinkRequest,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -385,6 +413,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ISocialAuthToken>(new HttpRequest
             {
                 Uri = "/api/v1/idps/{idpId}/users/{userId}/credentials/tokens",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/InlineHooksClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/InlineHooksClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IInlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -45,6 +46,7 @@ namespace Okta.Sdk
             => await PostAsync<InlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks",
+                Verb = HttpVerb.Post,
                 Payload = inlineHook,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -53,6 +55,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -65,6 +68,7 @@ namespace Okta.Sdk
             => await GetAsync<InlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -77,6 +81,7 @@ namespace Okta.Sdk
             => await PutAsync<InlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}",
+                Verb = HttpVerb.Put,
                 Payload = inlineHook,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -89,6 +94,7 @@ namespace Okta.Sdk
             => await PostAsync<InlineHookResponse>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}/execute",
+                Verb = HttpVerb.Post,
                 Payload = payloadData,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -101,6 +107,7 @@ namespace Okta.Sdk
             => await PostAsync<InlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -113,6 +120,7 @@ namespace Okta.Sdk
             => await PostAsync<InlineHook>(new HttpRequest
             {
                 Uri = "/api/v1/inlineHooks/{inlineHookId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/LinkedObjectsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/LinkedObjectsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ILinkedObject>(new HttpRequest
             {
                 Uri = "/api/v1/meta/schemas/user/linkedObjects",
+                Verb = HttpVerb.Get,
                 
             });
                     
@@ -41,6 +42,7 @@ namespace Okta.Sdk
             => await PostAsync<LinkedObject>(new HttpRequest
             {
                 Uri = "/api/v1/meta/schemas/user/linkedObjects",
+                Verb = HttpVerb.Post,
                 Payload = linkedObject,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -49,6 +51,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/meta/schemas/user/linkedObjects/{linkedObjectName}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -61,6 +64,7 @@ namespace Okta.Sdk
             => await GetAsync<LinkedObject>(new HttpRequest
             {
                 Uri = "/api/v1/meta/schemas/user/linkedObjects/{linkedObjectName}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/LogsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/LogsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ILogEvent>(new HttpRequest
             {
                 Uri = "/api/v1/logs",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/PoliciesClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/PoliciesClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IPolicy>(new HttpRequest
             {
                 Uri = "/api/v1/policies",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -47,6 +48,7 @@ namespace Okta.Sdk
             => await PostAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/policies",
+                Verb = HttpVerb.Post,
                 Payload = policy,
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -59,6 +61,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -71,6 +74,7 @@ namespace Okta.Sdk
             => await GetAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -87,6 +91,7 @@ namespace Okta.Sdk
             => await PutAsync<Policy>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}",
+                Verb = HttpVerb.Put,
                 Payload = policy,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -99,6 +104,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -111,6 +117,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -123,6 +130,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IPolicyRule>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -135,6 +143,7 @@ namespace Okta.Sdk
             => await PostAsync<PolicyRule>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules",
+                Verb = HttpVerb.Post,
                 Payload = policyRule,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -147,6 +156,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules/{ruleId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -160,6 +170,7 @@ namespace Okta.Sdk
             => await GetAsync<PolicyRule>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules/{ruleId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -173,6 +184,7 @@ namespace Okta.Sdk
             => await PutAsync<PolicyRule>(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules/{ruleId}",
+                Verb = HttpVerb.Put,
                 Payload = policyRule,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -186,6 +198,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules/{ruleId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -199,6 +212,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/policies/{policyId}/rules/{ruleId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/SessionsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/SessionsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => await PostAsync<Session>(new HttpRequest
             {
                 Uri = "/api/v1/sessions",
+                Verb = HttpVerb.Post,
                 Payload = createSessionRequest,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -41,6 +42,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/sessions/{sessionId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -53,6 +55,7 @@ namespace Okta.Sdk
             => await GetAsync<Session>(new HttpRequest
             {
                 Uri = "/api/v1/sessions/{sessionId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -65,6 +68,7 @@ namespace Okta.Sdk
             => await PostAsync<Session>(new HttpRequest
             {
                 Uri = "/api/v1/sessions/{sessionId}/lifecycle/refresh",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/TemplatesClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/TemplatesClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ISmsTemplate>(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -45,6 +46,7 @@ namespace Okta.Sdk
             => await PostAsync<SmsTemplate>(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms",
+                Verb = HttpVerb.Post,
                 Payload = smsTemplate,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -53,6 +55,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms/{templateId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -65,6 +68,7 @@ namespace Okta.Sdk
             => await GetAsync<SmsTemplate>(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms/{templateId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -77,6 +81,7 @@ namespace Okta.Sdk
             => await PostAsync<SmsTemplate>(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms/{templateId}",
+                Verb = HttpVerb.Post,
                 Payload = smsTemplate,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -89,6 +94,7 @@ namespace Okta.Sdk
             => await PutAsync<SmsTemplate>(new HttpRequest
             {
                 Uri = "/api/v1/templates/sms/{templateId}",
+                Verb = HttpVerb.Put,
                 Payload = smsTemplate,
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/TrustedOriginsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/TrustedOriginsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ITrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -48,6 +49,7 @@ namespace Okta.Sdk
             => await PostAsync<TrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins",
+                Verb = HttpVerb.Post,
                 Payload = trustedOrigin,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -56,6 +58,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins/{trustedOriginId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -68,6 +71,7 @@ namespace Okta.Sdk
             => await GetAsync<TrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins/{trustedOriginId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -80,6 +84,7 @@ namespace Okta.Sdk
             => await PutAsync<TrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins/{trustedOriginId}",
+                Verb = HttpVerb.Put,
                 Payload = trustedOrigin,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -92,6 +97,7 @@ namespace Okta.Sdk
             => await PostAsync<TrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins/{trustedOriginId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -104,6 +110,7 @@ namespace Okta.Sdk
             => await PostAsync<TrustedOrigin>(new HttpRequest
             {
                 Uri = "/api/v1/trustedOrigins/{trustedOriginId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UserFactorsClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IUserFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -45,6 +46,7 @@ namespace Okta.Sdk
             => await PostAsync<UserFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors",
+                Verb = HttpVerb.Post,
                 Payload = body,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -64,6 +66,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IUserFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/catalog",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -76,6 +79,7 @@ namespace Okta.Sdk
             => GetCollectionClient<ISecurityQuestion>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/questions",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -88,6 +92,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/{factorId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -101,6 +106,7 @@ namespace Okta.Sdk
             => await GetAsync<UserFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/{factorId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -114,6 +120,7 @@ namespace Okta.Sdk
             => await PostAsync<UserFactor>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/{factorId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 Payload = body,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -127,6 +134,7 @@ namespace Okta.Sdk
             => await GetAsync<VerifyUserFactorResponse>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/{factorId}/transactions/{transactionId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -141,6 +149,7 @@ namespace Okta.Sdk
             => await PostAsync<VerifyUserFactorResponse>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/factors/{factorId}/verify",
+                Verb = HttpVerb.Post,
                 Payload = body,
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/UserTypesClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UserTypesClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IUserType>(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user",
+                Verb = HttpVerb.Get,
                 
             });
                     
@@ -41,6 +42,7 @@ namespace Okta.Sdk
             => await PostAsync<UserType>(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user",
+                Verb = HttpVerb.Post,
                 Payload = userType,
                 }, cancellationToken).ConfigureAwait(false);
         
@@ -49,6 +51,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user/{typeId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -61,6 +64,7 @@ namespace Okta.Sdk
             => await GetAsync<UserType>(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user/{typeId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -73,6 +77,7 @@ namespace Okta.Sdk
             => await PostAsync<UserType>(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user/{typeId}",
+                Verb = HttpVerb.Post,
                 Payload = userType,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -85,6 +90,7 @@ namespace Okta.Sdk
             => await PutAsync<UserType>(new HttpRequest
             {
                 Uri = "/api/v1/meta/types/user/{typeId}",
+                Verb = HttpVerb.Put,
                 Payload = userType,
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/Generated/UsersClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/UsersClient.Generated.cs
@@ -33,6 +33,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IUser>(new HttpRequest
             {
                 Uri = "/api/v1/users",
+                Verb = HttpVerb.Get,
                 
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -51,6 +52,7 @@ namespace Okta.Sdk
             => await PostAsync<User>(new HttpRequest
             {
                 Uri = "/api/v1/users",
+                Verb = HttpVerb.Post,
                 Payload = body,
                 QueryParameters = new Dictionary<string, object>()
                 {
@@ -65,6 +67,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{associatedUserId}/linkedObjects/{primaryRelationshipName}/{primaryUserId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -79,6 +82,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -95,6 +99,7 @@ namespace Okta.Sdk
             => await GetAsync<User>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -107,6 +112,7 @@ namespace Okta.Sdk
             => await PostAsync<User>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}",
+                Verb = HttpVerb.Post,
                 Payload = user,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -123,6 +129,7 @@ namespace Okta.Sdk
             => await PutAsync<User>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}",
+                Verb = HttpVerb.Put,
                 Payload = user,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -139,6 +146,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IAppLink>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/appLinks",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -151,6 +159,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2Client>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -163,6 +172,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/grants",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -176,6 +186,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/grants",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -195,6 +206,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/tokens",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -208,6 +220,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2RefreshToken>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/tokens",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -227,6 +240,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/tokens/{tokenId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -241,6 +255,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2RefreshToken>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/clients/{clientId}/tokens/{tokenId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -261,6 +276,7 @@ namespace Okta.Sdk
             => await PostAsync<UserCredentials>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/credentials/change_password",
+                Verb = HttpVerb.Post,
                 Payload = changePasswordRequest,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -277,6 +293,7 @@ namespace Okta.Sdk
             => await PostAsync<UserCredentials>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/credentials/change_recovery_question",
+                Verb = HttpVerb.Post,
                 Payload = userCredentials,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -289,6 +306,7 @@ namespace Okta.Sdk
             => await PostAsync<ForgotPasswordResponse>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/credentials/forgot_password",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -305,6 +323,7 @@ namespace Okta.Sdk
             => await PostAsync<ForgotPasswordResponse>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/credentials/forgot_password",
+                Verb = HttpVerb.Post,
                 Payload = user,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -321,6 +340,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/grants",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -333,6 +353,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IOAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/grants",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -352,6 +373,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/grants/{grantId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -365,6 +387,7 @@ namespace Okta.Sdk
             => await GetAsync<OAuth2ScopeConsentGrant>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/grants/{grantId}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -382,6 +405,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/groups",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -394,6 +418,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IIdentityProvider>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/idps",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -406,6 +431,7 @@ namespace Okta.Sdk
             => await PostAsync<UserActivationToken>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/activate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -422,6 +448,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/deactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -438,6 +465,7 @@ namespace Okta.Sdk
             => await PostAsync<User>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/expire_password?tempPassword=false",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -450,6 +478,7 @@ namespace Okta.Sdk
             => await PostAsync<TempPassword>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/expire_password?tempPassword=true",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -462,6 +491,7 @@ namespace Okta.Sdk
             => await PostAsync<UserActivationToken>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/reactivate",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -478,6 +508,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/reset_factors",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -490,6 +521,7 @@ namespace Okta.Sdk
             => await PostAsync<ResetPasswordToken>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/reset_password",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -506,6 +538,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/suspend",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -518,6 +551,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/unlock",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -530,6 +564,7 @@ namespace Okta.Sdk
             => await PostAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/lifecycle/unsuspend",
+                Verb = HttpVerb.Post,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -542,6 +577,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/linkedObjects/{relationshipName}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -555,6 +591,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IResponseLinks>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/linkedObjects/{relationshipName}",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -573,6 +610,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IRole>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -589,6 +627,7 @@ namespace Okta.Sdk
             => await PostAsync<Role>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles",
+                Verb = HttpVerb.Post,
                 Payload = assignRoleRequest,
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -605,6 +644,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -618,6 +658,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IApplication>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -636,6 +677,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -649,6 +691,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -663,6 +706,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -677,6 +721,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -692,6 +737,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -707,6 +753,7 @@ namespace Okta.Sdk
             => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups",
+                Verb = HttpVerb.Get,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -725,6 +772,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups/{groupId}",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -739,6 +787,7 @@ namespace Okta.Sdk
             => await PutAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/roles/{roleId}/targets/groups/{groupId}",
+                Verb = HttpVerb.Put,
                 
                 PathParameters = new Dictionary<string, object>()
                 {
@@ -753,6 +802,7 @@ namespace Okta.Sdk
             => await DeleteAsync(new HttpRequest
             {
                 Uri = "/api/v1/users/{userId}/sessions",
+                Verb = HttpVerb.Delete,
                 
                 PathParameters = new Dictionary<string, object>()
                 {

--- a/src/Okta.Sdk/HttpRequest.cs
+++ b/src/Okta.Sdk/HttpRequest.cs
@@ -3,8 +3,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Okta.Sdk.Internal;
 
 namespace Okta.Sdk
 {
@@ -13,6 +15,23 @@ namespace Okta.Sdk
     /// </summary>
     public class HttpRequest
     {
+        public HttpRequest() : this(new DefaultSerializer())
+        {
+        }
+
+        public HttpRequest(ISerializer serializer)
+        {
+            Serializer = serializer ?? new DefaultSerializer();
+        }
+
+        /// <summary>
+        /// Gets or sets the Http verb, also known as the request method.
+        /// </summary>
+        /// <value>
+        /// The request verb.
+        /// </value>
+        public HttpVerb Verb { get; set; }
+
         /// <summary>
         /// Gets or sets the request URI.
         /// </summary>
@@ -55,5 +74,47 @@ namespace Okta.Sdk
         /// </value>
         public IDictionary<string, string> Headers { get; set; }
             = new Dictionary<string, string>();
+
+        private string _body;
+
+        public string GetBody(ISerializer serializer = null)
+        {
+            if (serializer != null)
+            {
+                if (Serializer != serializer)
+                {
+                    Serializer = serializer;
+                    if (Payload != null)
+                    {
+                        _body = Serializer.Serialize(Payload); // re-serialize the payload if the specified serializer is different from the current 
+                    }
+                }
+            }
+
+            if (Payload != null)
+            {
+                // don't re-serialize if already done
+                if (string.IsNullOrEmpty(_body))
+                {
+                    _body = Serializer.Serialize(Payload);
+                }
+            }
+
+            return _body;
+        }
+
+        public HttpRequest SetBody(string body)
+        {
+            _body = body;
+            return this;
+        }
+
+        public HttpRequest SetSerializer(ISerializer serializer)
+        {
+            Serializer = serializer;
+            return this;
+        }
+
+        private ISerializer Serializer { get; set; }
     }
 }

--- a/src/Okta.Sdk/HttpVerb.cs
+++ b/src/Okta.Sdk/HttpVerb.cs
@@ -1,0 +1,10 @@
+﻿namespace Okta.Sdk
+{
+    public enum HttpVerb
+    {
+        Get,
+        Post,
+        Put,
+        Delete
+    }
+}

--- a/src/Okta.Sdk/Internal/ContentTypePayloadHandler.cs
+++ b/src/Okta.Sdk/Internal/ContentTypePayloadHandler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Okta.Sdk.Internal
+{
+    public class ContentTypePayloadHandler
+    {
+        public ContentTypePayloadHandler()
+        {
+        }
+
+        public static Dictionary<string, Func<ISerializer, object, string>> DefaultHandlers { get; set; }
+    }
+}

--- a/src/Okta.Sdk/Internal/DefaultDataStore.cs
+++ b/src/Okta.Sdk/Internal/DefaultDataStore.cs
@@ -205,7 +205,7 @@ namespace Okta.Sdk.Internal
         {
             PrepareRequest(request, requestContext);
 
-            var response = await _requestExecutor.GetAsync(request.Uri, request.Headers, cancellationToken).ConfigureAwait(false);
+            var response = await _requestExecutor.ExecuteRequestAsync(request.SetSerializer(_serializer), cancellationToken).ConfigureAwait(false);
             EnsureResponseSuccess(response);
 
             var resources = _serializer

--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -17,7 +17,7 @@ namespace Okta.Sdk.Internal
     /// <summary>
     /// The default implementation of <see cref="IRequestExecutor"/> that uses <c>System.Net.Http</c>.
     /// </summary>
-    public sealed class DefaultRequestExecutor : IRequestExecutor
+    public class DefaultRequestExecutor : IRequestExecutor
     {
         private const string OktaClientUserAgentName = "oktasdk-dotnet";
 
@@ -165,8 +165,25 @@ namespace Okta.Sdk.Internal
             }
         }
 
+        public virtual async Task<HttpResponse<string>> ExecuteRequestAsync(HttpRequest request, CancellationToken cancellationToken)
+        {
+            switch (request.Verb)
+            {
+                case HttpVerb.Get:
+                    return await GetAsync(request.Uri, request.Headers, cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Post:
+                    return await PostAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Put:
+                    return await PutAsync(request.Uri, request.Headers, request.GetBody(), cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Delete:
+                    return await DeleteAsync(request.Uri, request.Headers, cancellationToken).ConfigureAwait(false);
+                default:
+                    return await GetAsync(request.Uri, request.Headers, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         /// <inheritdoc/>
-        public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
+        public virtual Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
 
@@ -177,7 +194,7 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
-        public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
+        public virtual Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
 
@@ -192,7 +209,7 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
-        public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
+        public virtual Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
 
@@ -207,7 +224,7 @@ namespace Okta.Sdk.Internal
         }
 
         /// <inheritdoc/>
-        public Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
+        public virtual Task<HttpResponse<string>> DeleteAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
 

--- a/src/Okta.Sdk/Internal/IRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/IRequestExecutor.cs
@@ -15,6 +15,14 @@ namespace Okta.Sdk.Internal
     public interface IRequestExecutor
     {
         /// <summary>
+        /// Execute the specified request.
+        /// </summary>
+        /// <param name="request">The request to execute.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The HTTP response.</returns>
+        Task<HttpResponse<string>> ExecuteRequestAsync(HttpRequest request, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Sends a GET request to the specified <paramref name="href"/>.
         /// </summary>
         /// <param name="href">The request URL.</param>


### PR DESCRIPTION
## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
Cannot use POST to execute a request that returns a list/array.


## Desired behavior
Be able to use POST to execute a request that returns a list/array.


## Additional Context
The method AuthorizationServer.RotateKeys(...) requires POST verb and returns a list.  This change allows proper execution and deserialization of AuthorizationServer.RotateKeys.  Additionally, this change will simplify future changes requiring custom handling of http requests.

