### PR TITLE
OKTA-337528 .NET Sdk Update readme with warning...

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ await vader.DeactivateOrDeleteAsync();
 ### List a User's Groups
 
 ``` csharp
-// Find the desired user
-var user = await client.Users.FirstOrDefaultAsync(x => x.Profile.Email == "darth.vader@imperial-senate.gov");
+// Retrieve the desired user
+var user = await client.Users.GetUserAsync("darth.vader@imperial-senate.gov");
 
 // get the user's groups
 var groups = await user.Groups.ToListAsync();
@@ -247,8 +247,8 @@ await client.Groups.CreateGroupAsync(new CreateGroupOptions()
 
 ### Add a User to a Group
 ``` csharp
-// Find the desired user
-var user = await client.Users.FirstOrDefaultAsync(x => x.Profile.Email == "darth.vader@imperial-senate.gov");
+// Retrieve the desired user
+var user = await client.Users.GetUserAsync("darth.vader@imperial-senate.gov");
 
 // find the desired group
 var group = await client.Groups.FirstOrDefaultAsync(x => x.Profile.Name == "Stormtroopers");
@@ -272,8 +272,8 @@ var factors = await user.ListFactors().ToListAsync();
 
 ### Enroll a User in a new Factor
 ``` csharp
-// Find the desired user
-var user = await client.Users.FirstOrDefaultAsync(x => x.Profile.Email == "darth.vader@imperial-senate.gov");
+// Retrieve the desired user
+var user = await client.Users.GetUserAsync("darth.vader@imperial-senate.gov");
 
 // Enroll in Okta SMS factor
 await user.AddFactorAsync(new AddSmsFactorOptions
@@ -300,8 +300,8 @@ await client.UserFactors.ActivateFactorAsync(activateFactorRequest, user.Id, sms
 
 ### Verify a Factor
 ``` csharp
-// Find the desired user
-var user = await client.Users.FirstOrDefaultAsync(x => x.Profile.Email == "darth.vader@imperial-senate.gov");
+// Retrieve the desired user
+var user = await client.Users.GetUserAsync("darth.vader@imperial-senate.gov");
 
 // Find the desired factor
 var smsFactor = await user.Factors.FirstOrDefaultAsync(x => x.FactorType == FactorType.Sms);


### PR DESCRIPTION
 about using await client.Users.FirstOrDefaultAsync(x => x... with many users

<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
Fix #442 
https://oktainc.atlassian.net/browse/OKTA-337528

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [ ] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->


## Desired behavior
<!-- Describe what the desired behavior is. -->


## Additional Context
<!-- Describe the motivation or the concrete use case. -->
In code samples `GetUserAsync` is suggested instead of `FirstOrDefaultAsync` to find a user
