### PR TITLE
OKTA-317892: run test with retry to address flakiness

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -764,40 +763,37 @@ namespace Okta.Sdk.IntegrationTests
         [Fact]
         public async Task ForgotPasswordGenerateOneTimeToken()
         {
-            await RunTestWithRetry(nameof(ForgotPasswordGenerateOneTimeToken), async () =>
+            var client = TestClient.Create();
+            var guid = Guid.NewGuid();
+
+            var createdUser = await client.Users.CreateUserAsync(new CreateUserWithPasswordOptions
             {
-                var client = TestClient.Create();
-                var guid = Guid.NewGuid();
-
-                var createdUser = await client.Users.CreateUserAsync(new CreateUserWithPasswordOptions
+                Profile = new UserProfile
                 {
-                    Profile = new UserProfile
-                    {
-                        FirstName = "John",
-                        LastName = $"{nameof(ForgotPasswordGenerateOneTimeToken)}",
-                        Email = $"{nameof(ForgotPasswordGenerateOneTimeToken)}-dotnet-sdk-{guid}@example.com",
-                        Login = $"{nameof(ForgotPasswordGenerateOneTimeToken)}-dotnet-sdk-{guid}@example.com",
-                    },
-                    RecoveryQuestion = "Answer to life, the universe, & everything",
-                    RecoveryAnswer = "42 of course",
-                    Password = "Abcd1234",
-                    Activate = true,
-                });
-
-                Thread.Sleep(5000); // allow for user replication prior to read attempt
-
-                try
-                {
-                    var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
-                    forgotPasswordResponse.Should().NotBeNull();
-                    forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
-                }
-                finally
-                {
-                    await createdUser.DeactivateAsync();
-                    await createdUser.DeactivateOrDeleteAsync();
-                }
+                    FirstName = "John",
+                    LastName = $"{nameof(ForgotPasswordGenerateOneTimeToken)}",
+                    Email = $"{nameof(ForgotPasswordGenerateOneTimeToken)}-dotnet-sdk-{guid}@example.com",
+                    Login = $"{nameof(ForgotPasswordGenerateOneTimeToken)}-dotnet-sdk-{guid}@example.com",
+                },
+                RecoveryQuestion = "Answer to life, the universe, & everything",
+                RecoveryAnswer = "42 of course",
+                Password = "Abcd1234",
+                Activate = true,
             });
+
+            Thread.Sleep(5000); // allow for user replication prior to read attempt
+
+            try
+            {
+                var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
+                forgotPasswordResponse.Should().NotBeNull();
+                forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
+            }
+            finally
+            {
+                await createdUser.DeactivateAsync();
+                await createdUser.DeactivateOrDeleteAsync();
+            }
         }
 
         [Fact]
@@ -1087,26 +1083,6 @@ namespace Okta.Sdk.IntegrationTests
             {
                 await createdUser.DeactivateAsync();
                 await createdUser.DeactivateOrDeleteAsync();
-            }
-        }
-
-        private async Task RunTestWithRetry(string testName, Func<Task> testFunction, int retryCount = 2)
-        {
-            try
-            {
-                await testFunction();
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine($"Exception executing test: {testName}, retryCount = {retryCount}\r\n\t{ex.Message}");
-                if (retryCount > 0)
-                {
-                    await RunTestWithRetry(testName, testFunction, --retryCount);
-                }
-                else
-                {
-                    throw ex;
-                }
             }
         }
     }

--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -785,15 +785,9 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                await Polly.Policy
-                    .Handle<Exception>()
-                    .WaitAndRetryAsync(4, attemptNumber => TimeSpan.FromSeconds(Math.Pow(5, attemptNumber - 1)))
-                    .ExecuteAsync(async () =>
-                    {
-                        var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
-                        forgotPasswordResponse.Should().NotBeNull();
-                        forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
-                    });
+                var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
+                forgotPasswordResponse.Should().NotBeNull();
+                forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
             }
             finally
             {

--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -785,9 +785,15 @@ namespace Okta.Sdk.IntegrationTests
 
             try
             {
-                var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
-                forgotPasswordResponse.Should().NotBeNull();
-                forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
+                await Polly.Policy
+                    .Handle<Exception>()
+                    .WaitAndRetryAsync(4, attemptNumber => TimeSpan.FromSeconds(Math.Pow(5, attemptNumber - 1)))
+                    .ExecuteAsync(async () =>
+                    {
+                        var forgotPasswordResponse = await createdUser.ForgotPasswordGenerateOneTimeTokenAsync(false);
+                        forgotPasswordResponse.Should().NotBeNull();
+                        forgotPasswordResponse.ResetPasswordUrl.Should().NotBeNullOrEmpty();
+                    });
             }
             finally
             {

--- a/src/Okta.Sdk.IntegrationTests/xunit.runner.json
+++ b/src/Okta.Sdk.IntegrationTests/xunit.runner.json
@@ -1,5 +1,5 @@
 ﻿{
   "parallelizeAssembly": false,
   "parallelizeTestCollections": false,
-  "maxParallelThreads": 6
+  "maxParallelThreads": 1
 }


### PR DESCRIPTION
## Issue \#
~~Added minimal retry strategy to re-attempt flaky test 2 more times (in addition to the initial attempt, for a total of 3 tries).~~
Changed xunit config to use single thread.
[OKTA-317892](https://oktainc.atlassian.net/browse/OKTA-317892)


## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [ ] Implementation


## Current behavior
Test fails intermittently,


## Desired behavior
Test should always pass

