### PR TITLE
OKTA-324986 .NET Management SDK > New IApplication.Profile doesn't sa…

### DIFF
--- a/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTests/ApplicationScenarios.cs
@@ -1840,15 +1840,14 @@ namespace Okta.Sdk.IntegrationTests
             };
 
             var newApp = await oktaClient.Applications.CreateApplicationAsync(appCreateOptions);
-
-            var whitelist = newApp.Profile.GetArrayProperty<string>("whitelist");
-            whitelist.Add("test");
+            var somelist = newApp.Profile.GetArrayProperty<string>("somelist");
+            somelist.Add("test");
 
             try
             {
                 await oktaClient.Applications.UpdateApplicationAsync(newApp, newApp.Id);
                 var persistedApp = await oktaClient.Applications.GetApplicationAsync(newApp.Id);
-                var listProperty = persistedApp.Profile.GetArrayProperty<string>("whitelist");
+                var listProperty = persistedApp.Profile.GetArrayProperty<string>("somelist");
                 listProperty.Should().HaveCount(1);
                 listProperty.First().Should().Be("test");
             }

--- a/src/Okta.Sdk/Resource.cs
+++ b/src/Okta.Sdk/Resource.cs
@@ -314,7 +314,13 @@ namespace Okta.Sdk
         private T GetResourcePropertyInternal<T>(string key)
         {
             var nestedData = GetPropertyOrNull(key) as IDictionary<string, object>;
-            return _resourceFactory.CreateFromExistingData<T>(nestedData);
+            var resourceProperty = _resourceFactory.CreateFromExistingData<T>(nestedData);
+            if (nestedData == null)
+            {
+                SetProperty(key, resourceProperty);
+            }
+
+            return resourceProperty;
         }
     }
 }


### PR DESCRIPTION
…ve when empty

<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
Fix #319 
https://oktainc.atlassian.net/browse/OKTA-324986

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
When Resource property is not present in Resource's inner dictionary, getter creates and returns a new object but doesn't persist it.
So after this code is executed created reference is lost and App Profile is still empty:
```csharp
    var whitelist = newApp.Profile.GetArrayProperty<string>("whitelist");
    whitelist.Add("test");
```
 
## Desired behavior
<!-- Describe what the desired behavior is. -->
Created reference will be saved in inner dictionary, like it is done for collections in this function: `GetPropertyOrEmptyCollection`

## Additional Context
<!-- Describe the motivation or the concrete use case. -->

