### PR TITLE
Support systems with no HOME env var

### DIFF
--- a/src/Okta.Sdk/Internal/HomePath.cs
+++ b/src/Okta.Sdk/Internal/HomePath.cs
@@ -72,19 +72,27 @@ namespace Okta.Sdk.Internal
         /// <returns>true if home path was resolved; otherwise, false.</returns>
         public static bool TryGetHomePath(out string homePath)
         {
+            homePath = string.Empty;
+            try
+            {
 #if NET45
             homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 #else
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                homePath = Environment.GetEnvironmentVariable("USERPROFILE") ??
-                           Path.Combine(Environment.GetEnvironmentVariable("HOMEDRIVE"), Environment.GetEnvironmentVariable("HOMEPATH"));
-            }
-            else
-            {
-                homePath = Environment.GetEnvironmentVariable("HOME");
-            }
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    homePath = Environment.GetEnvironmentVariable("USERPROFILE") ??
+                               Path.Combine(Environment.GetEnvironmentVariable("HOMEDRIVE"), Environment.GetEnvironmentVariable("HOMEPATH"));
+                }
+                else
+                {
+                    homePath = Environment.GetEnvironmentVariable("HOME");
+                }
 #endif
+            }
+            catch
+            {
+                // Ignore
+            }
 
             return !string.IsNullOrEmpty(homePath);
         }

--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -129,13 +129,23 @@ namespace Okta.Sdk
         {
             string configurationFileRoot = Directory.GetCurrentDirectory();
 
-            var homeOktaYamlLocation = HomePath.Resolve("~", ".okta", "okta.yaml");
 
             var applicationAppSettingsLocation = Path.Combine(configurationFileRoot ?? string.Empty, "appsettings.json");
             var applicationOktaYamlLocation = Path.Combine(configurationFileRoot ?? string.Empty, "okta.yaml");
 
-            var configBuilder = new ConfigurationBuilder()
-                .AddYamlFile(homeOktaYamlLocation, optional: true)
+            var configBuilder = new ConfigurationBuilder();
+
+            try
+            {
+                var homeOktaYamlLocation = HomePath.Resolve("~", ".okta", "okta.yaml");
+                configBuilder.AddYamlFile(homeOktaYamlLocation, optional: true);
+            }
+            catch
+            {
+                // ignore -- production and pipeline environments often don't have a HOME location
+            }
+
+            configBuilder
                 .AddJsonFile(applicationAppSettingsLocation, optional: true)
                 .AddYamlFile(applicationOktaYamlLocation, optional: true)
                 .AddEnvironmentVariables("okta", "_", root: "okta")


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->


## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s) -- behaviour relies on system environment
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
Okta Client can't be used on systems without a `HOME` environment variable (quite common for build pipelines and containerised hosting)

## Desired behavior
<!-- Describe what the desired behavior is. -->
Okta client will now handle the lack of `HOME` environment variable.

## Additional Context
<!-- Describe the motivation or the concrete use case. -->
It is common good practise to remove as much user-account support from production environments as possible.
This change supports use in more locked-down hosting.
