### PR TITLE
Allow XML responses

### DIFF
--- a/src/Okta.Sdk/HttpResponse{T}.cs
+++ b/src/Okta.Sdk/HttpResponse{T}.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 
 namespace Okta.Sdk
 {
@@ -45,6 +46,11 @@ namespace Okta.Sdk
         /// The payload of the response.
         /// </value>
         public T Payload { get; set; }
+
+        /// <summary>
+        /// Gets the response's content type
+        /// </summary>
+        public MediaTypeHeaderValue ContentType { get; internal set; }
     }
 
 #pragma warning restore SA1649 // File name must match first type name

--- a/src/Okta.Sdk/Internal/DefaultDataStore.cs
+++ b/src/Okta.Sdk/Internal/DefaultDataStore.cs
@@ -185,6 +185,18 @@ namespace Okta.Sdk.Internal
             request.Uri = UrlFormatter.ApplyParametersToPath(request);
         }
 
+        private IDictionary<string, object> ExtractDataFromResponse(HttpResponse<string> response)
+        {
+            if (string.Equals(response.ContentType.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
+            {
+                return _serializer.Deserialize(PayloadOrEmpty(response));
+            }
+            else
+            {
+                return new Dictionary<string, object> { { "_rawData", response.Payload } };
+            }
+        }
+
         /// <inheritdoc/>
         public async Task<HttpResponse<T>> GetAsync<T>(
             HttpRequest request,
@@ -198,7 +210,7 @@ namespace Okta.Sdk.Internal
 
             EnsureResponseSuccess(response);
 
-            var data = _serializer.Deserialize(PayloadOrEmpty(response));
+            var data = ExtractDataFromResponse(response);
             var resource = _resourceFactory.CreateNew<T>(data);
 
             return CreateResourceResponse(response, resource);

--- a/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk/Internal/DefaultRequestExecutor.cs
@@ -110,6 +110,7 @@ namespace Okta.Sdk.Internal
                 Headers = ExtractHeaders(response),
                 StatusCode = (int)response.StatusCode,
                 Payload = stringContent,
+                ContentType = response.Content.Headers.ContentType,
             };
         }
 


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->


## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
The SDK doesn't allow XML responses 

## Desired behavior
<!-- Describe what the desired behavior is. -->


## Additional Context
<!-- Describe the motivation or the concrete use case. -->

Example of working with an XML response:
```csharp
    var appMetadata = await client.Applications.AppSamlMetadataAsync(app.Id);
    var xmlString = appMetadata["_rawData"].ToString();

    XmlDocument doc = new XmlDocument();
    doc.LoadXml(xmlString);
//..................
```