### PR TITLE
OKTA-441966: add github workflow file (github action) to regenerate and test the latest @okta/openapi

### DIFF
--- a/.github/workflows/regenerate-and-test.yml
+++ b/.github/workflows/regenerate-and-test.yml
@@ -1,0 +1,35 @@
+name: Regenerate Okta.Sdk
+
+on: [push]
+
+jobs:
+  regenerate-sdk:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install @okta/openapi
+      working-directory: ./openapi
+      run: npm install -g @okta/openapi
+    
+    - name: Npm install
+      working-directory: ./openapi
+      run: npm install
+
+    - name: Run Unit Tests Before Sdk Regeneration
+      working-directory: ./src/Okta.Sdk.UnitTests
+      run: dotnet test
+
+    - name: Regenerate Okta.Sdk
+      working-directory: ./openapi
+      run: npm run generate
+
+    - name: Git Diff
+      run: git diff
+      
+    - name: Run Unit Tests After Sdk Regeneration
+      working-directory: ./src/Okta.Sdk.UnitTests
+      run: |
+        dotnet clean &&
+        dotnet test


### PR DESCRIPTION
- added `.github/workflows/regenerate-and-test.yml` which defines steps to regenerate and test the Sdk from the latest version of the `okta/openapi` spec: see example run here: https://github.com/okta/okta-sdk-dotnet/runs/4048205948?check_suite_focus=true