### PR TITLE
change generated JWT expiry time to 50 minutes from 60 for time drift

### DIFF
--- a/src/Okta.Sdk/Internal/DefaultJwtGenerator.cs
+++ b/src/Okta.Sdk/Internal/DefaultJwtGenerator.cs
@@ -70,7 +70,7 @@ namespace Okta.Sdk.Internal
             try
             {
                 TimeSpan timeSpanIat = DateTime.UtcNow - new DateTime(1970, 1, 1);
-                TimeSpan timeSpanExp = DateTime.UtcNow.AddHours(1) - new DateTime(1970, 1, 1);
+		TimeSpan timeSpanExp = DateTime.UtcNow.AddMinutes(50) - new DateTime(1970, 1, 1);
 
                 var payload = new JwtPayload
                 {


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
Reference okta-sdk-java [PR #515](https://github.com/okta/okta-sdk-java/pull/515) and [OKTA-356323](https://oktainc.atlassian.net/browse/OKTA-356323) for the same issue in the java sdk.

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [ ] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
Currently the expiry time of a JWT is set for 60 minutes. Okta will reject any JWT whose expiry is further than 60 minutes in the future. If the Client machine has a slight time drift (ahead) of a number of seconds Okta will reject the /token request with
`(invalid_client (401, The client_assertion token has an expiration too far into the future.)`


## Desired behavior
<!-- Describe what the desired behavior is. -->
Allow for slight future time drift.

## Additional Context
<!-- Describe the motivation or the concrete use case. -->
A couple of clients periodically see `(invalid_client (401, The client_assertion token has an expiration too far into the future.)` when running management requests do to clock drift. Since Okta does not allow expiry further than 60 minutes, and the sdk sets the expiry for 60 minutes, a few second drift can cause the failures.

