### PR TITLE
bytearraypayloadhandler properly sets content-type header

### DIFF
--- a/src/Okta.Sdk.UnitTests/PayloadHandlerShould.cs
+++ b/src/Okta.Sdk.UnitTests/PayloadHandlerShould.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -97,6 +98,8 @@ namespace Okta.Sdk.UnitTests
             pkixCertPayloadHandler.SetHttpRequestMessageContent(testHttpRequest, httpRequestMessage);
             httpRequestMessage.Content.Should().NotBeNull();
             httpRequestMessage.Content.GetType().Should().Be(typeof(StringContent));
+            httpRequestMessage.Content.Headers.Contains("Content-Type");
+            httpRequestMessage.Content.Headers.ContentType.ToString().Should().Be("application/pkix-cert; charset=utf-8");
         }
 
         [Fact]
@@ -115,6 +118,8 @@ namespace Okta.Sdk.UnitTests
             pkixCertPayloadHandler.SetHttpRequestMessageContent(testHttpRequest, httpRequestMessage);
             httpRequestMessage.Content.Should().NotBeNull();
             httpRequestMessage.Content.GetType().Should().Be(typeof(ByteArrayContent));
+            httpRequestMessage.Content.Headers.Contains("Content-Type");
+            httpRequestMessage.Content.Headers.ContentType.ToString().Should().Be("application/x-pem-file");
         }
 
         [Fact]
@@ -133,6 +138,8 @@ namespace Okta.Sdk.UnitTests
             pkixCertPayloadHandler.SetHttpRequestMessageContent(testHttpRequest, httpRequestMessage);
             httpRequestMessage.Content.Should().NotBeNull();
             httpRequestMessage.Content.GetType().Should().Be(typeof(ByteArrayContent));
+            httpRequestMessage.Content.Headers.Contains("Content-Type");
+            httpRequestMessage.Content.Headers.ContentType.ToString().Should().Be("application/x-x509-ca-cert");
         }
     }
 }

--- a/src/Okta.Sdk/ApplicationsClient.cs
+++ b/src/Okta.Sdk/ApplicationsClient.cs
@@ -97,9 +97,8 @@ namespace Okta.Sdk
                 {
                     Uri = "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish",
                     Verb = HttpVerb.Post,
-                    Payload = Convert.FromBase64String(base64EncodedCertificateData),
+                    Payload = base64EncodedCertificateData,
                     ContentType = "application/pkix-cert",
-                    ContentTransferEncoding = "base64",
                     PathParameters = new Dictionary<string, object>()
                     {
                         ["appId"] = appId,

--- a/src/Okta.Sdk/Internal/ByteArrayPayloadHandler.cs
+++ b/src/Okta.Sdk/Internal/ByteArrayPayloadHandler.cs
@@ -26,7 +26,9 @@ namespace Okta.Sdk.Internal
                 throw new InvalidOperationException($"request payload should be of type byte array (byte[]), but was {httpRequest.Payload.GetType().FullName}");
             }
 
-            return new ByteArrayContent((byte[])httpRequest.Payload);
+            var content = new ByteArrayContent((byte[])httpRequest.Payload);
+            content.Headers.Add("Content-Type", ContentType);
+            return content;
         }
     }
 }

--- a/src/Okta.Sdk/Internal/PkixCertPayloadHandler.cs
+++ b/src/Okta.Sdk/Internal/PkixCertPayloadHandler.cs
@@ -41,7 +41,17 @@ namespace Okta.Sdk.Internal
                 throw new ArgumentNullException("request payload");
             }
 
-            return new StringContent((string)httpRequest.Payload, Encoding.UTF8, ContentType);
+            var content = string.Empty;
+            if (httpRequest.Payload is string stringPayload)
+            {
+                content = stringPayload;
+            }
+            else if (httpRequest.Payload is byte[] bytePayload)
+            {
+                content = Convert.ToBase64String(bytePayload);
+            }
+
+            return new StringContent(content, Encoding.UTF8, ContentType);
         }
     }
 }


### PR DESCRIPTION
## Issue \#
When using Publish* Certificate methods that accept byte arrays (byte[]), content related headers are not correctly set.

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
When using Publish* Certificate methods that accept byte arrays (byte[]) content related headers are not correctly set.


## Desired behavior
Content related headers are correctly set.


## Additional Context
Confusion about the requirements and expectations of the publish certificate methods, that accept binary data, lead to an incomplete implementation.

Manually tested each of the methods that accept binary data and received no content header related errors.

