### PR TITLE
OKTA-387100  .NET Mgmt SDK - Document how to set the "kid" value when creating the Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,33 @@ var client = new OktaClient(new OktaClientConfiguration
 });
 ```
 
+Key object for assigning to the PrivateKey can be created and initialized inline like in this example for RSA key:
+
+``` csharp
+var privateKey = new JsonWebKeyConfiguration
+{
+    P = "{{P}}",
+    Kty = "RSA",
+    Q = "{{Q}}",
+    D = "{{D}}",
+    E = "{{E}}",
+    Kid = "{{P}}",
+    Qi = "{{Qi}}"
+};
+
+var clientConfiguration = new OktaClientConfiguration
+{
+    OktaDomain = "https://{{yourOktaDomain}}",
+    AuthorizationMode = AuthorizationMode.PrivateKey,
+    ClientId = "{{clientId}}",
+    Scopes = new List<string> { "okta.users.read", "okta.apps.read" }, // Add all the scopes you need
+    PrivateKey = privateKey
+};
+
+var client = new OktaClient(clientConfiguration);
+```
+
+
 ## Usage guide
 
 These examples will help you understand how to use this library. You can also browse the full [API reference documentation][dotnetdocs].


### PR DESCRIPTION
Added example of initialization of RSA key for `OktaClientConfiguration`

Ticket: **OKTA-387100 .NET Mgmt SDK - Document how to set the "kid" value when creating the Client**
While our Management SDKs indicate how you can set up your YAML config to include the "kid" value associated with the private key you are using to instantiate your client (when using OAuth serice ap), https://github.com/okta/okta-sdk-dotnet#yaml-configuration, there is nothing in the documentation to explain how to do this inline (such as via the OktaClientConfiguration)

See existing README coverage here: https://github.com/okta/okta-sdk-dotnet#oauth-20
