### PR TITLE
Expose ITrustedOriginsClient from IOktaClient

### DIFF
--- a/src/Okta.Sdk/IOktaClient.cs
+++ b/src/Okta.Sdk/IOktaClient.cs
@@ -120,6 +120,14 @@ namespace Okta.Sdk
         ILinkedObjectsClient LinkedObjects { get; }
 
         /// <summary>
+        /// Gets an <see cref="ITrustedOriginsClient">TrustedOriginsClient</see> that interacts with the Okta Trusted Origins API.
+        /// </summary>
+        /// <value>
+        /// An <see cref="ITrustedOriginsClient">TrustedOriginsClient</see> that interacts with the Okta Trusted Origins API.
+        /// </value>
+        ITrustedOriginsClient TrustedOrigins { get; }
+
+        /// <summary>
         /// Gets a <see cref="IFeaturesClient">FeaturesClient</see> that interacts with the Okta Features API.
         /// </summary>
         /// <value>

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -196,6 +196,9 @@ namespace Okta.Sdk
         public ILinkedObjectsClient LinkedObjects => new LinkedObjectsClient(_dataStore, Configuration, _requestContext);
 
         /// <inheritdoc/>
+        public ITrustedOriginsClient TrustedOrigins => new TrustedOriginsClient(_dataStore, Configuration, _requestContext);
+
+        /// <inheritdoc/>
         public IFeaturesClient Features => new FeaturesClient(_dataStore, Configuration, _requestContext);
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Issue \#
#413 


## Code
- [ ] Unit test(s)
- [x] Implementation


## Current behavior
Access to the `ITrustedOriginsClient` is currently unavailable as `IOktaClient` does not expose this yet.


## Desired behavior
Have `ITrustedOriginsClient` exposed and available to use from `IOktaClient`.

