### PR TITLE
Obvious Fix - Pass HttpClient to DefaultOAuthTokenProvider()

### DIFF
--- a/src/Okta.Sdk/OktaClient.cs
+++ b/src/Okta.Sdk/OktaClient.cs
@@ -65,7 +65,7 @@ namespace Okta.Sdk
                                         Configuration.Proxy,
                                         logger);
 
-            var tokenProvider = GetTokenProvider(Configuration, logger, resourceFactory, oAuthTokenProvider);
+            var tokenProvider = GetTokenProvider(Configuration, logger, resourceFactory, oAuthTokenProvider, defaultHttpClient);
             var requestExecutor = new DefaultRequestExecutor(Configuration, defaultHttpClient, logger, retryStrategy, tokenProvider);
 
             _dataStore = new DefaultDataStore(
@@ -97,12 +97,12 @@ namespace Okta.Sdk
         {
         }
 
-        private IOAuthTokenProvider GetTokenProvider(OktaClientConfiguration configuration, ILogger logger, ResourceFactory resourceFactory, IOAuthTokenProvider customTokenProvider)
+        private IOAuthTokenProvider GetTokenProvider(OktaClientConfiguration configuration, ILogger logger, ResourceFactory resourceFactory, IOAuthTokenProvider customTokenProvider, HttpClient httpClient)
         {
             switch (configuration.AuthorizationMode)
             {
                 case AuthorizationMode.PrivateKey:
-                    return new DefaultOAuthTokenProvider(configuration, resourceFactory, logger: logger);
+                    return new DefaultOAuthTokenProvider(configuration, resourceFactory, logger: logger, httpClient: httpClient);
                 case AuthorizationMode.SSWS:
                     return NullOAuthTokenProvider.Instance;
                 case AuthorizationMode.BearerToken:


### PR DESCRIPTION
## Summary
Proxied HttpClient passed in OktaClient constructor was not being passed to DefaultOAuthTokenProvider() so it was failing due to proxy error.

Fixes #
N/A

## Type of PR
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
- [ ] My PR required test updates 

.NET Version: .NET 6
Os Version: Windows 10

## Signoff
- [ ] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I checked StyleCop warnings on my code

