### PR TITLE
OKTA-316815 expose trusted origins client

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/TrustedOriginScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/TrustedOriginScenarios.cs
@@ -21,16 +21,8 @@ namespace Okta.Sdk.IntegrationTests
         public async Task ListOrigins()
         {
             var client = TestClient.Create();
-            var trustedOrigins = await client.TrustedOrigins.ListOrigins().ToListAsync();
-            trustedOrigins.Should().NotBeNull();
-            trustedOrigins.Count.Should().BeGreaterThan(0);
-        }
-
-        [Fact]
-        public async Task CreateOrigin()
-        {
-            var client = TestClient.Create();
-            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(CreateOrigin)}_Test";
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ListOrigins)}_{guid}_Test";
             var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
                 new TrustedOrigin
                 {
@@ -40,11 +32,48 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
+                        },
+                    },
+                });
+
+            try
+            {
+                var trustedOrigins = await client.TrustedOrigins.ListOrigins().ToListAsync();
+                trustedOrigins.Should().NotBeNull();
+                trustedOrigins.Count.Should().BeGreaterThan(0);
+                trustedOrigins.FirstOrDefault(to => to.Name.Equals(testTrustedOriginName)).Should().NotBeNull();
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+
+        [Fact]
+        public async Task CreateOrigin()
+        {
+            var client = TestClient.Create();
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(CreateOrigin)}_{guid}_Test";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = ScopeType.Cors,
+                        },
+                        new Scope()
+                        {
+                            Type = ScopeType.Redirect,
                         },
                     },
                 });
@@ -67,7 +96,8 @@ namespace Okta.Sdk.IntegrationTests
         public async Task DeleteOrigin()
         {
             var client = TestClient.Create();
-            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(DeleteOrigin)}_Test";
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(DeleteOrigin)}_{guid}_Test";
             var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
                 new TrustedOrigin
                 {
@@ -77,11 +107,11 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
                         },
                     },
                 });
@@ -98,23 +128,8 @@ namespace Okta.Sdk.IntegrationTests
         public async Task GetOrigin()
         {
             var client = TestClient.Create();
-            var trustedOrigins = await client.TrustedOrigins.ListOrigins().ToListAsync();
-            trustedOrigins.Should().NotBeNull();
-            trustedOrigins.Count.Should().BeGreaterThan(0);
-            var trustedOrigin = trustedOrigins.FirstOrDefault();
-            var retrievedTrustedOrigin = await client.TrustedOrigins.GetOriginAsync(trustedOrigin.Id);
-            retrievedTrustedOrigin.Should().NotBeNull();
-            retrievedTrustedOrigin.Id.Should().Be(trustedOrigin.Id);
-            retrievedTrustedOrigin.Name.Should().Be(trustedOrigin.Name);
-            retrievedTrustedOrigin.Origin.Should().Be(trustedOrigin.Origin);
-        }
-
-        [Fact]
-        public async Task UpdateOrigin()
-        {
-            var client = TestClient.Create();
-            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_Test";
-            var testUpdatedTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_Test_Updated";
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(GetOrigin)}_{guid}_Test";
             var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
                 new TrustedOrigin
                 {
@@ -124,11 +139,49 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
+                        },
+                    },
+                });
+            try
+            {
+                var retrievedTrustedOrigin = await client.TrustedOrigins.GetOriginAsync(createdTrustedOrigin.Id);
+                retrievedTrustedOrigin.Should().NotBeNull();
+                retrievedTrustedOrigin.Id.Should().Be(createdTrustedOrigin.Id);
+                retrievedTrustedOrigin.Name.Should().Be(createdTrustedOrigin.Name);
+                retrievedTrustedOrigin.Origin.Should().Be(createdTrustedOrigin.Origin);
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateOrigin()
+        {
+            var client = TestClient.Create();
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_{guid}_Test";
+            var testUpdatedTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_{guid}_Test_Updated";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = ScopeType.Cors,
+                        },
+                        new Scope()
+                        {
+                            Type = ScopeType.Redirect,
                         },
                     },
                 });
@@ -144,11 +197,11 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
                         },
                     },
                 };
