### PR TITLE
OKTA-498007: regenerate sdk from open api spec v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `3.1.1`
 
+## 5.6.2
+
+### Bug Fixes
+
+- Add `search` parameter to `GroupsClient.ListGroups` 
+
 ## 5.6.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Running changelog of releases since `3.1.1`
 
 ### Bug Fixes
 
-- Add `search` parameter to `GroupsClient.ListGroups` 
+- Add `search` parameter to `GroupsClient.ListGroups` to align with [documentation](https://developer.okta.com/docs/reference/api/groups/#list-groups)
 
 ## 5.6.1
 

--- a/openapi/errata.js
+++ b/openapi/errata.js
@@ -350,7 +350,8 @@ const operationSkipList = [
   { id: 'uploadBrandThemeBackgroundImage', reason: 'Operation defined manually'},
   { id: 'uploadBrandThemeFavicon', reason: 'Operation defined manually'},
   { id: 'uploadBrandThemeLogo', reason: 'Operation defined manually'},
-  { id: 'updateOrgLogo', reason: 'Operation defined manually'}
+  { id: 'updateOrgLogo', reason: 'Operation defined manually'},
+  { id: 'listGroups', reason: 'Operation defined manually'}
 ];
 
 function shouldSkipOperation(operationId) {

--- a/openapi/package.json
+++ b/openapi/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/okta/oktasdk-sdk-dotnet#readme",
   "devDependencies": {
-    "@okta/openapi": "^2.12.0",
+    "@okta/openapi": "^2.13.0",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.21"
   }

--- a/src/Okta.Sdk/Generated/AuthenticatorProviderConfiguration.Generated.cs
+++ b/src/Okta.Sdk/Generated/AuthenticatorProviderConfiguration.Generated.cs
@@ -24,6 +24,13 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc/>
+        public string Host 
+        {
+            get => GetStringProperty("host");
+            set => this["host"] = value;
+        }
+        
+        /// <inheritdoc/>
         public string HostName 
         {
             get => GetStringProperty("hostName");
@@ -35,6 +42,20 @@ namespace Okta.Sdk
         {
             get => GetStringProperty("instanceId");
             set => this["instanceId"] = value;
+        }
+        
+        /// <inheritdoc/>
+        public string IntegrationKey 
+        {
+            get => GetStringProperty("integrationKey");
+            set => this["integrationKey"] = value;
+        }
+        
+        /// <inheritdoc/>
+        public string SecretKey 
+        {
+            get => GetStringProperty("secretKey");
+            set => this["secretKey"] = value;
         }
         
         /// <inheritdoc/>

--- a/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
@@ -29,24 +29,6 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null)
-            => GetCollectionClient<IGroup>(new HttpRequest
-            {
-                Uri = "/api/v1/groups",
-                Verb = HttpVerb.Get,
-                
-                QueryParameters = new Dictionary<string, object>()
-                {
-                    ["q"] = q,
-                    ["filter"] = filter,
-                    ["after"] = after,
-                    ["limit"] = limit,
-                    ["expand"] = expand,
-                    ["search"] = search,
-                },
-            });
-                    
-        /// <inheritdoc />
         public async Task<IGroup> CreateGroupAsync(IGroup group, CancellationToken cancellationToken = default(CancellationToken))
             => await PostAsync<Group>(new HttpRequest
             {

--- a/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/GroupsClient.Generated.cs
@@ -29,7 +29,7 @@ namespace Okta.Sdk
         }
         
         /// <inheritdoc />
-        public ICollectionClient<IGroup> ListGroups(string q = null, string search = null, string after = null, int? limit = 10000, string expand = null)
+        public ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null)
             => GetCollectionClient<IGroup>(new HttpRequest
             {
                 Uri = "/api/v1/groups",
@@ -38,10 +38,11 @@ namespace Okta.Sdk
                 QueryParameters = new Dictionary<string, object>()
                 {
                     ["q"] = q,
-                    ["search"] = search,
+                    ["filter"] = filter,
                     ["after"] = after,
                     ["limit"] = limit,
                     ["expand"] = expand,
+                    ["search"] = search,
                 },
             });
                     

--- a/src/Okta.Sdk/Generated/IAuthenticatorProviderConfiguration.Generated.cs
+++ b/src/Okta.Sdk/Generated/IAuthenticatorProviderConfiguration.Generated.cs
@@ -17,9 +17,15 @@ namespace Okta.Sdk
     {
         int? AuthPort { get; set; }
 
+        string Host { get; set; }
+
         string HostName { get; set; }
 
         string InstanceId { get; set; }
+
+        string IntegrationKey { get; set; }
+
+        string SecretKey { get; set; }
 
         string SharedSecret { get; set; }
 

--- a/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
@@ -16,18 +16,6 @@ namespace Okta.Sdk
     public partial interface IGroupsClient
     {
         /// <summary>
-        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
-        /// </summary>
-        /// <param name="q">Searches the name property of groups for matching value</param>
-        /// <param name="filter">Filter expression for groups</param>
-        /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
-        /// <param name="limit">Specifies the number of group results in a page</param>
-        /// <param name="expand">If specified, it causes additional metadata to be included in the response.</param>
-        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
-        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null);
-
-        /// <summary>
         /// Adds a new group with `OKTA_GROUP` type to your organization.
         /// </summary>
         /// <param name="group">The <see cref="IGroup"/> resource.</param>

--- a/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
+++ b/src/Okta.Sdk/Generated/IGroupsClient.Generated.cs
@@ -19,12 +19,13 @@ namespace Okta.Sdk
         /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
         /// </summary>
         /// <param name="q">Searches the name property of groups for matching value</param>
-        /// <param name="search">Filter expression for groups</param>
+        /// <param name="filter">Filter expression for groups</param>
         /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
         /// <param name="limit">Specifies the number of group results in a page</param>
         /// <param name="expand">If specified, it causes additional metadata to be included in the response.</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
         /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
-        ICollectionClient<IGroup> ListGroups(string q = null, string search = null, string after = null, int? limit = 10000, string expand = null);
+        ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null);
 
         /// <summary>
         /// Adds a new group with `OKTA_GROUP` type to your organization.

--- a/src/Okta.Sdk/GroupsClient.cs
+++ b/src/Okta.Sdk/GroupsClient.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,5 +36,58 @@ namespace Okta.Sdk
 
         /// <inheritdoc/>
         public IAsyncEnumerator<IGroup> GetAsyncEnumerator(CancellationToken cancellationToken = default) => ListGroups().GetAsyncEnumerator(cancellationToken);
+
+        /// <inheritdoc />
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        public ICollectionClient<IGroup> ListGroups(string q)
+        {
+            return ListGroups(q, null, null, null, null, null);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        public ICollectionClient<IGroup> ListGroups(string q, string search)
+        {
+            return ListGroups(q, null, null, null, null, search);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        public ICollectionClient<IGroup> ListGroups(string q, string search, string after)
+        {
+            return ListGroups(q, search, after, null, null, null);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        public ICollectionClient<IGroup> ListGroups(string q, string search, string after, int? limit)
+        {
+            return ListGroups(q, search, after, limit, null, null);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        public ICollectionClient<IGroup> ListGroups(string q, string search, string after, int? limit, string expand)
+        {
+            return ListGroups(q, search, after, limit, expand, null);
+        }
+
+        /// <inheritdoc />
+        public ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null)
+            => GetCollectionClient<IGroup>(new HttpRequest
+            {
+                Uri = "/api/v1/groups",
+                Verb = HttpVerb.Get,
+
+                QueryParameters = new Dictionary<string, object>()
+                {
+                    ["q"] = q,
+                    ["filter"] = filter,
+                    ["after"] = after,
+                    ["limit"] = limit,
+                    ["expand"] = expand,
+                    ["search"] = search,
+                },
+            });
     }
 }

--- a/src/Okta.Sdk/IGroupsClient.cs
+++ b/src/Okta.Sdk/IGroupsClient.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,5 +28,66 @@ namespace Okta.Sdk
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteGroupRuleAsync(string ruleId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        ICollectionClient<IGroup> ListGroups(string q);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        ICollectionClient<IGroup> ListGroups(string q, string search);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
+        /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        ICollectionClient<IGroup> ListGroups(string q, string search, string after);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
+        /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
+        /// <param name="limit">Specifies the number of group results in a page</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        ICollectionClient<IGroup> ListGroups(string q, string search, string after, int? limit);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
+        /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
+        /// <param name="limit">Specifies the number of group results in a page</param>
+        /// <param name="expand">If specified, it causes additional metadata to be included in the response.</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        [Obsolete("Use ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null) instead")]
+        ICollectionClient<IGroup> ListGroups(string q, string search, string after, int? limit, string expand);
+
+        /// <summary>
+        /// Enumerates groups in your organization with pagination. A subset of groups can be returned that match a supported filter expression or query.
+        /// </summary>
+        /// <param name="q">Searches the name property of groups for matching value</param>
+        /// <param name="filter">Filter expression for groups</param>
+        /// <param name="after">Specifies the pagination cursor for the next page of groups</param>
+        /// <param name="limit">Specifies the number of group results in a page</param>
+        /// <param name="expand">If specified, it causes additional metadata to be included in the response.</param>
+        /// <param name="search">Searches for groups with a supported filtering expression for all attributes except for _embedded, _links, and objectClass</param>
+        /// <returns>A collection of <see cref="IGroup"/> that can be enumerated asynchronously.</returns>
+        ICollectionClient<IGroup> ListGroups(string q = null, string filter = null, string after = null, int? limit = 10000, string expand = null, string search = null);
     }
 }

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
-    <Version>5.6.1</Version>
+    <Version>5.6.2</Version>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR constitutes the result of updating the okta open api spec to v2.13.0 and running `npm run generate`