### PR TITLE
Added support for Password Import Inline Hook user creation.

### DIFF
--- a/src/Okta.Sdk/CreateUserWithPasswordImportInlineHookOptions.cs
+++ b/src/Okta.Sdk/CreateUserWithPasswordImportInlineHookOptions.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="CreateUserWithPasswordOptions.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Contains the options for creating a new <see cref="IUser">User</see> with password import inline hook.
+    /// Used with <see cref="IUsersClient.CreateUserAsync(CreateUserWithPasswordImportInlineHookOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-password-import-inline-hook">Create User with Password Import Inline Hook</a> in the documentation.</remarks>
+    public sealed class CreateUserWithPasswordImportInlineHookOptions
+    {
+        /// <summary>
+        /// Gets or sets the new user's profile.
+        /// </summary>
+        /// <value>
+        /// The user's profile.
+        /// </value>
+        public UserProfile Profile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the new user should be activated immediately.
+        /// </summary>
+        /// <remarks>The default value is <c>true</c> (users will be activated immediately).</remarks>
+        /// <value>
+        /// Whether the new user should be activated immediately.
+        /// </value>
+        public bool Activate { get; set; } = true;
+    }
+}

--- a/src/Okta.Sdk/IUsersClient.cs
+++ b/src/Okta.Sdk/IUsersClient.cs
@@ -23,6 +23,15 @@ namespace Okta.Sdk
         Task<IUser> CreateUserAsync(CreateUserWithoutCredentialsOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Creates a new user in your Okta organization without a password or a recovery question/answer.
+        /// </summary>
+        /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-password-import-inline-hook">Create User with Password Import Inline Hook</a> in the documentation.</remarks>
+        /// <param name="options">The options for this Create User (with password import inline hook) request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The created user.</returns>
+        Task<IUser> CreateUserAsync(CreateUserWithPasswordImportInlineHookOptions options, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Creates a new user in your Okta organization with a recovery question/answer (but no password).
         /// </summary>
         /// <remarks>See <a href="https://developer.okta.com/docs/api/resources/users.html#create-user-with-recovery-question">Create User with Recovery Question</a> in the documentation.</remarks>

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -35,6 +35,26 @@ namespace Okta.Sdk
         }
 
         /// <inheritdoc/>
+        public Task<IUser> CreateUserAsync(CreateUserWithPasswordImportInlineHookOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var user = new CreateUserRequest
+            {
+                Profile = options.Profile,
+                Credentials = new UserCredentials
+                {
+                    Password = new PasswordCredential { Hook = new PasswordCredentialHook() { Type = "default" } },
+                },
+            };
+
+            return CreateUserAsync(user, options.Activate, cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public Task<IUser> CreateUserAsync(CreateUserWithRecoveryQuestionOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options == null)


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
Fixes #408 


## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [x] Implementation


## Current behavior
Lacks support for Password Import Inline Hook user creation.


## Desired behavior
Add support for Password Import Inline Hook user creation.

