### PR TITLE
use mock configuration in unit test

### DIFF
--- a/src/Okta.Sdk.UnitTests/OktaClientShould.cs
+++ b/src/Okta.Sdk.UnitTests/OktaClientShould.cs
@@ -346,7 +346,10 @@ namespace Okta.Sdk.UnitTests
         [Fact]
         public void RegisterPayloadHandlers()
         {
-            _ = new OktaClient();
+            var testableClient = new TestableHttpClient();
+            var client = new OktaClient(
+                TestableOktaClient.DefaultFakeConfiguration,
+                testableClient);
             PayloadHandler.ForContentType("application/pkix-cert").GetType().Should().Be(typeof(PkixCertPayloadHandler));
             PayloadHandler.ForContentType("application/x-pem-file").GetType().Should().Be(typeof(PemFilePayloadHandler));
             PayloadHandler.ForContentType("application/x-x509-ca-cert").GetType().Should().Be(typeof(X509CaCertPayloadHandler));


### PR DESCRIPTION
Correct unit test to use mock config instead of profile.
