### PR TITLE
OKTA-317191 Implement - Create User with Imported Hashed Password

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -156,11 +156,11 @@ namespace Okta.Sdk.IntegrationTests
         }
 
         [Fact]
-        public async Task CreateUserWithImportedHashedPasswords()
+        public async Task CreateUserWithImportedHashedPassword()
         {
             var client = TestClient.Create();
             var guid = Guid.NewGuid();
-            var userLastName = nameof(CreateUserWithImportedHashedPasswords);
+            var userLastName = nameof(CreateUserWithImportedHashedPassword);
             var userMail = $"{userLastName.ToLower()}-{guid}@example.com";
 
             // Create a user

--- a/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/UserScenarios.cs
@@ -173,7 +173,7 @@ namespace Okta.Sdk.IntegrationTests
                     Email = userMail,
                     Login = userMail,
                 },
-                Hash = new PasswordCredentialHash
+                PasswordCredentialHash = new PasswordCredentialHash
                 {
                     Algorithm = PasswordCredentialHashAlgorithm.Bcrypt,
                     WorkerFactor = 10,

--- a/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
+++ b/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
@@ -26,7 +26,7 @@ namespace Okta.Sdk
         /// <value>
         /// The user's hashed password.
         /// </value>
-        public PasswordCredentialHash Hash { get; set; }
+        public PasswordCredentialHash PasswordCredentialHash { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the new user should be activated immediately.

--- a/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
+++ b/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="CreateUserWithImportedHashedPasswordOptions.cs" company="Okta, Inc">
+// Copyright (c) 2014 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.Sdk
+{
+    /// <summary>
+    /// Contains the options for creating a new <see cref="IUser">User</see> without a password or a recovery question/answer.
+    /// Used with <see cref="IUsersClient.CreateUserAsync(CreateUserWithImportedHashedPasswordOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-imported-hashed-password">Create User with Imported Hashed Password</a> in the documentation.</remarks>
+    public sealed class CreateUserWithImportedHashedPasswordOptions
+    {
+        /// <summary>
+        /// Gets or sets the new user's profile.
+        /// </summary>
+        /// <value>
+        /// The user's profile.
+        /// </value>
+        public UserProfile Profile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new user's hashed password
+        /// </summary>
+        /// <value>
+        /// The user's hashed password.
+        /// </value>
+        public PasswordCredentialHash Hash { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the new user should be activated immediately.
+        /// </summary>
+        /// <remarks>The default value is <c>true</c> (users will be activated immediately).</remarks>
+        /// <value>
+        /// Whether the new user should be activated immediately.
+        /// </value>
+        public bool Activate { get; set; } = true;
+    }
+}

--- a/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
+++ b/src/Okta.Sdk/CreateUserWithImportedHashedPasswordOptions.cs
@@ -6,7 +6,7 @@
 namespace Okta.Sdk
 {
     /// <summary>
-    /// Contains the options for creating a new <see cref="IUser">User</see> without a password or a recovery question/answer.
+    /// Contains the options for creating a new <see cref="IUser">User</see> with imported hashed password.
     /// Used with <see cref="IUsersClient.CreateUserAsync(CreateUserWithImportedHashedPasswordOptions, System.Threading.CancellationToken)"/>.
     /// </summary>
     /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-imported-hashed-password">Create User with Imported Hashed Password</a> in the documentation.</remarks>

--- a/src/Okta.Sdk/IUsersClient.cs
+++ b/src/Okta.Sdk/IUsersClient.cs
@@ -23,6 +23,15 @@ namespace Okta.Sdk
         Task<IUser> CreateUserAsync(CreateUserWithoutCredentialsOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Creates a new user in your Okta organization a user with a specified hashed password.
+        /// </summary>
+        /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-imported-hashed-password">Create User with Imported Hashed Password</a> in the documentation.</remarks>
+        /// <param name="options">The options for this Create User (with a specified hashed password) request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The created user.</returns>
+        Task<IUser> CreateUserAsync(CreateUserWithImportedHashedPasswordOptions options, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Creates a new user in your Okta organization specifying that a Password Inline Hook should be used to handle password verification..
         /// </summary>
         /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-password-import-inline-hook">Create User with Password Import Inline Hook</a> in the documentation.</remarks>

--- a/src/Okta.Sdk/IUsersClient.cs
+++ b/src/Okta.Sdk/IUsersClient.cs
@@ -23,7 +23,7 @@ namespace Okta.Sdk
         Task<IUser> CreateUserAsync(CreateUserWithoutCredentialsOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Creates a new user in your Okta organization a user with a specified hashed password.
+        /// Creates a new user in your Okta organization with the specified hashed password.
         /// </summary>
         /// <remarks>See <a href="https://developer.okta.com/docs/reference/api/users/#create-user-with-imported-hashed-password">Create User with Imported Hashed Password</a> in the documentation.</remarks>
         /// <param name="options">The options for this Create User (with a specified hashed password) request.</param>

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -49,7 +49,7 @@ namespace Okta.Sdk
                 {
                     Password = new PasswordCredential
                     {
-                        Hash = options.Hash,
+                        Hash = options.PasswordCredentialHash,
                     },
                 },
             };

--- a/src/Okta.Sdk/UsersClient.cs
+++ b/src/Okta.Sdk/UsersClient.cs
@@ -35,6 +35,29 @@ namespace Okta.Sdk
         }
 
         /// <inheritdoc/>
+        public Task<IUser> CreateUserAsync(CreateUserWithImportedHashedPasswordOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var user = new CreateUserRequest
+            {
+                Profile = options.Profile,
+                Credentials = new UserCredentials
+                {
+                    Password = new PasswordCredential
+                    {
+                        Hash = options.Hash,
+                    },
+                },
+            };
+
+            return CreateUserAsync(user, options.Activate, cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public Task<IUser> CreateUserAsync(CreateUserWithPasswordImportInlineHookOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options == null)


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
https://oktainc.atlassian.net/browse/OKTA-317191

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->


## Desired behavior
<!-- Describe what the desired behavior is. -->
Implemented CreateUserAsync with CreateUserWithImportedHashedPasswordOptions options

## Additional Context
<!-- Describe the motivation or the concrete use case. -->
https://github.com/okta/okta-sdk-dotnet/issues/402