@@ -170,7 +223,8 @@ namespace Okta.Sdk.IntegrationTests
         public async Task ActivateOrigin()
         {
             var client = TestClient.Create();
-            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_Test";
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_{guid}_Test";
             var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
                 new TrustedOrigin
                 {
@@ -180,11 +234,11 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
                         },
                     },
                 });
@@ -207,7 +261,8 @@ namespace Okta.Sdk.IntegrationTests
         public async Task DeactivateOrigin()
         {
             var client = TestClient.Create();
-            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_Test";
+            var guid = Guid.NewGuid();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_{guid}_Test";
             var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
                 new TrustedOrigin
                 {
@@ -217,11 +272,11 @@ namespace Okta.Sdk.IntegrationTests
                     {
                         new Scope()
                         {
-                            Type = "CORS",
+                            Type = ScopeType.Cors,
                         },
                         new Scope()
                         {
-                            Type = "REDIRECT",
+                            Type = ScopeType.Redirect,
                         },
                     },
                 });

--- a/src/Okta.Sdk.IntegrationTests/TrustedOriginScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/TrustedOriginScenarios.cs
@@ -1,0 +1,241 @@
+﻿// <copyright file="TrustedOriginScenarios.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Okta.Sdk.IntegrationTests
+{
+    public class TrustedOriginScenarios
+    {
+        private static string dotnetSdkPrefix = "dotnetSdk";
+
+        [Fact]
+        public async Task ListOrigins()
+        {
+            var client = TestClient.Create();
+            var trustedOrigins = await client.TrustedOrigins.ListOrigins().ToListAsync();
+            trustedOrigins.Should().NotBeNull();
+            trustedOrigins.Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task CreateOrigin()
+        {
+            var client = TestClient.Create();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(CreateOrigin)}_Test";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                });
+
+            try
+            {
+                createdTrustedOrigin.Should().NotBeNull();
+                createdTrustedOrigin.Name.Should().Be(testTrustedOriginName);
+                createdTrustedOrigin.Scopes.Count.Should().Be(2);
+                createdTrustedOrigin.Scopes.FirstOrDefault(scope => scope.Type == ScopeType.Cors).Should().NotBeNull();
+                createdTrustedOrigin.Scopes.FirstOrDefault(scope => scope.Type == ScopeType.Redirect).Should().NotBeNull();
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteOrigin()
+        {
+            var client = TestClient.Create();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(DeleteOrigin)}_Test";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                });
+
+            var retrievedTrustedOrigin = await client.TrustedOrigins.GetOriginAsync(createdTrustedOrigin.Id);
+            retrievedTrustedOrigin.Should().NotBeNull();
+            await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+
+            var ex = await Assert.ThrowsAsync<OktaApiException>(() => client.TrustedOrigins.GetOriginAsync(createdTrustedOrigin.Id));
+            ex.StatusCode.Should().Be(404);
+        }
+
+        [Fact]
+        public async Task GetOrigin()
+        {
+            var client = TestClient.Create();
+            var trustedOrigins = await client.TrustedOrigins.ListOrigins().ToListAsync();
+            trustedOrigins.Should().NotBeNull();
+            trustedOrigins.Count.Should().BeGreaterThan(0);
+            var trustedOrigin = trustedOrigins.FirstOrDefault();
+            var retrievedTrustedOrigin = await client.TrustedOrigins.GetOriginAsync(trustedOrigin.Id);
+            retrievedTrustedOrigin.Should().NotBeNull();
+            retrievedTrustedOrigin.Id.Should().Be(trustedOrigin.Id);
+            retrievedTrustedOrigin.Name.Should().Be(trustedOrigin.Name);
+            retrievedTrustedOrigin.Origin.Should().Be(trustedOrigin.Origin);
+        }
+
+        [Fact]
+        public async Task UpdateOrigin()
+        {
+            var client = TestClient.Create();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_Test";
+            var testUpdatedTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(UpdateOrigin)}_Test_Updated";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                });
+
+            try
+            {
+                createdTrustedOrigin.Name.Should().Be(testTrustedOriginName);
+                var updatedTrustedOrigin = new TrustedOrigin
+                {
+                    Name = testUpdatedTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                };
+                var updatedTrustedOriginResponse = await client.TrustedOrigins.UpdateOriginAsync(updatedTrustedOrigin, createdTrustedOrigin.Id);
+                updatedTrustedOriginResponse.Id.Should().Be(createdTrustedOrigin.Id);
+                updatedTrustedOriginResponse.Name.Should().Be(testUpdatedTrustedOriginName);
+
+                var retrievedTrustedOriginResponse = await client.TrustedOrigins.GetOriginAsync(updatedTrustedOriginResponse.Id);
+                retrievedTrustedOriginResponse.Id.Should().Be(createdTrustedOrigin.Id);
+                retrievedTrustedOriginResponse.Name.Should().Be(testUpdatedTrustedOriginName);
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+
+        [Fact]
+        public async Task ActivateOrigin()
+        {
+            var client = TestClient.Create();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_Test";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                });
+
+            try
+            {
+                createdTrustedOrigin.Status.Should().Be("ACTIVE");
+                var deactivatedTrustedOrigin = await client.TrustedOrigins.DeactivateOriginAsync(createdTrustedOrigin.Id);
+                deactivatedTrustedOrigin.Status.Should().Be("INACTIVE");
+                var reactivatedTrustedOrigin = await client.TrustedOrigins.ActivateOriginAsync(createdTrustedOrigin.Id);
+                reactivatedTrustedOrigin.Status.Should().Be("ACTIVE");
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+
+        [Fact]
+        public async Task DeactivateOrigin()
+        {
+            var client = TestClient.Create();
+            var testTrustedOriginName = $"{dotnetSdkPrefix}_{nameof(ActivateOrigin)}_Test";
+            var createdTrustedOrigin = await client.TrustedOrigins.CreateOriginAsync(
+                new TrustedOrigin
+                {
+                    Name = testTrustedOriginName,
+                    Origin = "http://example.com",
+                    Scopes = new List<IScope>()
+                    {
+                        new Scope()
+                        {
+                            Type = "CORS",
+                        },
+                        new Scope()
+                        {
+                            Type = "REDIRECT",
+                        },
+                    },
+                });
+
+            try
+            {
+                createdTrustedOrigin.Status.Should().Be("ACTIVE");
+                var deactivatedTrustedOrigin = await client.TrustedOrigins.DeactivateOriginAsync(createdTrustedOrigin.Id);
+                deactivatedTrustedOrigin.Status.Should().Be("INACTIVE");
+            }
+            finally
+            {
+                await client.TrustedOrigins.DeleteOriginAsync(createdTrustedOrigin.Id);
+            }
+        }
+    }
+}

--- a/src/Okta.Sdk/IOktaClient.cs
+++ b/src/Okta.Sdk/IOktaClient.cs
@@ -120,6 +120,14 @@ namespace Okta.Sdk
         ILinkedObjectsClient LinkedObjects { get; }
 
         /// <summary>
+        /// Gets an <see cref="ITrustedOriginsClient">TrustedOriginsClient</see> that interacts with the Okta Trusted Origins API.
+        /// </summary>
+        /// <value>
+        /// An <see cref="ITrustedOriginsClient">TrustedOriginsClient</see> that interacts with the Okta Trusted Origins API.
+        /// </value>
+        ITrustedOriginsClient TrustedOrigins { get; }
+
+        /// <summary>
         /// Gets a <see cref="IFeaturesClient">FeaturesClient</see> that interacts with the Okta Features API.
         /// </summary>
         /// <value>

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -196,6 +196,9 @@ namespace Okta.Sdk
         public ILinkedObjectsClient LinkedObjects => new LinkedObjectsClient(_dataStore, Configuration, _requestContext);
 
         /// <inheritdoc/>
+        public ITrustedOriginsClient TrustedOrigins => new TrustedOriginsClient(_dataStore, Configuration, _requestContext);
+
+        /// <inheritdoc/>
         public IFeaturesClient Features => new FeaturesClient(_dataStore, Configuration, _requestContext);
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
This  change adds the TrustedOrigins client to the default OktaClient class definition.
[OKTA-316815](https://oktainc.atlassian.net/browse/OKTA-316815)

Closes #413 



