### PR TITLE
Allow additionalProperties by default, and test User Profile.

### DIFF
--- a/openapi3/config.json
+++ b/openapi3/config.json
@@ -16,11 +16,13 @@
     "gitHost": "github.com",
     "gitUserId" : "okta",
     "gitRepoId" : "okta-sdk-dotnet", 
+    "additionalProperties": {
+      "disallowAdditionalPropertiesIfNotPresent": false  
+    },
     "globalProperties": {
         "apiTests": false,
         "modelTests": false,
         "isOAuth": false
-        
     },
     "files": {
         "WebLink.mustache":{

--- a/openapi3/management-noEnums.yaml
+++ b/openapi3/management-noEnums.yaml
@@ -20747,7 +20747,6 @@ components:
           type: string
           maxLength: 50
           nullable: true
-      x-okta-extensible: true
     UserSchema:
       type: object
       properties:

--- a/openapi3/templates/modelGeneric.mustache
+++ b/openapi3/templates/modelGeneric.mustache
@@ -108,7 +108,7 @@
         public {{classname}}() { }
         {{/isAdditionalPropertiesTrue}}
         {{#isAdditionalPropertiesTrue}}
-        protected {{classname}}()
+        public {{classname}}()
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "6.0.1"
+  }
+}

--- a/src/Okta.Sdk.IntegrationTest/UserScenarios.cs
+++ b/src/Okta.Sdk.IntegrationTest/UserScenarios.cs
@@ -303,6 +303,8 @@ namespace Okta.Sdk.IntegrationTest
             {
                 // Update profile
                 createdUser.Profile.NickName = nickName;
+                createdUser.Profile.AdditionalProperties = new Dictionary<string, object>();
+                createdUser.Profile.AdditionalProperties["homeworld"] = "Planet Earth";
                 var updateUserRequest = new UpdateUserRequest
                 {
                     Profile = createdUser.Profile
@@ -310,9 +312,11 @@ namespace Okta.Sdk.IntegrationTest
 
                 var updatedUser = await _userApi.UpdateUserAsync(createdUser.Id, updateUserRequest);
                 updatedUser.Profile.NickName.Should().Be(nickName);
+                updatedUser.Profile.AdditionalProperties["homeworld"].Should().Be("Planet Earth");
 
                 var retrievedUser = await _userApi.GetUserAsync(createdUser.Id);
                 retrievedUser.Profile.NickName.Should().Be(nickName);
+                retrievedUser.Profile.AdditionalProperties["homeworld"].Should().Be("Planet Earth");
             }
             finally
             {

--- a/src/Okta.Sdk/Model/APNSConfiguration.cs
+++ b/src/Okta.Sdk/Model/APNSConfiguration.cs
@@ -62,6 +62,12 @@ namespace Okta.Sdk.Model
         public string TokenSigningKey { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -73,6 +79,7 @@ namespace Okta.Sdk.Model
             sb.Append("  KeyId: ").Append(KeyId).Append("\n");
             sb.Append("  TeamId: ").Append(TeamId).Append("\n");
             sb.Append("  TokenSigningKey: ").Append(TokenSigningKey).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -127,7 +134,8 @@ namespace Okta.Sdk.Model
                     this.TokenSigningKey == input.TokenSigningKey ||
                     (this.TokenSigningKey != null &&
                     this.TokenSigningKey.Equals(input.TokenSigningKey))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -154,6 +162,10 @@ namespace Okta.Sdk.Model
                 if (this.TokenSigningKey != null)
                 {
                     hashCode = (hashCode * 59) + this.TokenSigningKey.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/APNSPushProvider.cs
+++ b/src/Okta.Sdk/Model/APNSPushProvider.cs
@@ -44,6 +44,12 @@ namespace Okta.Sdk.Model
         public APNSConfiguration _Configuration { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -53,6 +59,7 @@ namespace Okta.Sdk.Model
             sb.Append("class APNSPushProvider {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  _Configuration: ").Append(_Configuration).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -92,7 +99,8 @@ namespace Okta.Sdk.Model
                     this._Configuration == input._Configuration ||
                     (this._Configuration != null &&
                     this._Configuration.Equals(input._Configuration))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -107,6 +115,10 @@ namespace Okta.Sdk.Model
                 if (this._Configuration != null)
                 {
                     hashCode = (hashCode * 59) + this._Configuration.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicy.cs
+++ b/src/Okta.Sdk/Model/AccessPolicy.cs
@@ -49,6 +49,12 @@ namespace Okta.Sdk.Model
         public PolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -58,6 +64,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AccessPolicy {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -112,6 +120,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyConstraint.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyConstraint.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public List<string> Types { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Methods: ").Append(Methods).Append("\n");
             sb.Append("  ReauthenticateIn: ").Append(ReauthenticateIn).Append("\n");
             sb.Append("  Types: ").Append(Types).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                     this.Types != null &&
                     input.Types != null &&
                     this.Types.SequenceEqual(input.Types)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -136,6 +144,10 @@ namespace Okta.Sdk.Model
                 if (this.Types != null)
                 {
                     hashCode = (hashCode * 59) + this.Types.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyConstraints.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyConstraints.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public PossessionConstraint Possession { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AccessPolicyConstraints {\n");
             sb.Append("  Knowledge: ").Append(Knowledge).Append("\n");
             sb.Append("  Possession: ").Append(Possession).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Possession == input.Possession ||
                     (this.Possession != null &&
                     this.Possession.Equals(input.Possession))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Possession != null)
                 {
                     hashCode = (hashCode * 59) + this.Possession.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyRule.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyRule.cs
@@ -53,6 +53,12 @@ namespace Okta.Sdk.Model
         public AccessPolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Actions: ").Append(Actions).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyRuleActions.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public AccessPolicyRuleApplicationSignOn AppSignOn { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
             sb.Append("  AppSignOn: ").Append(AppSignOn).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -159,7 +166,8 @@ namespace Okta.Sdk.Model
                     this.AppSignOn == input.AppSignOn ||
                     (this.AppSignOn != null &&
                     this.AppSignOn.Equals(input.AppSignOn))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -198,6 +206,10 @@ namespace Okta.Sdk.Model
                 if (this.AppSignOn != null)
                 {
                     hashCode = (hashCode * 59) + this.AppSignOn.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyRuleApplicationSignOn.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyRuleApplicationSignOn.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public VerificationMethod VerificationMethod { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AccessPolicyRuleApplicationSignOn {\n");
             sb.Append("  Access: ").Append(Access).Append("\n");
             sb.Append("  VerificationMethod: ").Append(VerificationMethod).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.VerificationMethod == input.VerificationMethod ||
                     (this.VerificationMethod != null &&
                     this.VerificationMethod.Equals(input.VerificationMethod))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.VerificationMethod != null)
                 {
                     hashCode = (hashCode * 59) + this.VerificationMethod.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyRuleConditions.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyRuleConditions.cs
@@ -172,6 +172,12 @@ namespace Okta.Sdk.Model
         public UserTypeCondition UserType { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -202,6 +208,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
             sb.Append("  ElCondition: ").Append(ElCondition).Append("\n");
             sb.Append("  UserType: ").Append(UserType).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -351,7 +358,8 @@ namespace Okta.Sdk.Model
                     this.UserType == input.UserType ||
                     (this.UserType != null &&
                     this.UserType.Equals(input.UserType))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -454,6 +462,10 @@ namespace Okta.Sdk.Model
                 if (this.UserType != null)
                 {
                     hashCode = (hashCode * 59) + this.UserType.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AccessPolicyRuleCustomCondition.cs
+++ b/src/Okta.Sdk/Model/AccessPolicyRuleCustomCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Condition { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class AccessPolicyRuleCustomCondition {\n");
             sb.Append("  Condition: ").Append(Condition).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Condition == input.Condition ||
                     (this.Condition != null &&
                     this.Condition.Equals(input.Condition))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Condition != null)
                 {
                     hashCode = (hashCode * 59) + this.Condition.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AcsEndpoint.cs
+++ b/src/Okta.Sdk/Model/AcsEndpoint.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Url { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AcsEndpoint {\n");
             sb.Append("  Index: ").Append(Index).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ActivateFactorRequest.cs
+++ b/src/Okta.Sdk/Model/ActivateFactorRequest.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public string StateToken { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  PassCode: ").Append(PassCode).Append("\n");
             sb.Append("  RegistrationData: ").Append(RegistrationData).Append("\n");
             sb.Append("  StateToken: ").Append(StateToken).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -135,7 +142,8 @@ namespace Okta.Sdk.Model
                     this.StateToken == input.StateToken ||
                     (this.StateToken != null &&
                     this.StateToken.Equals(input.StateToken))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -166,6 +174,10 @@ namespace Okta.Sdk.Model
                 if (this.StateToken != null)
                 {
                     hashCode = (hashCode * 59) + this.StateToken.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Agent.cs
+++ b/src/Okta.Sdk/Model/Agent.cs
@@ -117,6 +117,12 @@ namespace Okta.Sdk.Model
         public HrefObject Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -136,6 +142,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UpdateStatus: ").Append(UpdateStatus).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -228,7 +235,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -281,6 +289,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AgentPool.cs
+++ b/src/Okta.Sdk/Model/AgentPool.cs
@@ -74,6 +74,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -86,6 +92,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  OperationalStatus: ").Append(OperationalStatus).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -177,6 +185,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AgentPoolUpdate.cs
+++ b/src/Okta.Sdk/Model/AgentPoolUpdate.cs
@@ -116,6 +116,12 @@ namespace Okta.Sdk.Model
         public HrefObject Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -135,6 +141,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  TargetVersion: ").Append(TargetVersion).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -227,7 +234,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -277,6 +285,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AgentPoolUpdateSetting.cs
+++ b/src/Okta.Sdk/Model/AgentPoolUpdateSetting.cs
@@ -86,6 +86,12 @@ namespace Okta.Sdk.Model
         public string ReleaseChannel { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -100,6 +106,7 @@ namespace Okta.Sdk.Model
             sb.Append("  PoolId: ").Append(PoolId).Append("\n");
             sb.Append("  PoolName: ").Append(PoolName).Append("\n");
             sb.Append("  ReleaseChannel: ").Append(ReleaseChannel).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -168,7 +175,8 @@ namespace Okta.Sdk.Model
                     this.ReleaseChannel == input.ReleaseChannel ||
                     (this.ReleaseChannel != null &&
                     this.ReleaseChannel.Equals(input.ReleaseChannel))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -204,6 +212,10 @@ namespace Okta.Sdk.Model
                 if (this.ReleaseChannel != null)
                 {
                     hashCode = (hashCode * 59) + this.ReleaseChannel.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApiToken.cs
+++ b/src/Okta.Sdk/Model/ApiToken.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="ApiToken" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public ApiToken() { }
+        public ApiToken()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets ClientName
@@ -134,6 +137,12 @@ namespace Okta.Sdk.Model
         public ApiTokenLink Link { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -150,6 +159,7 @@ namespace Okta.Sdk.Model
             sb.Append("  TokenWindow: ").Append(TokenWindow).Append("\n");
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Link: ").Append(Link).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -229,7 +239,8 @@ namespace Okta.Sdk.Model
                     this.Link == input.Link ||
                     (this.Link != null &&
                     this.Link.Equals(input.Link))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -276,6 +287,10 @@ namespace Okta.Sdk.Model
                 if (this.Link != null)
                 {
                     hashCode = (hashCode * 59) + this.Link.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApiTokenLink.cs
+++ b/src/Okta.Sdk/Model/ApiTokenLink.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public HrefObject Self { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ApiTokenLink {\n");
             sb.Append("  Self: ").Append(Self).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Self == input.Self ||
                     (this.Self != null &&
                     this.Self.Equals(input.Self))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Self != null)
                 {
                     hashCode = (hashCode * 59) + this.Self.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppAndInstanceConditionEvaluatorAppOrInstance.cs
+++ b/src/Okta.Sdk/Model/AppAndInstanceConditionEvaluatorAppOrInstance.cs
@@ -60,6 +60,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -70,6 +76,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -119,7 +126,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -142,6 +150,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppAndInstancePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/AppAndInstancePolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<AppAndInstanceConditionEvaluatorAppOrInstance> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AppAndInstancePolicyRuleCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppInstancePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/AppInstancePolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AppInstancePolicyRuleCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppLink.cs
+++ b/src/Okta.Sdk/Model/AppLink.cs
@@ -174,6 +174,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -191,6 +197,7 @@ namespace Okta.Sdk.Model
             sb.Append("  LinkUrl: ").Append(LinkUrl).Append("\n");
             sb.Append("  LogoUrl: ").Append(LogoUrl).Append("\n");
             sb.Append("  SortOrder: ").Append(SortOrder).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -272,7 +279,8 @@ namespace Okta.Sdk.Model
                 (
                     this.SortOrder == input.SortOrder ||
                     this.SortOrder.Equals(input.SortOrder)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -315,6 +323,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.LogoUrl.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.SortOrder.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/AppUser.cs
+++ b/src/Okta.Sdk/Model/AppUser.cs
@@ -198,6 +198,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -219,6 +225,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SyncState: ").Append(SyncState).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -326,7 +333,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -393,6 +401,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppUserCredentials.cs
+++ b/src/Okta.Sdk/Model/AppUserCredentials.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AppUserCredentials {\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AppUserPasswordCredential.cs
+++ b/src/Okta.Sdk/Model/AppUserPasswordCredential.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class AppUserPasswordCredential {\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Application.cs
+++ b/src/Okta.Sdk/Model/Application.cs
@@ -179,6 +179,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -199,6 +205,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Visibility: ").Append(Visibility).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -302,7 +309,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -365,6 +373,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationAccessibility.cs
+++ b/src/Okta.Sdk/Model/ApplicationAccessibility.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public bool SelfService { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ErrorRedirectUrl: ").Append(ErrorRedirectUrl).Append("\n");
             sb.Append("  LoginRedirectUrl: ").Append(LoginRedirectUrl).Append("\n");
             sb.Append("  SelfService: ").Append(SelfService).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -110,7 +117,8 @@ namespace Okta.Sdk.Model
                 (
                     this.SelfService == input.SelfService ||
                     this.SelfService.Equals(input.SelfService)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -131,6 +139,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.LoginRedirectUrl.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.SelfService.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/ApplicationCredentials.cs
+++ b/src/Okta.Sdk/Model/ApplicationCredentials.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public ApplicationCredentialsUsernameTemplate UserNameTemplate { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ApplicationCredentials {\n");
             sb.Append("  Signing: ").Append(Signing).Append("\n");
             sb.Append("  UserNameTemplate: ").Append(UserNameTemplate).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.UserNameTemplate == input.UserNameTemplate ||
                     (this.UserNameTemplate != null &&
                     this.UserNameTemplate.Equals(input.UserNameTemplate))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.UserNameTemplate != null)
                 {
                     hashCode = (hashCode * 59) + this.UserNameTemplate.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationCredentialsOAuthClient.cs
+++ b/src/Okta.Sdk/Model/ApplicationCredentialsOAuthClient.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string TokenEndpointAuthMethod { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ClientId: ").Append(ClientId).Append("\n");
             sb.Append("  ClientSecret: ").Append(ClientSecret).Append("\n");
             sb.Append("  TokenEndpointAuthMethod: ").Append(TokenEndpointAuthMethod).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,7 +129,8 @@ namespace Okta.Sdk.Model
                     this.TokenEndpointAuthMethod == input.TokenEndpointAuthMethod ||
                     (this.TokenEndpointAuthMethod != null &&
                     this.TokenEndpointAuthMethod.Equals(input.TokenEndpointAuthMethod))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.TokenEndpointAuthMethod != null)
                 {
                     hashCode = (hashCode * 59) + this.TokenEndpointAuthMethod.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationCredentialsSigning.cs
+++ b/src/Okta.Sdk/Model/ApplicationCredentialsSigning.cs
@@ -80,6 +80,12 @@ namespace Okta.Sdk.Model
         public string Use { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -92,6 +98,7 @@ namespace Okta.Sdk.Model
             sb.Append("  NextRotation: ").Append(NextRotation).Append("\n");
             sb.Append("  RotationMode: ").Append(RotationMode).Append("\n");
             sb.Append("  Use: ").Append(Use).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -151,7 +158,8 @@ namespace Okta.Sdk.Model
                     this.Use == input.Use ||
                     (this.Use != null &&
                     this.Use.Equals(input.Use))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Use != null)
                 {
                     hashCode = (hashCode * 59) + this.Use.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationCredentialsUsernameTemplate.cs
+++ b/src/Okta.Sdk/Model/ApplicationCredentialsUsernameTemplate.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Suffix: ").Append(Suffix).Append("\n");
             sb.Append("  Template: ").Append(Template).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationFeature.cs
+++ b/src/Okta.Sdk/Model/ApplicationFeature.cs
@@ -72,6 +72,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -84,6 +90,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -144,7 +151,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -175,6 +183,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationGroupAssignment.cs
+++ b/src/Okta.Sdk/Model/ApplicationGroupAssignment.cs
@@ -102,6 +102,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -115,6 +121,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Profile: ").Append(Profile).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -181,7 +188,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -213,6 +221,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationLayout.cs
+++ b/src/Okta.Sdk/Model/ApplicationLayout.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Rule: ").Append(Rule).Append("\n");
             sb.Append("  Scope: ").Append(Scope).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -149,7 +156,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -184,6 +192,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationLayoutRule.cs
+++ b/src/Okta.Sdk/Model/ApplicationLayoutRule.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public ApplicationLayoutRuleCondition Condition { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ApplicationLayoutRule {\n");
             sb.Append("  Effect: ").Append(Effect).Append("\n");
             sb.Append("  Condition: ").Append(Condition).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Condition == input.Condition ||
                     (this.Condition != null &&
                     this.Condition.Equals(input.Condition))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Condition != null)
                 {
                     hashCode = (hashCode * 59) + this.Condition.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationLayoutRuleCondition.cs
+++ b/src/Okta.Sdk/Model/ApplicationLayoutRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Scope { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ApplicationLayoutRuleCondition {\n");
             sb.Append("  Schema: ").Append(Schema).Append("\n");
             sb.Append("  Scope: ").Append(Scope).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Scope == input.Scope ||
                     (this.Scope != null &&
                     this.Scope.Equals(input.Scope))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Scope != null)
                 {
                     hashCode = (hashCode * 59) + this.Scope.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationLicensing.cs
+++ b/src/Okta.Sdk/Model/ApplicationLicensing.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public int SeatCount { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ApplicationLicensing {\n");
             sb.Append("  SeatCount: ").Append(SeatCount).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -86,7 +93,8 @@ namespace Okta.Sdk.Model
                 (
                     this.SeatCount == input.SeatCount ||
                     this.SeatCount.Equals(input.SeatCount)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -99,6 +107,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.SeatCount.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/ApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/ApplicationSettings.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public ApplicationSettingsNotifications Notifications { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  InlineHookId: ").Append(InlineHookId).Append("\n");
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -134,7 +141,8 @@ namespace Okta.Sdk.Model
                     this.Notifications == input.Notifications ||
                     (this.Notifications != null &&
                     this.Notifications.Equals(input.Notifications))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -162,6 +170,10 @@ namespace Okta.Sdk.Model
                 if (this.Notifications != null)
                 {
                     hashCode = (hashCode * 59) + this.Notifications.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationSettingsNotes.cs
+++ b/src/Okta.Sdk/Model/ApplicationSettingsNotes.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Enduser { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ApplicationSettingsNotes {\n");
             sb.Append("  Admin: ").Append(Admin).Append("\n");
             sb.Append("  Enduser: ").Append(Enduser).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Enduser == input.Enduser ||
                     (this.Enduser != null &&
                     this.Enduser.Equals(input.Enduser))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Enduser != null)
                 {
                     hashCode = (hashCode * 59) + this.Enduser.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationSettingsNotifications.cs
+++ b/src/Okta.Sdk/Model/ApplicationSettingsNotifications.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public ApplicationSettingsNotificationsVpn Vpn { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ApplicationSettingsNotifications {\n");
             sb.Append("  Vpn: ").Append(Vpn).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Vpn == input.Vpn ||
                     (this.Vpn != null &&
                     this.Vpn.Equals(input.Vpn))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Vpn != null)
                 {
                     hashCode = (hashCode * 59) + this.Vpn.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationSettingsNotificationsVpn.cs
+++ b/src/Okta.Sdk/Model/ApplicationSettingsNotificationsVpn.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public ApplicationSettingsNotificationsVpnNetwork Network { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  HelpUrl: ").Append(HelpUrl).Append("\n");
             sb.Append("  Message: ").Append(Message).Append("\n");
             sb.Append("  Network: ").Append(Network).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Network == input.Network ||
                     (this.Network != null &&
                     this.Network.Equals(input.Network))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Network != null)
                 {
                     hashCode = (hashCode * 59) + this.Network.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationSettingsNotificationsVpnNetwork.cs
+++ b/src/Okta.Sdk/Model/ApplicationSettingsNotificationsVpnNetwork.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Connection: ").Append(Connection).Append("\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -136,6 +144,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationVisibility.cs
+++ b/src/Okta.Sdk/Model/ApplicationVisibility.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public ApplicationVisibilityHide Hide { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  AutoLaunch: ").Append(AutoLaunch).Append("\n");
             sb.Append("  AutoSubmitToolbar: ").Append(AutoSubmitToolbar).Append("\n");
             sb.Append("  Hide: ").Append(Hide).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,7 +129,8 @@ namespace Okta.Sdk.Model
                     this.Hide == input.Hide ||
                     (this.Hide != null &&
                     this.Hide.Equals(input.Hide))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -143,6 +151,10 @@ namespace Okta.Sdk.Model
                 if (this.Hide != null)
                 {
                     hashCode = (hashCode * 59) + this.Hide.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ApplicationVisibilityHide.cs
+++ b/src/Okta.Sdk/Model/ApplicationVisibilityHide.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public bool Web { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ApplicationVisibilityHide {\n");
             sb.Append("  IOS: ").Append(IOS).Append("\n");
             sb.Append("  Web: ").Append(Web).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Web == input.Web ||
                     this.Web.Equals(input.Web)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.IOS.GetHashCode();
                 hashCode = (hashCode * 59) + this.Web.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/AssignRoleRequest.cs
+++ b/src/Okta.Sdk/Model/AssignRoleRequest.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class AssignRoleRequest {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthenticationProvider.cs
+++ b/src/Okta.Sdk/Model/AuthenticationProvider.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AuthenticationProvider {\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Authenticator.cs
+++ b/src/Okta.Sdk/Model/Authenticator.cs
@@ -126,6 +126,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -143,6 +149,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -228,7 +235,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -279,6 +287,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthenticatorProvider.cs
+++ b/src/Okta.Sdk/Model/AuthenticatorProvider.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AuthenticatorProvider {\n");
             sb.Append("  _Configuration: ").Append(_Configuration).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthenticatorProviderConfiguration.cs
+++ b/src/Okta.Sdk/Model/AuthenticatorProviderConfiguration.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public AuthenticatorProviderConfigurationUserNameTemplate UserNameTemplate { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  InstanceId: ").Append(InstanceId).Append("\n");
             sb.Append("  SharedSecret: ").Append(SharedSecret).Append("\n");
             sb.Append("  UserNameTemplate: ").Append(UserNameTemplate).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -134,7 +141,8 @@ namespace Okta.Sdk.Model
                     this.UserNameTemplate == input.UserNameTemplate ||
                     (this.UserNameTemplate != null &&
                     this.UserNameTemplate.Equals(input.UserNameTemplate))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -162,6 +170,10 @@ namespace Okta.Sdk.Model
                 if (this.UserNameTemplate != null)
                 {
                     hashCode = (hashCode * 59) + this.UserNameTemplate.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthenticatorProviderConfigurationUserNameTemplate.cs
+++ b/src/Okta.Sdk/Model/AuthenticatorProviderConfigurationUserNameTemplate.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Template { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class AuthenticatorProviderConfigurationUserNameTemplate {\n");
             sb.Append("  Template: ").Append(Template).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Template == input.Template ||
                     (this.Template != null &&
                     this.Template.Equals(input.Template))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Template != null)
                 {
                     hashCode = (hashCode * 59) + this.Template.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthenticatorSettings.cs
+++ b/src/Okta.Sdk/Model/AuthenticatorSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string UserVerification { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Compliance: ").Append(Compliance).Append("\n");
             sb.Append("  TokenLifetimeInMinutes: ").Append(TokenLifetimeInMinutes).Append("\n");
             sb.Append("  UserVerification: ").Append(UserVerification).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.UserVerification == input.UserVerification ||
                     (this.UserVerification != null &&
                     this.UserVerification.Equals(input.UserVerification))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.UserVerification != null)
                 {
                     hashCode = (hashCode * 59) + this.UserVerification.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServer.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServer.cs
@@ -132,6 +132,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -150,6 +156,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -241,7 +248,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -296,6 +304,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerCredentials.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerCredentials.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public AuthorizationServerCredentialsSigningConfig Signing { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class AuthorizationServerCredentials {\n");
             sb.Append("  Signing: ").Append(Signing).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Signing == input.Signing ||
                     (this.Signing != null &&
                     this.Signing.Equals(input.Signing))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Signing != null)
                 {
                     hashCode = (hashCode * 59) + this.Signing.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerCredentialsSigningConfig.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerCredentialsSigningConfig.cs
@@ -80,6 +80,12 @@ namespace Okta.Sdk.Model
         public string Use { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -92,6 +98,7 @@ namespace Okta.Sdk.Model
             sb.Append("  NextRotation: ").Append(NextRotation).Append("\n");
             sb.Append("  RotationMode: ").Append(RotationMode).Append("\n");
             sb.Append("  Use: ").Append(Use).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -151,7 +158,8 @@ namespace Okta.Sdk.Model
                     this.Use == input.Use ||
                     (this.Use != null &&
                     this.Use.Equals(input.Use))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Use != null)
                 {
                     hashCode = (hashCode * 59) + this.Use.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerPolicy.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerPolicy.cs
@@ -49,6 +49,12 @@ namespace Okta.Sdk.Model
         public PolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -58,6 +64,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AuthorizationServerPolicy {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -112,6 +120,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerPolicyRule.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerPolicyRule.cs
@@ -53,6 +53,12 @@ namespace Okta.Sdk.Model
         public AuthorizationServerPolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Actions: ").Append(Actions).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleActions.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public TokenAuthorizationServerPolicyRuleAction Token { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
             sb.Append("  Token: ").Append(Token).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -159,7 +166,8 @@ namespace Okta.Sdk.Model
                     this.Token == input.Token ||
                     (this.Token != null &&
                     this.Token.Equals(input.Token))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -198,6 +206,10 @@ namespace Okta.Sdk.Model
                 if (this.Token != null)
                 {
                     hashCode = (hashCode * 59) + this.Token.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleConditions.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AutoLoginApplication.cs
+++ b/src/Okta.Sdk/Model/AutoLoginApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public AutoLoginApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AutoLoginApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/AutoLoginApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public AutoLoginApplicationSettingsSignOn SignOn { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  SignOn: ").Append(SignOn).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.SignOn == input.SignOn ||
                     (this.SignOn != null &&
                     this.SignOn.Equals(input.SignOn))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.SignOn != null)
                 {
                     hashCode = (hashCode * 59) + this.SignOn.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AutoLoginApplicationSettingsSignOn.cs
+++ b/src/Okta.Sdk/Model/AutoLoginApplicationSettingsSignOn.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string RedirectUrl { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class AutoLoginApplicationSettingsSignOn {\n");
             sb.Append("  LoginUrl: ").Append(LoginUrl).Append("\n");
             sb.Append("  RedirectUrl: ").Append(RedirectUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.RedirectUrl == input.RedirectUrl ||
                     (this.RedirectUrl != null &&
                     this.RedirectUrl.Equals(input.RedirectUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.RedirectUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.RedirectUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/AutoUpdateSchedule.cs
+++ b/src/Okta.Sdk/Model/AutoUpdateSchedule.cs
@@ -67,6 +67,12 @@ namespace Okta.Sdk.Model
         public string Timezone { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -79,6 +85,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Duration: ").Append(Duration).Append("\n");
             sb.Append("  LastUpdated: ").Append(LastUpdated).Append("\n");
             sb.Append("  Timezone: ").Append(Timezone).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -136,7 +143,8 @@ namespace Okta.Sdk.Model
                     this.Timezone == input.Timezone ||
                     (this.Timezone != null &&
                     this.Timezone.Equals(input.Timezone))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -161,6 +169,10 @@ namespace Okta.Sdk.Model
                 if (this.Timezone != null)
                 {
                     hashCode = (hashCode * 59) + this.Timezone.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BaseEmailDomain.cs
+++ b/src/Okta.Sdk/Model/BaseEmailDomain.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BaseEmailDomain" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BaseEmailDomain() { }
+        public BaseEmailDomain()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets DisplayName
@@ -51,6 +54,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BaseEmailDomain {\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -104,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BasicApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/BasicApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public BasicApplicationSettingsApplication App { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.App == input.App ||
                     (this.App != null &&
                     this.App.Equals(input.App))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.App != null)
                 {
                     hashCode = (hashCode * 59) + this.App.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BasicApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/BasicApplicationSettingsApplication.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Url { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BasicApplicationSettingsApplication {\n");
             sb.Append("  AuthURL: ").Append(AuthURL).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BasicAuthApplication.cs
+++ b/src/Okta.Sdk/Model/BasicAuthApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public BasicApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BeforeScheduledActionPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/BeforeScheduledActionPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public ScheduledUserLifecycleAction LifecycleAction { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BeforeScheduledActionPolicyRuleCondition {\n");
             sb.Append("  Duration: ").Append(Duration).Append("\n");
             sb.Append("  LifecycleAction: ").Append(LifecycleAction).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.LifecycleAction == input.LifecycleAction ||
                     (this.LifecycleAction != null &&
                     this.LifecycleAction.Equals(input.LifecycleAction))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.LifecycleAction != null)
                 {
                     hashCode = (hashCode * 59) + this.LifecycleAction.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour.cs
+++ b/src/Okta.Sdk/Model/BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour.cs
@@ -36,13 +36,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour() { }
+        public BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets VelocityKph
         /// </summary>
         [DataMember(Name = "velocityKph", IsRequired = true, EmitDefaultValue = false)]
         public int VelocityKph { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -53,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class BehaviorDetectionRuleSettingsBasedOnDeviceVelocityInKilometersPerHour {\n");
             sb.Append("  VelocityKph: ").Append(VelocityKph).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -91,7 +101,8 @@ namespace Okta.Sdk.Model
                 (
                     this.VelocityKph == input.VelocityKph ||
                     this.VelocityKph.Equals(input.VelocityKph)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -104,6 +115,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.VelocityKph.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorDetectionRuleSettingsBasedOnEventHistory.cs
+++ b/src/Okta.Sdk/Model/BehaviorDetectionRuleSettingsBasedOnEventHistory.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public int MinEventsNeededForEvaluation { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorDetectionRuleSettingsBasedOnEventHistory {\n");
             sb.Append("  MaxEventsUsedForEvaluation: ").Append(MaxEventsUsedForEvaluation).Append("\n");
             sb.Append("  MinEventsNeededForEvaluation: ").Append(MinEventsNeededForEvaluation).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinEventsNeededForEvaluation == input.MinEventsNeededForEvaluation ||
                     this.MinEventsNeededForEvaluation.Equals(input.MinEventsNeededForEvaluation)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.MaxEventsUsedForEvaluation.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinEventsNeededForEvaluation.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRule.cs
+++ b/src/Okta.Sdk/Model/BehaviorRule.cs
@@ -46,7 +46,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRule" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRule() { }
+        public BehaviorRule()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Created
@@ -115,6 +118,12 @@ namespace Okta.Sdk.Model
         public ApiTokenLink Link { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -129,6 +138,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Link: ").Append(Link).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -198,7 +208,8 @@ namespace Okta.Sdk.Model
                     this.Link == input.Link ||
                     (this.Link != null &&
                     this.Link.Equals(input.Link))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -237,6 +248,10 @@ namespace Okta.Sdk.Model
                 if (this.Link != null)
                 {
                     hashCode = (hashCode * 59) + this.Link.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BehaviorRuleAnomalousDevice.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleAnomalousDevice.cs
@@ -42,13 +42,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleAnomalousDevice" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleAnomalousDevice() { }
+        public BehaviorRuleAnomalousDevice()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Settings
         /// </summary>
         [DataMember(Name = "settings", EmitDefaultValue = false)]
         public BehaviorRuleSettingsAnomalousDevice Settings { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleAnomalousDevice {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +109,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +125,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BehaviorRuleAnomalousIP.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleAnomalousIP.cs
@@ -42,13 +42,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleAnomalousIP" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleAnomalousIP() { }
+        public BehaviorRuleAnomalousIP()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Settings
         /// </summary>
         [DataMember(Name = "settings", EmitDefaultValue = false)]
         public BehaviorRuleSettingsAnomalousIP Settings { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleAnomalousIP {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +109,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +125,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BehaviorRuleAnomalousLocation.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleAnomalousLocation.cs
@@ -42,13 +42,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleAnomalousLocation" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleAnomalousLocation() { }
+        public BehaviorRuleAnomalousLocation()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Settings
         /// </summary>
         [DataMember(Name = "settings", EmitDefaultValue = false)]
         public BehaviorRuleSettingsAnomalousLocation Settings { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleAnomalousLocation {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +109,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +125,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousDevice.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousDevice.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public int MinEventsNeededForEvaluation { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleSettingsAnomalousDevice {\n");
             sb.Append("  MaxEventsUsedForEvaluation: ").Append(MaxEventsUsedForEvaluation).Append("\n");
             sb.Append("  MinEventsNeededForEvaluation: ").Append(MinEventsNeededForEvaluation).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinEventsNeededForEvaluation == input.MinEventsNeededForEvaluation ||
                     this.MinEventsNeededForEvaluation.Equals(input.MinEventsNeededForEvaluation)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.MaxEventsUsedForEvaluation.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinEventsNeededForEvaluation.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousIP.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousIP.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public int MinEventsNeededForEvaluation { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleSettingsAnomalousIP {\n");
             sb.Append("  MaxEventsUsedForEvaluation: ").Append(MaxEventsUsedForEvaluation).Append("\n");
             sb.Append("  MinEventsNeededForEvaluation: ").Append(MinEventsNeededForEvaluation).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinEventsNeededForEvaluation == input.MinEventsNeededForEvaluation ||
                     this.MinEventsNeededForEvaluation.Equals(input.MinEventsNeededForEvaluation)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.MaxEventsUsedForEvaluation.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinEventsNeededForEvaluation.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousLocation.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleSettingsAnomalousLocation.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleSettingsAnomalousLocation" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleSettingsAnomalousLocation() { }
+        public BehaviorRuleSettingsAnomalousLocation()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets MaxEventsUsedForEvaluation
@@ -64,6 +67,12 @@ namespace Okta.Sdk.Model
         public int RadiusKilometers { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -75,6 +84,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MinEventsNeededForEvaluation: ").Append(MinEventsNeededForEvaluation).Append("\n");
             sb.Append("  Granularity: ").Append(Granularity).Append("\n");
             sb.Append("  RadiusKilometers: ").Append(RadiusKilometers).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -126,7 +136,8 @@ namespace Okta.Sdk.Model
                 (
                     this.RadiusKilometers == input.RadiusKilometers ||
                     this.RadiusKilometers.Equals(input.RadiusKilometers)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -145,6 +156,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Granularity.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.RadiusKilometers.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRuleSettingsHistoryBased.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleSettingsHistoryBased.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public int MinEventsNeededForEvaluation { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleSettingsHistoryBased {\n");
             sb.Append("  MaxEventsUsedForEvaluation: ").Append(MaxEventsUsedForEvaluation).Append("\n");
             sb.Append("  MinEventsNeededForEvaluation: ").Append(MinEventsNeededForEvaluation).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinEventsNeededForEvaluation == input.MinEventsNeededForEvaluation ||
                     this.MinEventsNeededForEvaluation.Equals(input.MinEventsNeededForEvaluation)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.MaxEventsUsedForEvaluation.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinEventsNeededForEvaluation.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRuleSettingsVelocity.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleSettingsVelocity.cs
@@ -36,13 +36,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleSettingsVelocity" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleSettingsVelocity() { }
+        public BehaviorRuleSettingsVelocity()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets VelocityKph
         /// </summary>
         [DataMember(Name = "velocityKph", IsRequired = true, EmitDefaultValue = false)]
         public int VelocityKph { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -53,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class BehaviorRuleSettingsVelocity {\n");
             sb.Append("  VelocityKph: ").Append(VelocityKph).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -91,7 +101,8 @@ namespace Okta.Sdk.Model
                 (
                     this.VelocityKph == input.VelocityKph ||
                     this.VelocityKph.Equals(input.VelocityKph)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -104,6 +115,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.VelocityKph.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/BehaviorRuleVelocity.cs
+++ b/src/Okta.Sdk/Model/BehaviorRuleVelocity.cs
@@ -42,13 +42,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="BehaviorRuleVelocity" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public BehaviorRuleVelocity() { }
+        public BehaviorRuleVelocity()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Settings
         /// </summary>
         [DataMember(Name = "settings", EmitDefaultValue = false)]
         public BehaviorRuleSettingsVelocity Settings { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BehaviorRuleVelocity {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +109,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +125,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BookmarkApplication.cs
+++ b/src/Okta.Sdk/Model/BookmarkApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public BookmarkApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BookmarkApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/BookmarkApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public BookmarkApplicationSettingsApplication App { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.App == input.App ||
                     (this.App != null &&
                     this.App.Equals(input.App))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.App != null)
                 {
                     hashCode = (hashCode * 59) + this.App.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BookmarkApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/BookmarkApplicationSettingsApplication.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Url { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BookmarkApplicationSettingsApplication {\n");
             sb.Append("  RequestIntegration: ").Append(RequestIntegration).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BouncesRemoveListError.cs
+++ b/src/Okta.Sdk/Model/BouncesRemoveListError.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Reason { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BouncesRemoveListError {\n");
             sb.Append("  EmailAddress: ").Append(EmailAddress).Append("\n");
             sb.Append("  Reason: ").Append(Reason).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Reason == input.Reason ||
                     (this.Reason != null &&
                     this.Reason.Equals(input.Reason))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Reason != null)
                 {
                     hashCode = (hashCode * 59) + this.Reason.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BouncesRemoveListObj.cs
+++ b/src/Okta.Sdk/Model/BouncesRemoveListObj.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> EmailAddresses { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class BouncesRemoveListObj {\n");
             sb.Append("  EmailAddresses: ").Append(EmailAddresses).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.EmailAddresses != null &&
                     input.EmailAddresses != null &&
                     this.EmailAddresses.SequenceEqual(input.EmailAddresses)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.EmailAddresses != null)
                 {
                     hashCode = (hashCode * 59) + this.EmailAddresses.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BouncesRemoveListResult.cs
+++ b/src/Okta.Sdk/Model/BouncesRemoveListResult.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<BouncesRemoveListError> Errors { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class BouncesRemoveListResult {\n");
             sb.Append("  Errors: ").Append(Errors).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Errors != null &&
                     input.Errors != null &&
                     this.Errors.SequenceEqual(input.Errors)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Errors != null)
                 {
                     hashCode = (hashCode * 59) + this.Errors.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Brand.cs
+++ b/src/Okta.Sdk/Model/Brand.cs
@@ -99,6 +99,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -114,6 +120,7 @@ namespace Okta.Sdk.Model
             sb.Append("  OptOutOfUserCommunications: ").Append(OptOutOfUserCommunications).Append("\n");
             sb.Append("  RemovePoweredByOkta: ").Append(RemovePoweredByOkta).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -186,7 +193,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -220,6 +228,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BrandDefaultApp.cs
+++ b/src/Okta.Sdk/Model/BrandDefaultApp.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string AppLinkName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class BrandDefaultApp {\n");
             sb.Append("  AppInstanceId: ").Append(AppInstanceId).Append("\n");
             sb.Append("  AppLinkName: ").Append(AppLinkName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.AppLinkName == input.AppLinkName ||
                     (this.AppLinkName != null &&
                     this.AppLinkName.Equals(input.AppLinkName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.AppLinkName != null)
                 {
                     hashCode = (hashCode * 59) + this.AppLinkName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/BrowserPluginApplication.cs
+++ b/src/Okta.Sdk/Model/BrowserPluginApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public SwaApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CAPTCHAInstance.cs
+++ b/src/Okta.Sdk/Model/CAPTCHAInstance.cs
@@ -78,6 +78,12 @@ namespace Okta.Sdk.Model
         public ApiTokenLink Link { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -91,6 +97,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SiteKey: ").Append(SiteKey).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Link: ").Append(Link).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -155,7 +162,8 @@ namespace Okta.Sdk.Model
                     this.Link == input.Link ||
                     (this.Link != null &&
                     this.Link.Equals(input.Link))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -190,6 +198,10 @@ namespace Okta.Sdk.Model
                 if (this.Link != null)
                 {
                     hashCode = (hashCode * 59) + this.Link.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CallUserFactor.cs
+++ b/src/Okta.Sdk/Model/CallUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public CallUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class CallUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CallUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/CallUserFactorProfile.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string PhoneNumber { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class CallUserFactorProfile {\n");
             sb.Append("  PhoneExtension: ").Append(PhoneExtension).Append("\n");
             sb.Append("  PhoneNumber: ").Append(PhoneNumber).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.PhoneNumber == input.PhoneNumber ||
                     (this.PhoneNumber != null &&
                     this.PhoneNumber.Equals(input.PhoneNumber))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.PhoneNumber != null)
                 {
                     hashCode = (hashCode * 59) + this.PhoneNumber.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CapabilitiesCreateObject.cs
+++ b/src/Okta.Sdk/Model/CapabilitiesCreateObject.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public LifecycleCreateSettingObject LifecycleCreate { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class CapabilitiesCreateObject {\n");
             sb.Append("  LifecycleCreate: ").Append(LifecycleCreate).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.LifecycleCreate == input.LifecycleCreate ||
                     (this.LifecycleCreate != null &&
                     this.LifecycleCreate.Equals(input.LifecycleCreate))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.LifecycleCreate != null)
                 {
                     hashCode = (hashCode * 59) + this.LifecycleCreate.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CapabilitiesObject.cs
+++ b/src/Okta.Sdk/Model/CapabilitiesObject.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public CapabilitiesUpdateObject Update { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class CapabilitiesObject {\n");
             sb.Append("  Create: ").Append(Create).Append("\n");
             sb.Append("  Update: ").Append(Update).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Update == input.Update ||
                     (this.Update != null &&
                     this.Update.Equals(input.Update))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Update != null)
                 {
                     hashCode = (hashCode * 59) + this.Update.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CapabilitiesUpdateObject.cs
+++ b/src/Okta.Sdk/Model/CapabilitiesUpdateObject.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public ProfileSettingObject Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  LifecycleDeactivate: ").Append(LifecycleDeactivate).Append("\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CatalogApplication.cs
+++ b/src/Okta.Sdk/Model/CatalogApplication.cs
@@ -130,6 +130,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -149,6 +155,7 @@ namespace Okta.Sdk.Model
             sb.Append("  VerificationStatus: ").Append(VerificationStatus).Append("\n");
             sb.Append("  Website: ").Append(Website).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -246,7 +253,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -305,6 +313,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ChangePasswordRequest.cs
+++ b/src/Okta.Sdk/Model/ChangePasswordRequest.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public PasswordCredential OldPassword { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ChangePasswordRequest {\n");
             sb.Append("  NewPassword: ").Append(NewPassword).Append("\n");
             sb.Append("  OldPassword: ").Append(OldPassword).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.OldPassword == input.OldPassword ||
                     (this.OldPassword != null &&
                     this.OldPassword.Equals(input.OldPassword))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.OldPassword != null)
                 {
                     hashCode = (hashCode * 59) + this.OldPassword.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ChannelBinding.cs
+++ b/src/Okta.Sdk/Model/ChannelBinding.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Style { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ChannelBinding {\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
             sb.Append("  Style: ").Append(Style).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Style == input.Style ||
                     (this.Style != null &&
                     this.Style.Equals(input.Style))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Style != null)
                 {
                     hashCode = (hashCode * 59) + this.Style.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ClientPolicyCondition.cs
+++ b/src/Okta.Sdk/Model/ClientPolicyCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ClientPolicyCondition {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Compliance.cs
+++ b/src/Okta.Sdk/Model/Compliance.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Fips { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class Compliance {\n");
             sb.Append("  Fips: ").Append(Fips).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Fips == input.Fips ||
                     (this.Fips != null &&
                     this.Fips.Equals(input.Fips))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Fips != null)
                 {
                     hashCode = (hashCode * 59) + this.Fips.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ContextPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/ContextPolicyRuleCondition.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public string Expression { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Rooted: ").Append(Rooted).Append("\n");
             sb.Append("  TrustLevel: ").Append(TrustLevel).Append("\n");
             sb.Append("  Expression: ").Append(Expression).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -133,7 +140,8 @@ namespace Okta.Sdk.Model
                     this.Expression == input.Expression ||
                     (this.Expression != null &&
                     this.Expression.Equals(input.Expression))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -158,6 +166,10 @@ namespace Okta.Sdk.Model
                 if (this.Expression != null)
                 {
                     hashCode = (hashCode * 59) + this.Expression.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CreateSessionRequest.cs
+++ b/src/Okta.Sdk/Model/CreateSessionRequest.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string SessionToken { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class CreateSessionRequest {\n");
             sb.Append("  SessionToken: ").Append(SessionToken).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.SessionToken == input.SessionToken ||
                     (this.SessionToken != null &&
                     this.SessionToken.Equals(input.SessionToken))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.SessionToken != null)
                 {
                     hashCode = (hashCode * 59) + this.SessionToken.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CreateUserRequest.cs
+++ b/src/Okta.Sdk/Model/CreateUserRequest.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="CreateUserRequest" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public CreateUserRequest() { }
+        public CreateUserRequest()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Credentials
@@ -63,6 +66,12 @@ namespace Okta.Sdk.Model
         public UserType Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +83,7 @@ namespace Okta.Sdk.Model
             sb.Append("  GroupIds: ").Append(GroupIds).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -129,7 +139,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -156,6 +167,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Csr.cs
+++ b/src/Okta.Sdk/Model/Csr.cs
@@ -90,6 +90,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -101,6 +107,7 @@ namespace Okta.Sdk.Model
             sb.Append("  _Csr: ").Append(_Csr).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Kty: ").Append(Kty).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -155,7 +162,8 @@ namespace Okta.Sdk.Model
                     this.Kty == input.Kty ||
                     (this.Kty != null &&
                     this.Kty.Equals(input.Kty))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Kty != null)
                 {
                     hashCode = (hashCode * 59) + this.Kty.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CsrMetadata.cs
+++ b/src/Okta.Sdk/Model/CsrMetadata.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public CsrMetadataSubjectAltNames SubjectAltNames { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class CsrMetadata {\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
             sb.Append("  SubjectAltNames: ").Append(SubjectAltNames).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.SubjectAltNames == input.SubjectAltNames ||
                     (this.SubjectAltNames != null &&
                     this.SubjectAltNames.Equals(input.SubjectAltNames))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.SubjectAltNames != null)
                 {
                     hashCode = (hashCode * 59) + this.SubjectAltNames.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CsrMetadataSubject.cs
+++ b/src/Okta.Sdk/Model/CsrMetadataSubject.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string StateOrProvinceName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  OrganizationalUnitName: ").Append(OrganizationalUnitName).Append("\n");
             sb.Append("  OrganizationName: ").Append(OrganizationName).Append("\n");
             sb.Append("  StateOrProvinceName: ").Append(StateOrProvinceName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this.StateOrProvinceName == input.StateOrProvinceName ||
                     (this.StateOrProvinceName != null &&
                     this.StateOrProvinceName.Equals(input.StateOrProvinceName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.StateOrProvinceName != null)
                 {
                     hashCode = (hashCode * 59) + this.StateOrProvinceName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CsrMetadataSubjectAltNames.cs
+++ b/src/Okta.Sdk/Model/CsrMetadataSubjectAltNames.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> DnsNames { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class CsrMetadataSubjectAltNames {\n");
             sb.Append("  DnsNames: ").Append(DnsNames).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.DnsNames != null &&
                     input.DnsNames != null &&
                     this.DnsNames.SequenceEqual(input.DnsNames)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.DnsNames != null)
                 {
                     hashCode = (hashCode * 59) + this.DnsNames.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CustomHotpUserFactor.cs
+++ b/src/Okta.Sdk/Model/CustomHotpUserFactor.cs
@@ -61,6 +61,12 @@ namespace Okta.Sdk.Model
         public CustomHotpUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  FactorProfileId: ").Append(FactorProfileId).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -115,7 +122,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CustomHotpUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/CustomHotpUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string SharedSecret { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class CustomHotpUserFactorProfile {\n");
             sb.Append("  SharedSecret: ").Append(SharedSecret).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.SharedSecret == input.SharedSecret ||
                     (this.SharedSecret != null &&
                     this.SharedSecret.Equals(input.SharedSecret))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.SharedSecret != null)
                 {
                     hashCode = (hashCode * 59) + this.SharedSecret.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/CustomizablePage.cs
+++ b/src/Okta.Sdk/Model/CustomizablePage.cs
@@ -36,13 +36,22 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="CustomizablePage" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public CustomizablePage() { }
+        public CustomizablePage()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets PageContent
         /// </summary>
         [DataMember(Name = "pageContent", IsRequired = true, EmitDefaultValue = false)]
         public string PageContent { get; set; }
+
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -53,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class CustomizablePage {\n");
             sb.Append("  PageContent: ").Append(PageContent).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -92,7 +102,8 @@ namespace Okta.Sdk.Model
                     this.PageContent == input.PageContent ||
                     (this.PageContent != null &&
                     this.PageContent.Equals(input.PageContent))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -107,6 +118,10 @@ namespace Okta.Sdk.Model
                 if (this.PageContent != null)
                 {
                     hashCode = (hashCode * 59) + this.PageContent.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DNSRecord.cs
+++ b/src/Okta.Sdk/Model/DNSRecord.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public List<string> Values { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Fqdn: ").Append(Fqdn).Append("\n");
             sb.Append("  RecordType: ").Append(RecordType).Append("\n");
             sb.Append("  Values: ").Append(Values).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -124,7 +131,8 @@ namespace Okta.Sdk.Model
                     this.Values != null &&
                     input.Values != null &&
                     this.Values.SequenceEqual(input.Values)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -151,6 +159,10 @@ namespace Okta.Sdk.Model
                 if (this.Values != null)
                 {
                     hashCode = (hashCode * 59) + this.Values.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DeviceAccessPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/DeviceAccessPolicyRuleCondition.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public bool Registered { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  TrustLevel: ").Append(TrustLevel).Append("\n");
             sb.Append("  Managed: ").Append(Managed).Append("\n");
             sb.Append("  Registered: ").Append(Registered).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -143,7 +150,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Registered == input.Registered ||
                     this.Registered.Equals(input.Registered)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -167,6 +175,10 @@ namespace Okta.Sdk.Model
                 }
                 hashCode = (hashCode * 59) + this.Managed.GetHashCode();
                 hashCode = (hashCode * 59) + this.Registered.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/DeviceAssurance.cs
+++ b/src/Okta.Sdk/Model/DeviceAssurance.cs
@@ -153,6 +153,12 @@ namespace Okta.Sdk.Model
         public ApiTokenLink Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -173,6 +179,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ScreenLockType: ").Append(ScreenLockType).Append("\n");
             sb.Append("  SecureHardwarePresent: ").Append(SecureHardwarePresent).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -270,7 +277,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -327,6 +335,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DeviceAssuranceDiskEncryptionType.cs
+++ b/src/Okta.Sdk/Model/DeviceAssuranceDiskEncryptionType.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class DeviceAssuranceDiskEncryptionType {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DeviceAssuranceScreenLockType.cs
+++ b/src/Okta.Sdk/Model/DeviceAssuranceScreenLockType.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class DeviceAssuranceScreenLockType {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DevicePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/DevicePolicyRuleCondition.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string TrustLevel { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Platform: ").Append(Platform).Append("\n");
             sb.Append("  Rooted: ").Append(Rooted).Append("\n");
             sb.Append("  TrustLevel: ").Append(TrustLevel).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -121,7 +128,8 @@ namespace Okta.Sdk.Model
                     this.TrustLevel == input.TrustLevel ||
                     (this.TrustLevel != null &&
                     this.TrustLevel.Equals(input.TrustLevel))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -142,6 +150,10 @@ namespace Okta.Sdk.Model
                 if (this.TrustLevel != null)
                 {
                     hashCode = (hashCode * 59) + this.TrustLevel.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DevicePolicyRuleConditionPlatform.cs
+++ b/src/Okta.Sdk/Model/DevicePolicyRuleConditionPlatform.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Types { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class DevicePolicyRuleConditionPlatform {\n");
             sb.Append("  SupportedMDMFrameworks: ").Append(SupportedMDMFrameworks).Append("\n");
             sb.Append("  Types: ").Append(Types).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Types != null &&
                     input.Types != null &&
                     this.Types.SequenceEqual(input.Types)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Types != null)
                 {
                     hashCode = (hashCode * 59) + this.Types.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Domain.cs
+++ b/src/Okta.Sdk/Model/Domain.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string ValidationStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  PublicCertificate: ").Append(PublicCertificate).Append("\n");
             sb.Append("  ValidationStatus: ").Append(ValidationStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -148,7 +155,8 @@ namespace Okta.Sdk.Model
                     this.ValidationStatus == input.ValidationStatus ||
                     (this.ValidationStatus != null &&
                     this.ValidationStatus.Equals(input.ValidationStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -183,6 +191,10 @@ namespace Okta.Sdk.Model
                 if (this.ValidationStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.ValidationStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DomainCertificate.cs
+++ b/src/Okta.Sdk/Model/DomainCertificate.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  CertificateChain: ").Append(CertificateChain).Append("\n");
             sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DomainCertificateMetadata.cs
+++ b/src/Okta.Sdk/Model/DomainCertificateMetadata.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Subject { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  Fingerprint: ").Append(Fingerprint).Append("\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Subject == input.Subject ||
                     (this.Subject != null &&
                     this.Subject.Equals(input.Subject))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Subject != null)
                 {
                     hashCode = (hashCode * 59) + this.Subject.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DomainLinks.cs
+++ b/src/Okta.Sdk/Model/DomainLinks.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public Object Verify { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Self: ").Append(Self).Append("\n");
             sb.Append("  Verify: ").Append(Verify).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Verify == input.Verify ||
                     (this.Verify != null &&
                     this.Verify.Equals(input.Verify))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Verify != null)
                 {
                     hashCode = (hashCode * 59) + this.Verify.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DomainListResponse.cs
+++ b/src/Okta.Sdk/Model/DomainListResponse.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<DomainResponse> Domains { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class DomainListResponse {\n");
             sb.Append("  Domains: ").Append(Domains).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Domains != null &&
                     input.Domains != null &&
                     this.Domains.SequenceEqual(input.Domains)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Domains != null)
                 {
                     hashCode = (hashCode * 59) + this.Domains.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/DomainResponse.cs
+++ b/src/Okta.Sdk/Model/DomainResponse.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public DomainLinks Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  PublicCertificate: ").Append(PublicCertificate).Append("\n");
             sb.Append("  ValidationStatus: ").Append(ValidationStatus).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -160,7 +167,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -199,6 +207,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Duration.cs
+++ b/src/Okta.Sdk/Model/Duration.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Unit { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class Duration {\n");
             sb.Append("  Number: ").Append(Number).Append("\n");
             sb.Append("  Unit: ").Append(Unit).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Unit == input.Unit ||
                     (this.Unit != null &&
                     this.Unit.Equals(input.Unit))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Unit != null)
                 {
                     hashCode = (hashCode * 59) + this.Unit.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailContent.cs
+++ b/src/Okta.Sdk/Model/EmailContent.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailContent" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailContent() { }
+        public EmailContent()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// The email&#39;s HTML body. May contain [variable references](https://velocity.apache.org/engine/1.7/user-guide.html#references).
@@ -53,6 +56,12 @@ namespace Okta.Sdk.Model
         public string Subject { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +71,7 @@ namespace Okta.Sdk.Model
             sb.Append("class EmailContent {\n");
             sb.Append("  Body: ").Append(Body).Append("\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -106,7 +116,8 @@ namespace Okta.Sdk.Model
                     this.Subject == input.Subject ||
                     (this.Subject != null &&
                     this.Subject.Equals(input.Subject))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -125,6 +136,10 @@ namespace Okta.Sdk.Model
                 if (this.Subject != null)
                 {
                     hashCode = (hashCode * 59) + this.Subject.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailCustomization.cs
+++ b/src/Okta.Sdk/Model/EmailCustomization.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailCustomization" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailCustomization() { }
+        public EmailCustomization()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// The email&#39;s HTML body. May contain [variable references](https://velocity.apache.org/engine/1.7/user-guide.html#references).
@@ -118,6 +121,12 @@ namespace Okta.Sdk.Model
         public EmailCustomizationAllOfLinks Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -133,6 +142,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Language: ").Append(Language).Append("\n");
             sb.Append("  LastUpdated: ").Append(LastUpdated).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -206,7 +216,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -246,6 +257,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailCustomizationAllOfLinks.cs
+++ b/src/Okta.Sdk/Model/EmailCustomizationAllOfLinks.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public HrefObject Test { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Template: ").Append(Template).Append("\n");
             sb.Append("  Preview: ").Append(Preview).Append("\n");
             sb.Append("  Test: ").Append(Test).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Test == input.Test ||
                     (this.Test != null &&
                     this.Test.Equals(input.Test))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Test != null)
                 {
                     hashCode = (hashCode * 59) + this.Test.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailDefaultContent.cs
+++ b/src/Okta.Sdk/Model/EmailDefaultContent.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailDefaultContent" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailDefaultContent() { }
+        public EmailDefaultContent()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// The email&#39;s HTML body. May contain [variable references](https://velocity.apache.org/engine/1.7/user-guide.html#references).
@@ -59,6 +62,12 @@ namespace Okta.Sdk.Model
         public EmailDefaultContentAllOfLinks Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +78,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Body: ").Append(Body).Append("\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -118,7 +128,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -141,6 +152,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailDefaultContentAllOfLinks.cs
+++ b/src/Okta.Sdk/Model/EmailDefaultContentAllOfLinks.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public HrefObject Test { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Template: ").Append(Template).Append("\n");
             sb.Append("  Preview: ").Append(Preview).Append("\n");
             sb.Append("  Test: ").Append(Test).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Test == input.Test ||
                     (this.Test != null &&
                     this.Test.Equals(input.Test))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Test != null)
                 {
                     hashCode = (hashCode * 59) + this.Test.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailDomain.cs
+++ b/src/Okta.Sdk/Model/EmailDomain.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailDomain" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailDomain() { }
+        public EmailDomain()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Domain
@@ -57,6 +60,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -67,6 +76,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Domain: ").Append(Domain).Append("\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -116,7 +126,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -139,6 +150,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailDomainListResponse.cs
+++ b/src/Okta.Sdk/Model/EmailDomainListResponse.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<EmailDomainResponse> EmailDomains { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class EmailDomainListResponse {\n");
             sb.Append("  EmailDomains: ").Append(EmailDomains).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.EmailDomains != null &&
                     input.EmailDomains != null &&
                     this.EmailDomains.SequenceEqual(input.EmailDomains)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.EmailDomains != null)
                 {
                     hashCode = (hashCode * 59) + this.EmailDomains.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailDomainResponse.cs
+++ b/src/Okta.Sdk/Model/EmailDomainResponse.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailDomainResponse" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailDomainResponse() { }
+        public EmailDomainResponse()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets DnsValidationRecords
@@ -75,6 +78,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -88,6 +97,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ValidationStatus: ").Append(ValidationStatus).Append("\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -153,7 +163,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -188,6 +199,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailPreview.cs
+++ b/src/Okta.Sdk/Model/EmailPreview.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public EmailPreviewLinks Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -80,6 +86,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Body: ").Append(Body).Append("\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -129,7 +136,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -152,6 +160,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailPreviewLinks.cs
+++ b/src/Okta.Sdk/Model/EmailPreviewLinks.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public HrefObject DefaultContent { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Template: ").Append(Template).Append("\n");
             sb.Append("  Test: ").Append(Test).Append("\n");
             sb.Append("  DefaultContent: ").Append(DefaultContent).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -135,7 +142,8 @@ namespace Okta.Sdk.Model
                     this.DefaultContent == input.DefaultContent ||
                     (this.DefaultContent != null &&
                     this.DefaultContent.Equals(input.DefaultContent))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -166,6 +174,10 @@ namespace Okta.Sdk.Model
                 if (this.DefaultContent != null)
                 {
                     hashCode = (hashCode * 59) + this.DefaultContent.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailSettings.cs
+++ b/src/Okta.Sdk/Model/EmailSettings.cs
@@ -68,8 +68,17 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="EmailSettings" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public EmailSettings() { }
+        public EmailSettings()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
@@ -79,6 +88,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class EmailSettings {\n");
             sb.Append("  Recipients: ").Append(Recipients).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -117,7 +127,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Recipients == input.Recipients ||
                     this.Recipients.Equals(input.Recipients)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -130,6 +141,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.Recipients.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/EmailTemplate.cs
+++ b/src/Okta.Sdk/Model/EmailTemplate.cs
@@ -61,6 +61,12 @@ namespace Okta.Sdk.Model
         public EmailTemplateLinks Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -120,7 +127,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -143,6 +151,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailTemplateEmbedded.cs
+++ b/src/Okta.Sdk/Model/EmailTemplateEmbedded.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public int CustomizationCount { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class EmailTemplateEmbedded {\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
             sb.Append("  CustomizationCount: ").Append(CustomizationCount).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                 (
                     this.CustomizationCount == input.CustomizationCount ||
                     this.CustomizationCount.Equals(input.CustomizationCount)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -115,6 +123,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.CustomizationCount.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/EmailTemplateLinks.cs
+++ b/src/Okta.Sdk/Model/EmailTemplateLinks.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public HrefObject Test { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  DefaultContent: ").Append(DefaultContent).Append("\n");
             sb.Append("  Customizations: ").Append(Customizations).Append("\n");
             sb.Append("  Test: ").Append(Test).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -135,7 +142,8 @@ namespace Okta.Sdk.Model
                     this.Test == input.Test ||
                     (this.Test != null &&
                     this.Test.Equals(input.Test))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -166,6 +174,10 @@ namespace Okta.Sdk.Model
                 if (this.Test != null)
                 {
                     hashCode = (hashCode * 59) + this.Test.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailUserFactor.cs
+++ b/src/Okta.Sdk/Model/EmailUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public EmailUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class EmailUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EmailUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/EmailUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Email { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class EmailUserFactorProfile {\n");
             sb.Append("  Email: ").Append(Email).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Email == input.Email ||
                     (this.Email != null &&
                     this.Email.Equals(input.Email))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Email != null)
                 {
                     hashCode = (hashCode * 59) + this.Email.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Error.cs
+++ b/src/Okta.Sdk/Model/Error.cs
@@ -68,6 +68,12 @@ namespace Okta.Sdk.Model
         public string ErrorSummary { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -80,6 +86,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ErrorId: ").Append(ErrorId).Append("\n");
             sb.Append("  ErrorLink: ").Append(ErrorLink).Append("\n");
             sb.Append("  ErrorSummary: ").Append(ErrorSummary).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -140,7 +147,8 @@ namespace Okta.Sdk.Model
                     this.ErrorSummary == input.ErrorSummary ||
                     (this.ErrorSummary != null &&
                     this.ErrorSummary.Equals(input.ErrorSummary))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -171,6 +179,10 @@ namespace Okta.Sdk.Model
                 if (this.ErrorSummary != null)
                 {
                     hashCode = (hashCode * 59) + this.ErrorSummary.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ErrorErrorCauses.cs
+++ b/src/Okta.Sdk/Model/ErrorErrorCauses.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string ErrorSummary { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ErrorErrorCauses {\n");
             sb.Append("  ErrorSummary: ").Append(ErrorSummary).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.ErrorSummary == input.ErrorSummary ||
                     (this.ErrorSummary != null &&
                     this.ErrorSummary.Equals(input.ErrorSummary))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.ErrorSummary != null)
                 {
                     hashCode = (hashCode * 59) + this.ErrorSummary.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventHook.cs
+++ b/src/Okta.Sdk/Model/EventHook.cs
@@ -126,6 +126,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -143,6 +149,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  VerificationStatus: ").Append(VerificationStatus).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -228,7 +235,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -279,6 +287,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventHookChannel.cs
+++ b/src/Okta.Sdk/Model/EventHookChannel.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string _Version { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Config: ").Append(Config).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventHookChannelConfig.cs
+++ b/src/Okta.Sdk/Model/EventHookChannelConfig.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Uri { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  AuthScheme: ").Append(AuthScheme).Append("\n");
             sb.Append("  Headers: ").Append(Headers).Append("\n");
             sb.Append("  Uri: ").Append(Uri).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -112,7 +119,8 @@ namespace Okta.Sdk.Model
                     this.Uri == input.Uri ||
                     (this.Uri != null &&
                     this.Uri.Equals(input.Uri))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -135,6 +143,10 @@ namespace Okta.Sdk.Model
                 if (this.Uri != null)
                 {
                     hashCode = (hashCode * 59) + this.Uri.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventHookChannelConfigAuthScheme.cs
+++ b/src/Okta.Sdk/Model/EventHookChannelConfigAuthScheme.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Key: ").Append(Key).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventHookChannelConfigHeader.cs
+++ b/src/Okta.Sdk/Model/EventHookChannelConfigHeader.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class EventHookChannelConfigHeader {\n");
             sb.Append("  Key: ").Append(Key).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/EventSubscriptions.cs
+++ b/src/Okta.Sdk/Model/EventSubscriptions.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -57,6 +63,7 @@ namespace Okta.Sdk.Model
             sb.Append("class EventSubscriptions {\n");
             sb.Append("  Items: ").Append(Items).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -102,7 +109,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -121,6 +129,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/FCMConfiguration.cs
+++ b/src/Okta.Sdk/Model/FCMConfiguration.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public Object ServiceAccountJson { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -73,6 +79,7 @@ namespace Okta.Sdk.Model
             sb.Append("  FileName: ").Append(FileName).Append("\n");
             sb.Append("  ProjectId: ").Append(ProjectId).Append("\n");
             sb.Append("  ServiceAccountJson: ").Append(ServiceAccountJson).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,7 +129,8 @@ namespace Okta.Sdk.Model
                     this.ServiceAccountJson == input.ServiceAccountJson ||
                     (this.ServiceAccountJson != null &&
                     this.ServiceAccountJson.Equals(input.ServiceAccountJson))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -145,6 +153,10 @@ namespace Okta.Sdk.Model
                 if (this.ServiceAccountJson != null)
                 {
                     hashCode = (hashCode * 59) + this.ServiceAccountJson.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/FCMPushProvider.cs
+++ b/src/Okta.Sdk/Model/FCMPushProvider.cs
@@ -44,6 +44,12 @@ namespace Okta.Sdk.Model
         public FCMConfiguration _Configuration { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -53,6 +59,7 @@ namespace Okta.Sdk.Model
             sb.Append("class FCMPushProvider {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  _Configuration: ").Append(_Configuration).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -92,7 +99,8 @@ namespace Okta.Sdk.Model
                     this._Configuration == input._Configuration ||
                     (this._Configuration != null &&
                     this._Configuration.Equals(input._Configuration))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -107,6 +115,10 @@ namespace Okta.Sdk.Model
                 if (this._Configuration != null)
                 {
                     hashCode = (hashCode * 59) + this._Configuration.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Feature.cs
+++ b/src/Okta.Sdk/Model/Feature.cs
@@ -92,6 +92,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -106,6 +112,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -176,7 +183,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -215,6 +223,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/FeatureStage.cs
+++ b/src/Okta.Sdk/Model/FeatureStage.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class FeatureStage {\n");
             sb.Append("  State: ").Append(State).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ForgotPasswordResponse.cs
+++ b/src/Okta.Sdk/Model/ForgotPasswordResponse.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ForgotPasswordResponse {\n");
             sb.Append("  ResetPasswordUrl: ").Append(ResetPasswordUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -95,7 +102,8 @@ namespace Okta.Sdk.Model
                     this.ResetPasswordUrl == input.ResetPasswordUrl ||
                     (this.ResetPasswordUrl != null &&
                     this.ResetPasswordUrl.Equals(input.ResetPasswordUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -110,6 +118,10 @@ namespace Okta.Sdk.Model
                 if (this.ResetPasswordUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.ResetPasswordUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GrantTypePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/GrantTypePolicyRuleCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class GrantTypePolicyRuleCondition {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Group.cs
+++ b/src/Okta.Sdk/Model/Group.cs
@@ -144,6 +144,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -160,6 +166,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -242,7 +249,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -289,6 +297,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupCondition.cs
+++ b/src/Okta.Sdk/Model/GroupCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/GroupPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupPolicyRuleCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupProfile.cs
+++ b/src/Okta.Sdk/Model/GroupProfile.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupProfile {\n");
             sb.Append("  Description: ").Append(Description).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Name == input.Name ||
                     (this.Name != null &&
                     this.Name.Equals(input.Name))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Name != null)
                 {
                     hashCode = (hashCode * 59) + this.Name.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRule.cs
+++ b/src/Okta.Sdk/Model/GroupRule.cs
@@ -106,6 +106,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -121,6 +127,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -195,7 +202,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -238,6 +246,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleAction.cs
+++ b/src/Okta.Sdk/Model/GroupRuleAction.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public GroupRuleGroupAssignment AssignUserToGroups { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class GroupRuleAction {\n");
             sb.Append("  AssignUserToGroups: ").Append(AssignUserToGroups).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.AssignUserToGroups == input.AssignUserToGroups ||
                     (this.AssignUserToGroups != null &&
                     this.AssignUserToGroups.Equals(input.AssignUserToGroups))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.AssignUserToGroups != null)
                 {
                     hashCode = (hashCode * 59) + this.AssignUserToGroups.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleConditions.cs
+++ b/src/Okta.Sdk/Model/GroupRuleConditions.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public GroupRulePeopleCondition People { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupRuleConditions {\n");
             sb.Append("  Expression: ").Append(Expression).Append("\n");
             sb.Append("  People: ").Append(People).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.People == input.People ||
                     (this.People != null &&
                     this.People.Equals(input.People))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.People != null)
                 {
                     hashCode = (hashCode * 59) + this.People.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleExpression.cs
+++ b/src/Okta.Sdk/Model/GroupRuleExpression.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupRuleExpression {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleGroupAssignment.cs
+++ b/src/Okta.Sdk/Model/GroupRuleGroupAssignment.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> GroupIds { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class GroupRuleGroupAssignment {\n");
             sb.Append("  GroupIds: ").Append(GroupIds).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.GroupIds != null &&
                     input.GroupIds != null &&
                     this.GroupIds.SequenceEqual(input.GroupIds)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.GroupIds != null)
                 {
                     hashCode = (hashCode * 59) + this.GroupIds.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleGroupCondition.cs
+++ b/src/Okta.Sdk/Model/GroupRuleGroupCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupRuleGroupCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRulePeopleCondition.cs
+++ b/src/Okta.Sdk/Model/GroupRulePeopleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public GroupRuleUserCondition Users { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupRulePeopleCondition {\n");
             sb.Append("  Groups: ").Append(Groups).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Users == input.Users ||
                     (this.Users != null &&
                     this.Users.Equals(input.Users))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Users != null)
                 {
                     hashCode = (hashCode * 59) + this.Users.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupRuleUserCondition.cs
+++ b/src/Okta.Sdk/Model/GroupRuleUserCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupRuleUserCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchema.cs
+++ b/src/Okta.Sdk/Model/GroupSchema.cs
@@ -156,6 +156,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -174,6 +180,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Title: ").Append(Title).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -264,7 +271,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -319,6 +327,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchemaAttribute.cs
+++ b/src/Okta.Sdk/Model/GroupSchemaAttribute.cs
@@ -136,6 +136,12 @@ namespace Okta.Sdk.Model
         public string Unique { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -160,6 +166,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Union: ").Append(Union).Append("\n");
             sb.Append("  Unique: ").Append(Unique).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -279,7 +286,8 @@ namespace Okta.Sdk.Model
                     this.Unique == input.Unique ||
                     (this.Unique != null &&
                     this.Unique.Equals(input.Unique))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -349,6 +357,10 @@ namespace Okta.Sdk.Model
                 if (this.Unique != null)
                 {
                     hashCode = (hashCode * 59) + this.Unique.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchemaBase.cs
+++ b/src/Okta.Sdk/Model/GroupSchemaBase.cs
@@ -66,6 +66,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -77,6 +83,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -132,7 +139,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -159,6 +167,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchemaBaseProperties.cs
+++ b/src/Okta.Sdk/Model/GroupSchemaBaseProperties.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public GroupSchemaAttribute Name { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupSchemaBaseProperties {\n");
             sb.Append("  Description: ").Append(Description).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Name == input.Name ||
                     (this.Name != null &&
                     this.Name.Equals(input.Name))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Name != null)
                 {
                     hashCode = (hashCode * 59) + this.Name.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchemaCustom.cs
+++ b/src/Okta.Sdk/Model/GroupSchemaCustom.cs
@@ -66,6 +66,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -77,6 +83,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -133,7 +140,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -160,6 +168,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/GroupSchemaDefinitions.cs
+++ b/src/Okta.Sdk/Model/GroupSchemaDefinitions.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public GroupSchemaCustom Custom { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class GroupSchemaDefinitions {\n");
             sb.Append("  Base: ").Append(Base).Append("\n");
             sb.Append("  Custom: ").Append(Custom).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Custom == input.Custom ||
                     (this.Custom != null &&
                     this.Custom.Equals(input.Custom))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Custom != null)
                 {
                     hashCode = (hashCode * 59) + this.Custom.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/HardwareUserFactor.cs
+++ b/src/Okta.Sdk/Model/HardwareUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public HardwareUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class HardwareUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/HardwareUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/HardwareUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class HardwareUserFactorProfile {\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/HostedPage.cs
+++ b/src/Okta.Sdk/Model/HostedPage.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="HostedPage" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HostedPage() { }
+        public HostedPage()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets Type
@@ -51,6 +54,12 @@ namespace Okta.Sdk.Model
         public string Url { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class HostedPage {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -104,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/HrefObject.cs
+++ b/src/Okta.Sdk/Model/HrefObject.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Href { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class HrefObject {\n");
             sb.Append("  Hints: ").Append(Hints).Append("\n");
             sb.Append("  Href: ").Append(Href).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Href == input.Href ||
                     (this.Href != null &&
                     this.Href.Equals(input.Href))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Href != null)
                 {
                     hashCode = (hashCode * 59) + this.Href.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/HrefObjectHints.cs
+++ b/src/Okta.Sdk/Model/HrefObjectHints.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Allow { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class HrefObjectHints {\n");
             sb.Append("  Allow: ").Append(Allow).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Allow != null &&
                     input.Allow != null &&
                     this.Allow.SequenceEqual(input.Allow)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Allow != null)
                 {
                     hashCode = (hashCode * 59) + this.Allow.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProvider.cs
+++ b/src/Okta.Sdk/Model/IdentityProvider.cs
@@ -126,6 +126,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -143,6 +149,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -228,7 +235,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -279,6 +287,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderApplicationUser.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderApplicationUser.cs
@@ -100,6 +100,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -114,6 +120,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Profile: ").Append(Profile).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -186,7 +193,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -225,6 +233,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderCredentials.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderCredentials.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public IdentityProviderCredentialsTrust Trust { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  _Client: ").Append(_Client).Append("\n");
             sb.Append("  Signing: ").Append(Signing).Append("\n");
             sb.Append("  Trust: ").Append(Trust).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Trust == input.Trust ||
                     (this.Trust != null &&
                     this.Trust.Equals(input.Trust))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Trust != null)
                 {
                     hashCode = (hashCode * 59) + this.Trust.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderCredentialsClient.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderCredentialsClient.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string ClientSecret { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class IdentityProviderCredentialsClient {\n");
             sb.Append("  ClientId: ").Append(ClientId).Append("\n");
             sb.Append("  ClientSecret: ").Append(ClientSecret).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.ClientSecret == input.ClientSecret ||
                     (this.ClientSecret != null &&
                     this.ClientSecret.Equals(input.ClientSecret))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.ClientSecret != null)
                 {
                     hashCode = (hashCode * 59) + this.ClientSecret.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderCredentialsSigning.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderCredentialsSigning.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Kid { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class IdentityProviderCredentialsSigning {\n");
             sb.Append("  Kid: ").Append(Kid).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Kid == input.Kid ||
                     (this.Kid != null &&
                     this.Kid.Equals(input.Kid))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Kid != null)
                 {
                     hashCode = (hashCode * 59) + this.Kid.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderCredentialsTrust.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderCredentialsTrust.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public int RevocationCacheLifetime { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Kid: ").Append(Kid).Append("\n");
             sb.Append("  Revocation: ").Append(Revocation).Append("\n");
             sb.Append("  RevocationCacheLifetime: ").Append(RevocationCacheLifetime).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -134,7 +141,8 @@ namespace Okta.Sdk.Model
                 (
                     this.RevocationCacheLifetime == input.RevocationCacheLifetime ||
                     this.RevocationCacheLifetime.Equals(input.RevocationCacheLifetime)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -163,6 +171,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Revocation.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.RevocationCacheLifetime.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/IdentityProviderPolicy.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderPolicy.cs
@@ -73,6 +73,12 @@ namespace Okta.Sdk.Model
         public PolicySubject Subject { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -86,6 +92,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MaxClockSkew: ").Append(MaxClockSkew).Append("\n");
             sb.Append("  Provisioning: ").Append(Provisioning).Append("\n");
             sb.Append("  Subject: ").Append(Subject).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -144,7 +151,8 @@ namespace Okta.Sdk.Model
                     this.Subject == input.Subject ||
                     (this.Subject != null &&
                     this.Subject.Equals(input.Subject))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -172,6 +180,10 @@ namespace Okta.Sdk.Model
                 if (this.Subject != null)
                 {
                     hashCode = (hashCode * 59) + this.Subject.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdentityProviderPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Provider { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class IdentityProviderPolicyRuleCondition {\n");
             sb.Append("  IdpIds: ").Append(IdpIds).Append("\n");
             sb.Append("  Provider: ").Append(Provider).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Provider == input.Provider ||
                     (this.Provider != null &&
                     this.Provider.Equals(input.Provider))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Provider != null)
                 {
                     hashCode = (hashCode * 59) + this.Provider.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdpPolicyRuleAction.cs
+++ b/src/Okta.Sdk/Model/IdpPolicyRuleAction.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<IdpPolicyRuleActionProvider> Providers { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class IdpPolicyRuleAction {\n");
             sb.Append("  Providers: ").Append(Providers).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Providers != null &&
                     input.Providers != null &&
                     this.Providers.SequenceEqual(input.Providers)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Providers != null)
                 {
                     hashCode = (hashCode * 59) + this.Providers.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/IdpPolicyRuleActionProvider.cs
+++ b/src/Okta.Sdk/Model/IdpPolicyRuleActionProvider.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class IdpPolicyRuleActionProvider {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ImageUploadResponse.cs
+++ b/src/Okta.Sdk/Model/ImageUploadResponse.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ImageUploadResponse {\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -95,7 +102,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -110,6 +118,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InactivityPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/InactivityPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Unit { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class InactivityPolicyRuleCondition {\n");
             sb.Append("  Number: ").Append(Number).Append("\n");
             sb.Append("  Unit: ").Append(Unit).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Unit == input.Unit ||
                     (this.Unit != null &&
                     this.Unit.Equals(input.Unit))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Unit != null)
                 {
                     hashCode = (hashCode * 59) + this.Unit.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHook.cs
+++ b/src/Okta.Sdk/Model/InlineHook.cs
@@ -120,6 +120,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -136,6 +142,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -216,7 +223,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -263,6 +271,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookChannel.cs
+++ b/src/Okta.Sdk/Model/InlineHookChannel.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string _Version { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Config: ").Append(Config).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookChannelConfig.cs
+++ b/src/Okta.Sdk/Model/InlineHookChannelConfig.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Uri { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Headers: ").Append(Headers).Append("\n");
             sb.Append("  Method: ").Append(Method).Append("\n");
             sb.Append("  Uri: ").Append(Uri).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -124,7 +131,8 @@ namespace Okta.Sdk.Model
                     this.Uri == input.Uri ||
                     (this.Uri != null &&
                     this.Uri.Equals(input.Uri))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -151,6 +159,10 @@ namespace Okta.Sdk.Model
                 if (this.Uri != null)
                 {
                     hashCode = (hashCode * 59) + this.Uri.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookChannelConfigAuthScheme.cs
+++ b/src/Okta.Sdk/Model/InlineHookChannelConfigAuthScheme.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Key: ").Append(Key).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookChannelConfigHeaders.cs
+++ b/src/Okta.Sdk/Model/InlineHookChannelConfigHeaders.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class InlineHookChannelConfigHeaders {\n");
             sb.Append("  Key: ").Append(Key).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookResponse.cs
+++ b/src/Okta.Sdk/Model/InlineHookResponse.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<InlineHookResponseCommands> Commands { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class InlineHookResponse {\n");
             sb.Append("  Commands: ").Append(Commands).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Commands != null &&
                     input.Commands != null &&
                     this.Commands.SequenceEqual(input.Commands)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Commands != null)
                 {
                     hashCode = (hashCode * 59) + this.Commands.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookResponseCommandValue.cs
+++ b/src/Okta.Sdk/Model/InlineHookResponseCommandValue.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Op: ").Append(Op).Append("\n");
             sb.Append("  Path: ").Append(Path).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/InlineHookResponseCommands.cs
+++ b/src/Okta.Sdk/Model/InlineHookResponseCommands.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<InlineHookResponseCommandValue> Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class InlineHookResponseCommands {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Value != null &&
                     input.Value != null &&
                     this.Value.SequenceEqual(input.Value)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/JsonWebKey.cs
+++ b/src/Okta.Sdk/Model/JsonWebKey.cs
@@ -138,6 +138,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -161,6 +167,7 @@ namespace Okta.Sdk.Model
             sb.Append("  X5tS256: ").Append(X5tS256).Append("\n");
             sb.Append("  X5u: ").Append(X5u).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -278,7 +285,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -353,6 +361,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/JwkUse.cs
+++ b/src/Okta.Sdk/Model/JwkUse.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Use { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class JwkUse {\n");
             sb.Append("  Use: ").Append(Use).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Use == input.Use ||
                     (this.Use != null &&
                     this.Use.Equals(input.Use))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Use != null)
                 {
                     hashCode = (hashCode * 59) + this.Use.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/KnowledgeConstraint.cs
+++ b/src/Okta.Sdk/Model/KnowledgeConstraint.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public List<string> Types { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Methods: ").Append(Methods).Append("\n");
             sb.Append("  ReauthenticateIn: ").Append(ReauthenticateIn).Append("\n");
             sb.Append("  Types: ").Append(Types).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                     this.Types != null &&
                     input.Types != null &&
                     this.Types.SequenceEqual(input.Types)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -136,6 +144,10 @@ namespace Okta.Sdk.Model
                 if (this.Types != null)
                 {
                     hashCode = (hashCode * 59) + this.Types.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LifecycleCreateSettingObject.cs
+++ b/src/Okta.Sdk/Model/LifecycleCreateSettingObject.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class LifecycleCreateSettingObject {\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LifecycleDeactivateSettingObject.cs
+++ b/src/Okta.Sdk/Model/LifecycleDeactivateSettingObject.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class LifecycleDeactivateSettingObject {\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LifecycleExpirationPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/LifecycleExpirationPolicyRuleCondition.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Unit { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  LifecycleStatus: ").Append(LifecycleStatus).Append("\n");
             sb.Append("  Number: ").Append(Number).Append("\n");
             sb.Append("  Unit: ").Append(Unit).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -110,7 +117,8 @@ namespace Okta.Sdk.Model
                     this.Unit == input.Unit ||
                     (this.Unit != null &&
                     this.Unit.Equals(input.Unit))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -130,6 +138,10 @@ namespace Okta.Sdk.Model
                 if (this.Unit != null)
                 {
                     hashCode = (hashCode * 59) + this.Unit.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LinkedObject.cs
+++ b/src/Okta.Sdk/Model/LinkedObject.cs
@@ -60,6 +60,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -70,6 +76,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Associated: ").Append(Associated).Append("\n");
             sb.Append("  Primary: ").Append(Primary).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -120,7 +127,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -143,6 +151,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LinkedObjectDetails.cs
+++ b/src/Okta.Sdk/Model/LinkedObjectDetails.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Title: ").Append(Title).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogActor.cs
+++ b/src/Okta.Sdk/Model/LogActor.cs
@@ -104,6 +104,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -116,6 +122,7 @@ namespace Okta.Sdk.Model
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -176,7 +183,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -207,6 +215,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogAuthenticationContext.cs
+++ b/src/Okta.Sdk/Model/LogAuthenticationContext.cs
@@ -100,6 +100,12 @@ namespace Okta.Sdk.Model
         public LogIssuer Issuer { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -114,6 +120,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ExternalSessionId: ").Append(ExternalSessionId).Append("\n");
             sb.Append("  Interface: ").Append(Interface).Append("\n");
             sb.Append("  Issuer: ").Append(Issuer).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -182,7 +189,8 @@ namespace Okta.Sdk.Model
                     this.Issuer == input.Issuer ||
                     (this.Issuer != null &&
                     this.Issuer.Equals(input.Issuer))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -218,6 +226,10 @@ namespace Okta.Sdk.Model
                 if (this.Issuer != null)
                 {
                     hashCode = (hashCode * 59) + this.Issuer.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogClient.cs
+++ b/src/Okta.Sdk/Model/LogClient.cs
@@ -102,6 +102,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -115,6 +121,7 @@ namespace Okta.Sdk.Model
             sb.Append("  IpAddress: ").Append(IpAddress).Append("\n");
             sb.Append("  UserAgent: ").Append(UserAgent).Append("\n");
             sb.Append("  Zone: ").Append(Zone).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -179,7 +186,8 @@ namespace Okta.Sdk.Model
                     this.Zone == input.Zone ||
                     (this.Zone != null &&
                     this.Zone.Equals(input.Zone))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -214,6 +222,10 @@ namespace Okta.Sdk.Model
                 if (this.Zone != null)
                 {
                     hashCode = (hashCode * 59) + this.Zone.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogDebugContext.cs
+++ b/src/Okta.Sdk/Model/LogDebugContext.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class LogDebugContext {\n");
             sb.Append("  DebugData: ").Append(DebugData).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -96,7 +103,8 @@ namespace Okta.Sdk.Model
                     this.DebugData != null &&
                     input.DebugData != null &&
                     this.DebugData.SequenceEqual(input.DebugData)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 if (this.DebugData != null)
                 {
                     hashCode = (hashCode * 59) + this.DebugData.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogEvent.cs
+++ b/src/Okta.Sdk/Model/LogEvent.cs
@@ -186,6 +186,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -209,6 +215,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Transaction: ").Append(Transaction).Append("\n");
             sb.Append("  Uuid: ").Append(Uuid).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -324,7 +331,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -399,6 +407,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogGeographicalContext.cs
+++ b/src/Okta.Sdk/Model/LogGeographicalContext.cs
@@ -96,6 +96,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -108,6 +114,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Geolocation: ").Append(Geolocation).Append("\n");
             sb.Append("  PostalCode: ").Append(PostalCode).Append("\n");
             sb.Append("  State: ").Append(State).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -167,7 +174,8 @@ namespace Okta.Sdk.Model
                     this.State == input.State ||
                     (this.State != null &&
                     this.State.Equals(input.State))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -198,6 +206,10 @@ namespace Okta.Sdk.Model
                 if (this.State != null)
                 {
                     hashCode = (hashCode * 59) + this.State.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogGeolocation.cs
+++ b/src/Okta.Sdk/Model/LogGeolocation.cs
@@ -62,6 +62,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("class LogGeolocation {\n");
             sb.Append("  Lat: ").Append(Lat).Append("\n");
             sb.Append("  Lon: ").Append(Lon).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Lon == input.Lon ||
                     this.Lon.Equals(input.Lon)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -127,6 +135,10 @@ namespace Okta.Sdk.Model
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.Lat.GetHashCode();
                 hashCode = (hashCode * 59) + this.Lon.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/LogIpAddress.cs
+++ b/src/Okta.Sdk/Model/LogIpAddress.cs
@@ -82,6 +82,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -93,6 +99,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Ip: ").Append(Ip).Append("\n");
             sb.Append("  Source: ").Append(Source).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -174,6 +182,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogIssuer.cs
+++ b/src/Okta.Sdk/Model/LogIssuer.cs
@@ -62,6 +62,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("class LogIssuer {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -115,7 +122,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogOutcome.cs
+++ b/src/Okta.Sdk/Model/LogOutcome.cs
@@ -62,6 +62,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("class LogOutcome {\n");
             sb.Append("  Reason: ").Append(Reason).Append("\n");
             sb.Append("  Result: ").Append(Result).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -115,7 +122,8 @@ namespace Okta.Sdk.Model
                     this.Result == input.Result ||
                     (this.Result != null &&
                     this.Result.Equals(input.Result))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Result != null)
                 {
                     hashCode = (hashCode * 59) + this.Result.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogRequest.cs
+++ b/src/Okta.Sdk/Model/LogRequest.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class LogRequest {\n");
             sb.Append("  IpChain: ").Append(IpChain).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -96,7 +103,8 @@ namespace Okta.Sdk.Model
                     this.IpChain != null &&
                     input.IpChain != null &&
                     this.IpChain.SequenceEqual(input.IpChain)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -111,6 +119,10 @@ namespace Okta.Sdk.Model
                 if (this.IpChain != null)
                 {
                     hashCode = (hashCode * 59) + this.IpChain.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogSecurityContext.cs
+++ b/src/Okta.Sdk/Model/LogSecurityContext.cs
@@ -104,6 +104,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -116,6 +122,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Domain: ").Append(Domain).Append("\n");
             sb.Append("  Isp: ").Append(Isp).Append("\n");
             sb.Append("  IsProxy: ").Append(IsProxy).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -173,7 +180,8 @@ namespace Okta.Sdk.Model
                 (
                     this.IsProxy == input.IsProxy ||
                     this.IsProxy.Equals(input.IsProxy)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -199,6 +207,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Isp.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.IsProxy.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/LogTarget.cs
+++ b/src/Okta.Sdk/Model/LogTarget.cs
@@ -104,6 +104,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -116,6 +122,7 @@ namespace Okta.Sdk.Model
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -176,7 +183,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -207,6 +215,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogTransaction.cs
+++ b/src/Okta.Sdk/Model/LogTransaction.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -86,6 +92,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Detail: ").Append(Detail).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -136,7 +143,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -159,6 +167,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/LogUserAgent.cs
+++ b/src/Okta.Sdk/Model/LogUserAgent.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -86,6 +92,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Browser: ").Append(Browser).Append("\n");
             sb.Append("  Os: ").Append(Os).Append("\n");
             sb.Append("  RawUserAgent: ").Append(RawUserAgent).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -135,7 +142,8 @@ namespace Okta.Sdk.Model
                     this.RawUserAgent == input.RawUserAgent ||
                     (this.RawUserAgent != null &&
                     this.RawUserAgent.Equals(input.RawUserAgent))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -158,6 +166,10 @@ namespace Okta.Sdk.Model
                 if (this.RawUserAgent != null)
                 {
                     hashCode = (hashCode * 59) + this.RawUserAgent.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/MDMEnrollmentPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/MDMEnrollmentPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Enrollment { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class MDMEnrollmentPolicyRuleCondition {\n");
             sb.Append("  BlockNonSafeAndroid: ").Append(BlockNonSafeAndroid).Append("\n");
             sb.Append("  Enrollment: ").Append(Enrollment).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Enrollment == input.Enrollment ||
                     (this.Enrollment != null &&
                     this.Enrollment.Equals(input.Enrollment))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Enrollment != null)
                 {
                     hashCode = (hashCode * 59) + this.Enrollment.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/MultifactorEnrollmentPolicy.cs
+++ b/src/Okta.Sdk/Model/MultifactorEnrollmentPolicy.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public MultifactorEnrollmentPolicySettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -65,6 +71,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -109,7 +116,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -128,6 +136,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/MultifactorEnrollmentPolicyAuthenticatorSettings.cs
+++ b/src/Okta.Sdk/Model/MultifactorEnrollmentPolicyAuthenticatorSettings.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Key { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class MultifactorEnrollmentPolicyAuthenticatorSettings {\n");
             sb.Append("  Enroll: ").Append(Enroll).Append("\n");
             sb.Append("  Key: ").Append(Key).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Key == input.Key ||
                     (this.Key != null &&
                     this.Key.Equals(input.Key))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Key != null)
                 {
                     hashCode = (hashCode * 59) + this.Key.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/MultifactorEnrollmentPolicyAuthenticatorSettingsEnroll.cs
+++ b/src/Okta.Sdk/Model/MultifactorEnrollmentPolicyAuthenticatorSettingsEnroll.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Self { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class MultifactorEnrollmentPolicyAuthenticatorSettingsEnroll {\n");
             sb.Append("  Self: ").Append(Self).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Self == input.Self ||
                     (this.Self != null &&
                     this.Self.Equals(input.Self))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Self != null)
                 {
                     hashCode = (hashCode * 59) + this.Self.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/MultifactorEnrollmentPolicySettings.cs
+++ b/src/Okta.Sdk/Model/MultifactorEnrollmentPolicySettings.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class MultifactorEnrollmentPolicySettings {\n");
             sb.Append("  Authenticators: ").Append(Authenticators).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/NetworkZone.cs
+++ b/src/Okta.Sdk/Model/NetworkZone.cs
@@ -150,6 +150,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -171,6 +177,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Usage: ").Append(Usage).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -279,7 +286,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -343,6 +351,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/NetworkZoneAddress.cs
+++ b/src/Okta.Sdk/Model/NetworkZoneAddress.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class NetworkZoneAddress {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/NetworkZoneLocation.cs
+++ b/src/Okta.Sdk/Model/NetworkZoneLocation.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Region { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class NetworkZoneLocation {\n");
             sb.Append("  Country: ").Append(Country).Append("\n");
             sb.Append("  Region: ").Append(Region).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Region == input.Region ||
                     (this.Region != null &&
                     this.Region.Equals(input.Region))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Region != null)
                 {
                     hashCode = (hashCode * 59) + this.Region.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2Actor.cs
+++ b/src/Okta.Sdk/Model/OAuth2Actor.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OAuth2Actor {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2Claim.cs
+++ b/src/Okta.Sdk/Model/OAuth2Claim.cs
@@ -116,6 +116,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -134,6 +140,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("  ValueType: ").Append(ValueType).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -222,7 +229,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -271,6 +279,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2ClaimConditions.cs
+++ b/src/Okta.Sdk/Model/OAuth2ClaimConditions.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Scopes { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class OAuth2ClaimConditions {\n");
             sb.Append("  Scopes: ").Append(Scopes).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Scopes != null &&
                     input.Scopes != null &&
                     this.Scopes.SequenceEqual(input.Scopes)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Scopes != null)
                 {
                     hashCode = (hashCode * 59) + this.Scopes.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2Client.cs
+++ b/src/Okta.Sdk/Model/OAuth2Client.cs
@@ -104,6 +104,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -116,6 +122,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ClientUri: ").Append(ClientUri).Append("\n");
             sb.Append("  LogoUri: ").Append(LogoUri).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -176,7 +183,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -207,6 +215,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2RefreshToken.cs
+++ b/src/Okta.Sdk/Model/OAuth2RefreshToken.cs
@@ -154,6 +154,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -173,6 +179,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -270,7 +277,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -329,6 +337,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2Scope.cs
+++ b/src/Okta.Sdk/Model/OAuth2Scope.cs
@@ -90,6 +90,12 @@ namespace Okta.Sdk.Model
         public bool System { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -105,6 +111,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MetadataPublish: ").Append(MetadataPublish).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  System: ").Append(System).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -177,7 +184,8 @@ namespace Okta.Sdk.Model
                 (
                     this.System == input.System ||
                     this.System.Equals(input.System)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -215,6 +223,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Name.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.System.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/OAuth2ScopeConsentGrant.cs
+++ b/src/Okta.Sdk/Model/OAuth2ScopeConsentGrant.cs
@@ -146,6 +146,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -165,6 +171,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -261,7 +268,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -320,6 +328,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2ScopesMediationPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/OAuth2ScopesMediationPolicyRuleCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class OAuth2ScopesMediationPolicyRuleCondition {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuth2Token.cs
+++ b/src/Okta.Sdk/Model/OAuth2Token.cs
@@ -148,6 +148,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -166,6 +172,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -258,7 +265,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -313,6 +321,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OAuthApplicationCredentials.cs
+++ b/src/Okta.Sdk/Model/OAuthApplicationCredentials.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public ApplicationCredentialsOAuthClient OauthClient { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Signing: ").Append(Signing).Append("\n");
             sb.Append("  UserNameTemplate: ").Append(UserNameTemplate).Append("\n");
             sb.Append("  OauthClient: ").Append(OauthClient).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.OauthClient == input.OauthClient ||
                     (this.OauthClient != null &&
                     this.OauthClient.Equals(input.OauthClient))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.OauthClient != null)
                 {
                     hashCode = (hashCode * 59) + this.OauthClient.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicy.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicy.cs
@@ -49,6 +49,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -58,6 +64,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OktaSignOnPolicy {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -112,6 +120,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyConditions.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyRule.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyRule.cs
@@ -53,6 +53,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Actions: ").Append(Actions).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyRuleActions.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyRuleSignonActions Signon { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServicePasswordReset: ").Append(SelfServicePasswordReset).Append("\n");
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this.Signon == input.Signon ||
                     (this.Signon != null &&
                     this.Signon.Equals(input.Signon))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Signon != null)
                 {
                     hashCode = (hashCode * 59) + this.Signon.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyRuleConditions.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyRuleConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyRuleSignonActions.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyRuleSignonActions.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyRuleSignonSessionActions Session { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  RememberDeviceByDefault: ").Append(RememberDeviceByDefault).Append("\n");
             sb.Append("  RequireFactor: ").Append(RequireFactor).Append("\n");
             sb.Append("  Session: ").Append(Session).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -144,7 +151,8 @@ namespace Okta.Sdk.Model
                     this.Session == input.Session ||
                     (this.Session != null &&
                     this.Session.Equals(input.Session))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -170,6 +178,10 @@ namespace Okta.Sdk.Model
                 if (this.Session != null)
                 {
                     hashCode = (hashCode * 59) + this.Session.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OktaSignOnPolicyRuleSignonSessionActions.cs
+++ b/src/Okta.Sdk/Model/OktaSignOnPolicyRuleSignonSessionActions.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public bool UsePersistentCookie { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MaxSessionIdleMinutes: ").Append(MaxSessionIdleMinutes).Append("\n");
             sb.Append("  MaxSessionLifetimeMinutes: ").Append(MaxSessionLifetimeMinutes).Append("\n");
             sb.Append("  UsePersistentCookie: ").Append(UsePersistentCookie).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -108,7 +115,8 @@ namespace Okta.Sdk.Model
                 (
                     this.UsePersistentCookie == input.UsePersistentCookie ||
                     this.UsePersistentCookie.Equals(input.UsePersistentCookie)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +131,10 @@ namespace Okta.Sdk.Model
                 hashCode = (hashCode * 59) + this.MaxSessionIdleMinutes.GetHashCode();
                 hashCode = (hashCode * 59) + this.MaxSessionLifetimeMinutes.GetHashCode();
                 hashCode = (hashCode * 59) + this.UsePersistentCookie.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplication.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public OpenIdConnectApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplicationIdpInitiatedLogin.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplicationIdpInitiatedLogin.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Mode { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OpenIdConnectApplicationIdpInitiatedLogin {\n");
             sb.Append("  DefaultScope: ").Append(DefaultScope).Append("\n");
             sb.Append("  Mode: ").Append(Mode).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Mode == input.Mode ||
                     (this.Mode != null &&
                     this.Mode.Equals(input.Mode))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Mode != null)
                 {
                     hashCode = (hashCode * 59) + this.Mode.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public OpenIdConnectApplicationSettingsClient OauthClient { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  OauthClient: ").Append(OauthClient).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.OauthClient == input.OauthClient ||
                     (this.OauthClient != null &&
                     this.OauthClient.Equals(input.OauthClient))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.OauthClient != null)
                 {
                     hashCode = (hashCode * 59) + this.OauthClient.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsClient.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsClient.cs
@@ -130,6 +130,12 @@ namespace Okta.Sdk.Model
         public string WildcardRedirect { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -153,6 +159,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ResponseTypes: ").Append(ResponseTypes).Append("\n");
             sb.Append("  TosUri: ").Append(TosUri).Append("\n");
             sb.Append("  WildcardRedirect: ").Append(WildcardRedirect).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -271,7 +278,8 @@ namespace Okta.Sdk.Model
                     this.WildcardRedirect == input.WildcardRedirect ||
                     (this.WildcardRedirect != null &&
                     this.WildcardRedirect.Equals(input.WildcardRedirect))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -346,6 +354,10 @@ namespace Okta.Sdk.Model
                 if (this.WildcardRedirect != null)
                 {
                     hashCode = (hashCode * 59) + this.WildcardRedirect.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsClientKeys.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsClientKeys.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<JsonWebKey> Keys { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class OpenIdConnectApplicationSettingsClientKeys {\n");
             sb.Append("  Keys: ").Append(Keys).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Keys != null &&
                     input.Keys != null &&
                     this.Keys.SequenceEqual(input.Keys)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Keys != null)
                 {
                     hashCode = (hashCode * 59) + this.Keys.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsRefreshToken.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplicationSettingsRefreshToken.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string RotationType { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OpenIdConnectApplicationSettingsRefreshToken {\n");
             sb.Append("  Leeway: ").Append(Leeway).Append("\n");
             sb.Append("  RotationType: ").Append(RotationType).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.RotationType == input.RotationType ||
                     (this.RotationType != null &&
                     this.RotationType.Equals(input.RotationType))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.RotationType != null)
                 {
                     hashCode = (hashCode * 59) + this.RotationType.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgContactTypeObj.cs
+++ b/src/Okta.Sdk/Model/OrgContactTypeObj.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public Dictionary<string, Object> Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OrgContactTypeObj {\n");
             sb.Append("  ContactType: ").Append(ContactType).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgContactUser.cs
+++ b/src/Okta.Sdk/Model/OrgContactUser.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OrgContactUser {\n");
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -108,7 +115,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -127,6 +135,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgOktaCommunicationSetting.cs
+++ b/src/Okta.Sdk/Model/OrgOktaCommunicationSetting.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
         public Dictionary<string, Object> Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OrgOktaCommunicationSetting {\n");
             sb.Append("  OptOutEmailUsers: ").Append(OptOutEmailUsers).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +131,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgOktaSupportSettingsObj.cs
+++ b/src/Okta.Sdk/Model/OrgOktaSupportSettingsObj.cs
@@ -60,6 +60,12 @@ namespace Okta.Sdk.Model
         public Dictionary<string, Object> Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -70,6 +76,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  Support: ").Append(Support).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -120,7 +127,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -143,6 +151,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgPreferences.cs
+++ b/src/Okta.Sdk/Model/OrgPreferences.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
         public Dictionary<string, Object> Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class OrgPreferences {\n");
             sb.Append("  ShowEndUserFooter: ").Append(ShowEndUserFooter).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +131,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/OrgSetting.cs
+++ b/src/Okta.Sdk/Model/OrgSetting.cs
@@ -190,6 +190,12 @@ namespace Okta.Sdk.Model
         public Dictionary<string, Object> Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -215,6 +221,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SupportPhoneNumber: ").Append(SupportPhoneNumber).Append("\n");
             sb.Append("  Website: ").Append(Website).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -340,7 +347,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -423,6 +431,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordCredential.cs
+++ b/src/Okta.Sdk/Model/PasswordCredential.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Hash: ").Append(Hash).Append("\n");
             sb.Append("  Hook: ").Append(Hook).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordCredentialHash.cs
+++ b/src/Okta.Sdk/Model/PasswordCredentialHash.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public int WorkFactor { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SaltOrder: ").Append(SaltOrder).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("  WorkFactor: ").Append(WorkFactor).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -134,7 +141,8 @@ namespace Okta.Sdk.Model
                 (
                     this.WorkFactor == input.WorkFactor ||
                     this.WorkFactor.Equals(input.WorkFactor)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -163,6 +171,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.WorkFactor.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordCredentialHook.cs
+++ b/src/Okta.Sdk/Model/PasswordCredentialHook.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordCredentialHook {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordDictionary.cs
+++ b/src/Okta.Sdk/Model/PasswordDictionary.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PasswordDictionaryCommon Common { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordDictionary {\n");
             sb.Append("  Common: ").Append(Common).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Common == input.Common ||
                     (this.Common != null &&
                     this.Common.Equals(input.Common))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Common != null)
                 {
                     hashCode = (hashCode * 59) + this.Common.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordDictionaryCommon.cs
+++ b/src/Okta.Sdk/Model/PasswordDictionaryCommon.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public bool Exclude { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordDictionaryCommon {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -86,7 +93,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Exclude == input.Exclude ||
                     this.Exclude.Equals(input.Exclude)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -99,6 +107,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.Exclude.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordExpirationPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/PasswordExpirationPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Unit { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PasswordExpirationPolicyRuleCondition {\n");
             sb.Append("  Number: ").Append(Number).Append("\n");
             sb.Append("  Unit: ").Append(Unit).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -98,7 +105,8 @@ namespace Okta.Sdk.Model
                     this.Unit == input.Unit ||
                     (this.Unit != null &&
                     this.Unit.Equals(input.Unit))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -114,6 +122,10 @@ namespace Okta.Sdk.Model
                 if (this.Unit != null)
                 {
                     hashCode = (hashCode * 59) + this.Unit.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicy.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicy.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicySettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -65,6 +71,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -109,7 +116,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -128,6 +136,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyAuthenticationProviderCondition.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyAuthenticationProviderCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Provider { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PasswordPolicyAuthenticationProviderCondition {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
             sb.Append("  Provider: ").Append(Provider).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Provider == input.Provider ||
                     (this.Provider != null &&
                     this.Provider.Equals(input.Provider))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Provider != null)
                 {
                     hashCode = (hashCode * 59) + this.Provider.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyConditions.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyDelegationSettings.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyDelegationSettings.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyDelegationSettingsOptions Options { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyDelegationSettings {\n");
             sb.Append("  Options: ").Append(Options).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Options == input.Options ||
                     (this.Options != null &&
                     this.Options.Equals(input.Options))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Options != null)
                 {
                     hashCode = (hashCode * 59) + this.Options.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyDelegationSettingsOptions.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyDelegationSettingsOptions.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public bool SkipUnlock { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyDelegationSettingsOptions {\n");
             sb.Append("  SkipUnlock: ").Append(SkipUnlock).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -86,7 +93,8 @@ namespace Okta.Sdk.Model
                 (
                     this.SkipUnlock == input.SkipUnlock ||
                     this.SkipUnlock.Equals(input.SkipUnlock)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -99,6 +107,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.SkipUnlock.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordPolicyPasswordSettings.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyPasswordSettings.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyPasswordSettingsLockout Lockout { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Age: ").Append(Age).Append("\n");
             sb.Append("  Complexity: ").Append(Complexity).Append("\n");
             sb.Append("  Lockout: ").Append(Lockout).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Lockout == input.Lockout ||
                     (this.Lockout != null &&
                     this.Lockout.Equals(input.Lockout))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Lockout != null)
                 {
                     hashCode = (hashCode * 59) + this.Lockout.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsAge.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsAge.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public int MinAgeMinutes { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  HistoryCount: ").Append(HistoryCount).Append("\n");
             sb.Append("  MaxAgeDays: ").Append(MaxAgeDays).Append("\n");
             sb.Append("  MinAgeMinutes: ").Append(MinAgeMinutes).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -119,7 +126,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinAgeMinutes == input.MinAgeMinutes ||
                     this.MinAgeMinutes.Equals(input.MinAgeMinutes)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -135,6 +143,10 @@ namespace Okta.Sdk.Model
                 hashCode = (hashCode * 59) + this.HistoryCount.GetHashCode();
                 hashCode = (hashCode * 59) + this.MaxAgeDays.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinAgeMinutes.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsComplexity.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsComplexity.cs
@@ -82,6 +82,12 @@ namespace Okta.Sdk.Model
         public int MinUpperCase { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -97,6 +103,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MinNumber: ").Append(MinNumber).Append("\n");
             sb.Append("  MinSymbol: ").Append(MinSymbol).Append("\n");
             sb.Append("  MinUpperCase: ").Append(MinUpperCase).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -166,7 +173,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinUpperCase == input.MinUpperCase ||
                     this.MinUpperCase.Equals(input.MinUpperCase)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -192,6 +200,10 @@ namespace Okta.Sdk.Model
                 hashCode = (hashCode * 59) + this.MinNumber.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinSymbol.GetHashCode();
                 hashCode = (hashCode * 59) + this.MinUpperCase.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsLockout.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyPasswordSettingsLockout.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public List<string> UserLockoutNotificationChannels { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MaxAttempts: ").Append(MaxAttempts).Append("\n");
             sb.Append("  ShowLockoutFailures: ").Append(ShowLockoutFailures).Append("\n");
             sb.Append("  UserLockoutNotificationChannels: ").Append(UserLockoutNotificationChannels).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -121,7 +128,8 @@ namespace Okta.Sdk.Model
                     this.UserLockoutNotificationChannels != null &&
                     input.UserLockoutNotificationChannels != null &&
                     this.UserLockoutNotificationChannels.SequenceEqual(input.UserLockoutNotificationChannels)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -139,6 +147,10 @@ namespace Okta.Sdk.Model
                 if (this.UserLockoutNotificationChannels != null)
                 {
                     hashCode = (hashCode * 59) + this.UserLockoutNotificationChannels.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmail.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmail.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PasswordPolicyRecoveryEmail {\n");
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmailProperties.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmailProperties.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRecoveryEmailRecoveryToken RecoveryToken { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoveryEmailProperties {\n");
             sb.Append("  RecoveryToken: ").Append(RecoveryToken).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.RecoveryToken == input.RecoveryToken ||
                     (this.RecoveryToken != null &&
                     this.RecoveryToken.Equals(input.RecoveryToken))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.RecoveryToken != null)
                 {
                     hashCode = (hashCode * 59) + this.RecoveryToken.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmailRecoveryToken.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryEmailRecoveryToken.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public int TokenLifetimeMinutes { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoveryEmailRecoveryToken {\n");
             sb.Append("  TokenLifetimeMinutes: ").Append(TokenLifetimeMinutes).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -86,7 +93,8 @@ namespace Okta.Sdk.Model
                 (
                     this.TokenLifetimeMinutes == input.TokenLifetimeMinutes ||
                     this.TokenLifetimeMinutes.Equals(input.TokenLifetimeMinutes)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -99,6 +107,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.TokenLifetimeMinutes.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryFactorSettings.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryFactorSettings.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoveryFactorSettings {\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryFactors.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryFactors.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRecoveryQuestion RecoveryQuestion { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  OktaEmail: ").Append(OktaEmail).Append("\n");
             sb.Append("  OktaSms: ").Append(OktaSms).Append("\n");
             sb.Append("  RecoveryQuestion: ").Append(RecoveryQuestion).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.RecoveryQuestion == input.RecoveryQuestion ||
                     (this.RecoveryQuestion != null &&
                     this.RecoveryQuestion.Equals(input.RecoveryQuestion))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.RecoveryQuestion != null)
                 {
                     hashCode = (hashCode * 59) + this.RecoveryQuestion.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestion.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestion.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PasswordPolicyRecoveryQuestion {\n");
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestionComplexity.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestionComplexity.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoveryQuestionComplexity {\n");
             sb.Append("  MinLength: ").Append(MinLength).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -94,7 +101,8 @@ namespace Okta.Sdk.Model
                 (
                     this.MinLength == input.MinLength ||
                     this.MinLength.Equals(input.MinLength)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -107,6 +115,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.MinLength.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestionProperties.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoveryQuestionProperties.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRecoveryQuestionComplexity Complexity { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoveryQuestionProperties {\n");
             sb.Append("  Complexity: ").Append(Complexity).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Complexity == input.Complexity ||
                     (this.Complexity != null &&
                     this.Complexity.Equals(input.Complexity))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Complexity != null)
                 {
                     hashCode = (hashCode * 59) + this.Complexity.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRecoverySettings.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRecoverySettings.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRecoveryFactors Factors { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRecoverySettings {\n");
             sb.Append("  Factors: ").Append(Factors).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Factors == input.Factors ||
                     (this.Factors != null &&
                     this.Factors.Equals(input.Factors))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Factors != null)
                 {
                     hashCode = (hashCode * 59) + this.Factors.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRule.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRule.cs
@@ -53,6 +53,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Actions: ").Append(Actions).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRuleAction.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRuleAction.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Access { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PasswordPolicyRuleAction {\n");
             sb.Append("  Access: ").Append(Access).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Access == input.Access ||
                     (this.Access != null &&
                     this.Access.Equals(input.Access))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Access != null)
                 {
                     hashCode = (hashCode * 59) + this.Access.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRuleActions.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyRuleSignonActions Signon { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServicePasswordReset: ").Append(SelfServicePasswordReset).Append("\n");
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this.Signon == input.Signon ||
                     (this.Signon != null &&
                     this.Signon.Equals(input.Signon))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Signon != null)
                 {
                     hashCode = (hashCode * 59) + this.Signon.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicyRuleConditions.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicyRuleConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordPolicySettings.cs
+++ b/src/Okta.Sdk/Model/PasswordPolicySettings.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public PasswordPolicyRecoverySettings Recovery { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Delegation: ").Append(Delegation).Append("\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
             sb.Append("  Recovery: ").Append(Recovery).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Recovery == input.Recovery ||
                     (this.Recovery != null &&
                     this.Recovery.Equals(input.Recovery))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Recovery != null)
                 {
                     hashCode = (hashCode * 59) + this.Recovery.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PasswordSettingObject.cs
+++ b/src/Okta.Sdk/Model/PasswordSettingObject.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Change: ").Append(Change).Append("\n");
             sb.Append("  Seed: ").Append(Seed).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatform.cs
+++ b/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatform.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PlatformConditionEvaluatorPlatform {\n");
             sb.Append("  Os: ").Append(Os).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatformOperatingSystem.cs
+++ b/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatformOperatingSystem.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public PlatformConditionEvaluatorPlatformOperatingSystemVersion _Version { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Expression: ").Append(Expression).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatformOperatingSystemVersion.cs
+++ b/src/Okta.Sdk/Model/PlatformConditionEvaluatorPlatformOperatingSystemVersion.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PlatformConditionEvaluatorPlatformOperatingSystemVersion {\n");
             sb.Append("  MatchType: ").Append(MatchType).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PlatformPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/PlatformPolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<PlatformConditionEvaluatorPlatform> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PlatformPolicyRuleCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Policy.cs
+++ b/src/Okta.Sdk/Model/Policy.cs
@@ -156,6 +156,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -174,6 +180,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -263,7 +270,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -312,6 +320,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyAccountLink.cs
+++ b/src/Okta.Sdk/Model/PolicyAccountLink.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public PolicyAccountLinkFilter Filter { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PolicyAccountLink {\n");
             sb.Append("  Action: ").Append(Action).Append("\n");
             sb.Append("  Filter: ").Append(Filter).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Filter == input.Filter ||
                     (this.Filter != null &&
                     this.Filter.Equals(input.Filter))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Filter != null)
                 {
                     hashCode = (hashCode * 59) + this.Filter.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyAccountLinkFilter.cs
+++ b/src/Okta.Sdk/Model/PolicyAccountLinkFilter.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public PolicyAccountLinkFilterGroups Groups { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PolicyAccountLinkFilter {\n");
             sb.Append("  Groups: ").Append(Groups).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Groups == input.Groups ||
                     (this.Groups != null &&
                     this.Groups.Equals(input.Groups))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Groups != null)
                 {
                     hashCode = (hashCode * 59) + this.Groups.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyAccountLinkFilterGroups.cs
+++ b/src/Okta.Sdk/Model/PolicyAccountLinkFilterGroups.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PolicyAccountLinkFilterGroups {\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyNetworkCondition.cs
+++ b/src/Okta.Sdk/Model/PolicyNetworkCondition.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Connection: ").Append(Connection).Append("\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -136,6 +144,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyPeopleCondition.cs
+++ b/src/Okta.Sdk/Model/PolicyPeopleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public UserCondition Users { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class PolicyPeopleCondition {\n");
             sb.Append("  Groups: ").Append(Groups).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Users == input.Users ||
                     (this.Users != null &&
                     this.Users.Equals(input.Users))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Users != null)
                 {
                     hashCode = (hashCode * 59) + this.Users.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyRule.cs
+++ b/src/Okta.Sdk/Model/PolicyRule.cs
@@ -110,6 +110,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -125,6 +131,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  System: ").Append(System).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -197,7 +204,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -234,6 +242,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/PolicyRuleActions.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public OktaSignOnPolicyRuleSignonActions Signon { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServicePasswordReset: ").Append(SelfServicePasswordReset).Append("\n");
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this.Signon == input.Signon ||
                     (this.Signon != null &&
                     this.Signon.Equals(input.Signon))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this.Signon != null)
                 {
                     hashCode = (hashCode * 59) + this.Signon.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyRuleActionsEnroll.cs
+++ b/src/Okta.Sdk/Model/PolicyRuleActionsEnroll.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Self { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PolicyRuleActionsEnroll {\n");
             sb.Append("  Self: ").Append(Self).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Self == input.Self ||
                     (this.Self != null &&
                     this.Self.Equals(input.Self))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Self != null)
                 {
                     hashCode = (hashCode * 59) + this.Self.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyRuleAuthContextCondition.cs
+++ b/src/Okta.Sdk/Model/PolicyRuleAuthContextCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string AuthType { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PolicyRuleAuthContextCondition {\n");
             sb.Append("  AuthType: ").Append(AuthType).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.AuthType == input.AuthType ||
                     (this.AuthType != null &&
                     this.AuthType.Equals(input.AuthType))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.AuthType != null)
                 {
                     hashCode = (hashCode * 59) + this.AuthType.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyRuleConditions.cs
+++ b/src/Okta.Sdk/Model/PolicyRuleConditions.cs
@@ -160,6 +160,12 @@ namespace Okta.Sdk.Model
         public UserStatusPolicyRuleCondition UserStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -188,6 +194,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UserIdentifier: ").Append(UserIdentifier).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
             sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -327,7 +334,8 @@ namespace Okta.Sdk.Model
                     this.UserStatus == input.UserStatus ||
                     (this.UserStatus != null &&
                     this.UserStatus.Equals(input.UserStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -422,6 +430,10 @@ namespace Okta.Sdk.Model
                 if (this.UserStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.UserStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicySubject.cs
+++ b/src/Okta.Sdk/Model/PolicySubject.cs
@@ -64,6 +64,12 @@ namespace Okta.Sdk.Model
         public PolicyUserNameTemplate UserNameTemplate { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -76,6 +82,7 @@ namespace Okta.Sdk.Model
             sb.Append("  MatchAttribute: ").Append(MatchAttribute).Append("\n");
             sb.Append("  MatchType: ").Append(MatchType).Append("\n");
             sb.Append("  UserNameTemplate: ").Append(UserNameTemplate).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -136,7 +143,8 @@ namespace Okta.Sdk.Model
                     this.UserNameTemplate == input.UserNameTemplate ||
                     (this.UserNameTemplate != null &&
                     this.UserNameTemplate.Equals(input.UserNameTemplate))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -167,6 +175,10 @@ namespace Okta.Sdk.Model
                 if (this.UserNameTemplate != null)
                 {
                     hashCode = (hashCode * 59) + this.UserNameTemplate.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PolicyUserNameTemplate.cs
+++ b/src/Okta.Sdk/Model/PolicyUserNameTemplate.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Template { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PolicyUserNameTemplate {\n");
             sb.Append("  Template: ").Append(Template).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Template == input.Template ||
                     (this.Template != null &&
                     this.Template.Equals(input.Template))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Template != null)
                 {
                     hashCode = (hashCode * 59) + this.Template.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PossessionConstraint.cs
+++ b/src/Okta.Sdk/Model/PossessionConstraint.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public string UserPresence { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  HardwareProtection: ").Append(HardwareProtection).Append("\n");
             sb.Append("  PhishingResistant: ").Append(PhishingResistant).Append("\n");
             sb.Append("  UserPresence: ").Append(UserPresence).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -161,7 +168,8 @@ namespace Okta.Sdk.Model
                     this.UserPresence == input.UserPresence ||
                     (this.UserPresence != null &&
                     this.UserPresence.Equals(input.UserPresence))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -200,6 +208,10 @@ namespace Okta.Sdk.Model
                 if (this.UserPresence != null)
                 {
                     hashCode = (hashCode * 59) + this.UserPresence.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PreRegistrationInlineHook.cs
+++ b/src/Okta.Sdk/Model/PreRegistrationInlineHook.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string InlineHookId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class PreRegistrationInlineHook {\n");
             sb.Append("  InlineHookId: ").Append(InlineHookId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.InlineHookId == input.InlineHookId ||
                     (this.InlineHookId != null &&
                     this.InlineHookId.Equals(input.InlineHookId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.InlineHookId != null)
                 {
                     hashCode = (hashCode * 59) + this.InlineHookId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PrincipalRateLimitEntity.cs
+++ b/src/Okta.Sdk/Model/PrincipalRateLimitEntity.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="PrincipalRateLimitEntity" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public PrincipalRateLimitEntity() { }
+        public PrincipalRateLimitEntity()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets CreatedBy
@@ -163,6 +166,12 @@ namespace Okta.Sdk.Model
         public string PrincipalType { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -180,6 +189,7 @@ namespace Okta.Sdk.Model
             sb.Append("  OrgId: ").Append(OrgId).Append("\n");
             sb.Append("  PrincipalId: ").Append(PrincipalId).Append("\n");
             sb.Append("  PrincipalType: ").Append(PrincipalType).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -262,7 +272,8 @@ namespace Okta.Sdk.Model
                     this.PrincipalType == input.PrincipalType ||
                     (this.PrincipalType != null &&
                     this.PrincipalType.Equals(input.PrincipalType))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -307,6 +318,10 @@ namespace Okta.Sdk.Model
                 if (this.PrincipalType != null)
                 {
                     hashCode = (hashCode * 59) + this.PrincipalType.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicy.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicy.cs
@@ -49,6 +49,12 @@ namespace Okta.Sdk.Model
         public PolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -58,6 +64,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProfileEnrollmentPolicy {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -97,7 +104,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -112,6 +120,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRule.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRule.cs
@@ -53,6 +53,12 @@ namespace Okta.Sdk.Model
         public PolicyRuleConditions Conditions { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Actions: ").Append(Actions).Append("\n");
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Conditions == input.Conditions ||
                     (this.Conditions != null &&
                     this.Conditions.Equals(input.Conditions))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Conditions != null)
                 {
                     hashCode = (hashCode * 59) + this.Conditions.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleAction.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleAction.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string UnknownUserAction { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ProfileAttributes: ").Append(ProfileAttributes).Append("\n");
             sb.Append("  TargetGroupIds: ").Append(TargetGroupIds).Append("\n");
             sb.Append("  UnknownUserAction: ").Append(UnknownUserAction).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -150,7 +157,8 @@ namespace Okta.Sdk.Model
                     this.UnknownUserAction == input.UnknownUserAction ||
                     (this.UnknownUserAction != null &&
                     this.UnknownUserAction.Equals(input.UnknownUserAction))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -185,6 +193,10 @@ namespace Okta.Sdk.Model
                 if (this.UnknownUserAction != null)
                 {
                     hashCode = (hashCode * 59) + this.UnknownUserAction.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleActions.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleActions.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public ProfileEnrollmentPolicyRuleAction ProfileEnrollment { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SelfServiceUnlock: ").Append(SelfServiceUnlock).Append("\n");
             sb.Append("  Signon: ").Append(Signon).Append("\n");
             sb.Append("  ProfileEnrollment: ").Append(ProfileEnrollment).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -159,7 +166,8 @@ namespace Okta.Sdk.Model
                     this.ProfileEnrollment == input.ProfileEnrollment ||
                     (this.ProfileEnrollment != null &&
                     this.ProfileEnrollment.Equals(input.ProfileEnrollment))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -198,6 +206,10 @@ namespace Okta.Sdk.Model
                 if (this.ProfileEnrollment != null)
                 {
                     hashCode = (hashCode * 59) + this.ProfileEnrollment.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleActivationRequirement.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleActivationRequirement.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public bool EmailVerification { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProfileEnrollmentPolicyRuleActivationRequirement {\n");
             sb.Append("  EmailVerification: ").Append(EmailVerification).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -86,7 +93,8 @@ namespace Okta.Sdk.Model
                 (
                     this.EmailVerification == input.EmailVerification ||
                     this.EmailVerification.Equals(input.EmailVerification)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -99,6 +107,10 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 hashCode = (hashCode * 59) + this.EmailVerification.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleProfileAttribute.cs
+++ b/src/Okta.Sdk/Model/ProfileEnrollmentPolicyRuleProfileAttribute.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public bool Required { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Label: ").Append(Label).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -110,7 +117,8 @@ namespace Okta.Sdk.Model
                 (
                     this.Required == input.Required ||
                     this.Required.Equals(input.Required)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -131,6 +139,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Name.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.Required.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/ProfileMapping.cs
+++ b/src/Okta.Sdk/Model/ProfileMapping.cs
@@ -88,6 +88,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -100,6 +106,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Source: ").Append(Source).Append("\n");
             sb.Append("  Target: ").Append(Target).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -161,7 +168,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -192,6 +200,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileMappingProperty.cs
+++ b/src/Okta.Sdk/Model/ProfileMappingProperty.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string PushStatus { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProfileMappingProperty {\n");
             sb.Append("  Expression: ").Append(Expression).Append("\n");
             sb.Append("  PushStatus: ").Append(PushStatus).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.PushStatus == input.PushStatus ||
                     (this.PushStatus != null &&
                     this.PushStatus.Equals(input.PushStatus))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.PushStatus != null)
                 {
                     hashCode = (hashCode * 59) + this.PushStatus.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileMappingSource.cs
+++ b/src/Okta.Sdk/Model/ProfileMappingSource.cs
@@ -90,6 +90,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -101,6 +107,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -156,7 +163,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -183,6 +191,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProfileSettingObject.cs
+++ b/src/Okta.Sdk/Model/ProfileSettingObject.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProfileSettingObject {\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Protocol.cs
+++ b/src/Okta.Sdk/Model/Protocol.cs
@@ -82,6 +82,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -97,6 +103,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Scopes: ").Append(Scopes).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -172,7 +179,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -215,6 +223,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolAlgorithmType.cs
+++ b/src/Okta.Sdk/Model/ProtocolAlgorithmType.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public ProtocolAlgorithmTypeSignature Signature { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProtocolAlgorithmType {\n");
             sb.Append("  Signature: ").Append(Signature).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Signature == input.Signature ||
                     (this.Signature != null &&
                     this.Signature.Equals(input.Signature))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Signature != null)
                 {
                     hashCode = (hashCode * 59) + this.Signature.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolAlgorithmTypeSignature.cs
+++ b/src/Okta.Sdk/Model/ProtocolAlgorithmTypeSignature.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Scope { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProtocolAlgorithmTypeSignature {\n");
             sb.Append("  Algorithm: ").Append(Algorithm).Append("\n");
             sb.Append("  Scope: ").Append(Scope).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Scope == input.Scope ||
                     (this.Scope != null &&
                     this.Scope.Equals(input.Scope))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Scope != null)
                 {
                     hashCode = (hashCode * 59) + this.Scope.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolAlgorithms.cs
+++ b/src/Okta.Sdk/Model/ProtocolAlgorithms.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public ProtocolAlgorithmType Response { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProtocolAlgorithms {\n");
             sb.Append("  Request: ").Append(Request).Append("\n");
             sb.Append("  Response: ").Append(Response).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Response == input.Response ||
                     (this.Response != null &&
                     this.Response.Equals(input.Response))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Response != null)
                 {
                     hashCode = (hashCode * 59) + this.Response.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolEndpoint.cs
+++ b/src/Okta.Sdk/Model/ProtocolEndpoint.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Url { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Destination: ").Append(Destination).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Url == input.Url ||
                     (this.Url != null &&
                     this.Url.Equals(input.Url))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Url != null)
                 {
                     hashCode = (hashCode * 59) + this.Url.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolEndpoints.cs
+++ b/src/Okta.Sdk/Model/ProtocolEndpoints.cs
@@ -82,6 +82,12 @@ namespace Okta.Sdk.Model
         public ProtocolEndpoint UserInfo { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -97,6 +103,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Sso: ").Append(Sso).Append("\n");
             sb.Append("  Token: ").Append(Token).Append("\n");
             sb.Append("  UserInfo: ").Append(UserInfo).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -171,7 +178,8 @@ namespace Okta.Sdk.Model
                     this.UserInfo == input.UserInfo ||
                     (this.UserInfo != null &&
                     this.UserInfo.Equals(input.UserInfo))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -214,6 +222,10 @@ namespace Okta.Sdk.Model
                 if (this.UserInfo != null)
                 {
                     hashCode = (hashCode * 59) + this.UserInfo.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolRelayState.cs
+++ b/src/Okta.Sdk/Model/ProtocolRelayState.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Format { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProtocolRelayState {\n");
             sb.Append("  Format: ").Append(Format).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Format == input.Format ||
                     (this.Format != null &&
                     this.Format.Equals(input.Format))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Format != null)
                 {
                     hashCode = (hashCode * 59) + this.Format.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProtocolSettings.cs
+++ b/src/Okta.Sdk/Model/ProtocolSettings.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string NameFormat { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProtocolSettings {\n");
             sb.Append("  NameFormat: ").Append(NameFormat).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.NameFormat == input.NameFormat ||
                     (this.NameFormat != null &&
                     this.NameFormat.Equals(input.NameFormat))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.NameFormat != null)
                 {
                     hashCode = (hashCode * 59) + this.NameFormat.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Provisioning.cs
+++ b/src/Okta.Sdk/Model/Provisioning.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public bool ProfileMaster { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Conditions: ").Append(Conditions).Append("\n");
             sb.Append("  Groups: ").Append(Groups).Append("\n");
             sb.Append("  ProfileMaster: ").Append(ProfileMaster).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,7 +129,8 @@ namespace Okta.Sdk.Model
                 (
                     this.ProfileMaster == input.ProfileMaster ||
                     this.ProfileMaster.Equals(input.ProfileMaster)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -147,6 +155,10 @@ namespace Okta.Sdk.Model
                     hashCode = (hashCode * 59) + this.Groups.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.ProfileMaster.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/ProvisioningConditions.cs
+++ b/src/Okta.Sdk/Model/ProvisioningConditions.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public ProvisioningSuspendedCondition Suspended { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProvisioningConditions {\n");
             sb.Append("  Deprovisioned: ").Append(Deprovisioned).Append("\n");
             sb.Append("  Suspended: ").Append(Suspended).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Suspended == input.Suspended ||
                     (this.Suspended != null &&
                     this.Suspended.Equals(input.Suspended))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Suspended != null)
                 {
                     hashCode = (hashCode * 59) + this.Suspended.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningConnection.cs
+++ b/src/Okta.Sdk/Model/ProvisioningConnection.cs
@@ -60,6 +60,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -70,6 +76,7 @@ namespace Okta.Sdk.Model
             sb.Append("  AuthScheme: ").Append(AuthScheme).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -120,7 +127,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -143,6 +151,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningConnectionProfile.cs
+++ b/src/Okta.Sdk/Model/ProvisioningConnectionProfile.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Token { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class ProvisioningConnectionProfile {\n");
             sb.Append("  AuthScheme: ").Append(AuthScheme).Append("\n");
             sb.Append("  Token: ").Append(Token).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Token == input.Token ||
                     (this.Token != null &&
                     this.Token.Equals(input.Token))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Token != null)
                 {
                     hashCode = (hashCode * 59) + this.Token.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningConnectionRequest.cs
+++ b/src/Okta.Sdk/Model/ProvisioningConnectionRequest.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public ProvisioningConnectionProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProvisioningConnectionRequest {\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningDeprovisionedCondition.cs
+++ b/src/Okta.Sdk/Model/ProvisioningDeprovisionedCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Action { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProvisioningDeprovisionedCondition {\n");
             sb.Append("  Action: ").Append(Action).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Action == input.Action ||
                     (this.Action != null &&
                     this.Action.Equals(input.Action))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Action != null)
                 {
                     hashCode = (hashCode * 59) + this.Action.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningGroups.cs
+++ b/src/Okta.Sdk/Model/ProvisioningGroups.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string SourceAttributeName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Assignments: ").Append(Assignments).Append("\n");
             sb.Append("  Filter: ").Append(Filter).Append("\n");
             sb.Append("  SourceAttributeName: ").Append(SourceAttributeName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -125,7 +132,8 @@ namespace Okta.Sdk.Model
                     this.SourceAttributeName == input.SourceAttributeName ||
                     (this.SourceAttributeName != null &&
                     this.SourceAttributeName.Equals(input.SourceAttributeName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -152,6 +160,10 @@ namespace Okta.Sdk.Model
                 if (this.SourceAttributeName != null)
                 {
                     hashCode = (hashCode * 59) + this.SourceAttributeName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ProvisioningSuspendedCondition.cs
+++ b/src/Okta.Sdk/Model/ProvisioningSuspendedCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Action { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ProvisioningSuspendedCondition {\n");
             sb.Append("  Action: ").Append(Action).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Action == input.Action ||
                     (this.Action != null &&
                     this.Action.Equals(input.Action))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Action != null)
                 {
                     hashCode = (hashCode * 59) + this.Action.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PushProvider.cs
+++ b/src/Okta.Sdk/Model/PushProvider.cs
@@ -87,6 +87,12 @@ namespace Okta.Sdk.Model
         public ApiTokenLink Links { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -99,6 +105,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  ProviderType: ").Append(ProviderType).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -158,7 +165,8 @@ namespace Okta.Sdk.Model
                     this.Links == input.Links ||
                     (this.Links != null &&
                     this.Links.Equals(input.Links))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -189,6 +197,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PushUserFactor.cs
+++ b/src/Okta.Sdk/Model/PushUserFactor.cs
@@ -67,6 +67,12 @@ namespace Okta.Sdk.Model
         public PushUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -78,6 +84,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ExpiresAt: ").Append(ExpiresAt).Append("\n");
             sb.Append("  FactorResult: ").Append(FactorResult).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -127,7 +134,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -150,6 +158,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/PushUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/PushUserFactorProfile.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string _Version { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Platform: ").Append(Platform).Append("\n");
             sb.Append("  _Version: ").Append(_Version).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -147,7 +154,8 @@ namespace Okta.Sdk.Model
                     this._Version == input._Version ||
                     (this._Version != null &&
                     this._Version.Equals(input._Version))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -182,6 +190,10 @@ namespace Okta.Sdk.Model
                 if (this._Version != null)
                 {
                     hashCode = (hashCode * 59) + this._Version.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/RecoveryQuestionCredential.cs
+++ b/src/Okta.Sdk/Model/RecoveryQuestionCredential.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Question { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class RecoveryQuestionCredential {\n");
             sb.Append("  Answer: ").Append(Answer).Append("\n");
             sb.Append("  Question: ").Append(Question).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Question == input.Question ||
                     (this.Question != null &&
                     this.Question.Equals(input.Question))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Question != null)
                 {
                     hashCode = (hashCode * 59) + this.Question.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ResetPasswordToken.cs
+++ b/src/Okta.Sdk/Model/ResetPasswordToken.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ResetPasswordToken {\n");
             sb.Append("  ResetPasswordUrl: ").Append(ResetPasswordUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -95,7 +102,8 @@ namespace Okta.Sdk.Model
                     this.ResetPasswordUrl == input.ResetPasswordUrl ||
                     (this.ResetPasswordUrl != null &&
                     this.ResetPasswordUrl.Equals(input.ResetPasswordUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -110,6 +118,10 @@ namespace Okta.Sdk.Model
                 if (this.ResetPasswordUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.ResetPasswordUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/RiskPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/RiskPolicyRuleCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> Behaviors { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class RiskPolicyRuleCondition {\n");
             sb.Append("  Behaviors: ").Append(Behaviors).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.Behaviors != null &&
                     input.Behaviors != null &&
                     this.Behaviors.SequenceEqual(input.Behaviors)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.Behaviors != null)
                 {
                     hashCode = (hashCode * 59) + this.Behaviors.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/RiskScorePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/RiskScorePolicyRuleCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Level { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class RiskScorePolicyRuleCondition {\n");
             sb.Append("  Level: ").Append(Level).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Level == input.Level ||
                     (this.Level != null &&
                     this.Level.Equals(input.Level))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Level != null)
                 {
                     hashCode = (hashCode * 59) + this.Level.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Role.cs
+++ b/src/Okta.Sdk/Model/Role.cs
@@ -142,6 +142,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -159,6 +165,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -245,7 +252,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -296,6 +304,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SamlApplication.cs
+++ b/src/Okta.Sdk/Model/SamlApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public SamlApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SamlApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/SamlApplicationSettings.cs
@@ -76,6 +76,12 @@ namespace Okta.Sdk.Model
         public SamlApplicationSettingsSignOn SignOn { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -90,6 +96,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
             sb.Append("  SignOn: ").Append(SignOn).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -158,7 +165,8 @@ namespace Okta.Sdk.Model
                     this.SignOn == input.SignOn ||
                     (this.SignOn != null &&
                     this.SignOn.Equals(input.SignOn))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -194,6 +202,10 @@ namespace Okta.Sdk.Model
                 if (this.SignOn != null)
                 {
                     hashCode = (hashCode * 59) + this.SignOn.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SamlApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/SamlApplicationSettingsApplication.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string BaseUrl { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  AcsUrl: ").Append(AcsUrl).Append("\n");
             sb.Append("  AudRestriction: ").Append(AudRestriction).Append("\n");
             sb.Append("  BaseUrl: ").Append(BaseUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.BaseUrl == input.BaseUrl ||
                     (this.BaseUrl != null &&
                     this.BaseUrl.Equals(input.BaseUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.BaseUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.BaseUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SamlApplicationSettingsSignOn.cs
+++ b/src/Okta.Sdk/Model/SamlApplicationSettingsSignOn.cs
@@ -190,6 +190,12 @@ namespace Okta.Sdk.Model
         public string SubjectNameIdTemplate { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -223,6 +229,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SsoAcsUrlOverride: ").Append(SsoAcsUrlOverride).Append("\n");
             sb.Append("  SubjectNameIdFormat: ").Append(SubjectNameIdFormat).Append("\n");
             sb.Append("  SubjectNameIdTemplate: ").Append(SubjectNameIdTemplate).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -385,7 +392,8 @@ namespace Okta.Sdk.Model
                     this.SubjectNameIdTemplate == input.SubjectNameIdTemplate ||
                     (this.SubjectNameIdTemplate != null &&
                     this.SubjectNameIdTemplate.Equals(input.SubjectNameIdTemplate))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -485,6 +493,10 @@ namespace Okta.Sdk.Model
                 if (this.SubjectNameIdTemplate != null)
                 {
                     hashCode = (hashCode * 59) + this.SubjectNameIdTemplate.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SamlAttributeStatement.cs
+++ b/src/Okta.Sdk/Model/SamlAttributeStatement.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public List<string> Values { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Namespace: ").Append(Namespace).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Values: ").Append(Values).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -148,7 +155,8 @@ namespace Okta.Sdk.Model
                     this.Values != null &&
                     input.Values != null &&
                     this.Values.SequenceEqual(input.Values)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -183,6 +191,10 @@ namespace Okta.Sdk.Model
                 if (this.Values != null)
                 {
                     hashCode = (hashCode * 59) + this.Values.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ScheduledUserLifecycleAction.cs
+++ b/src/Okta.Sdk/Model/ScheduledUserLifecycleAction.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Status { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class ScheduledUserLifecycleAction {\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Status == input.Status ||
                     (this.Status != null &&
                     this.Status.Equals(input.Status))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Status != null)
                 {
                     hashCode = (hashCode * 59) + this.Status.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SchemeApplicationCredentials.cs
+++ b/src/Okta.Sdk/Model/SchemeApplicationCredentials.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  RevealPassword: ").Append(RevealPassword).Append("\n");
             sb.Append("  Scheme: ").Append(Scheme).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurePasswordStoreApplication.cs
+++ b/src/Okta.Sdk/Model/SecurePasswordStoreApplication.cs
@@ -63,6 +63,12 @@ namespace Okta.Sdk.Model
         public SecurePasswordStoreApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -74,6 +80,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -123,7 +130,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -146,6 +154,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurePasswordStoreApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/SecurePasswordStoreApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public SecurePasswordStoreApplicationSettingsApplication App { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.App == input.App ||
                     (this.App != null &&
                     this.App.Equals(input.App))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.App != null)
                 {
                     hashCode = (hashCode * 59) + this.App.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurePasswordStoreApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/SecurePasswordStoreApplicationSettingsApplication.cs
@@ -88,6 +88,12 @@ namespace Okta.Sdk.Model
         public string UsernameField { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -104,6 +110,7 @@ namespace Okta.Sdk.Model
             sb.Append("  PasswordField: ").Append(PasswordField).Append("\n");
             sb.Append("  Url: ").Append(Url).Append("\n");
             sb.Append("  UsernameField: ").Append(UsernameField).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -183,7 +190,8 @@ namespace Okta.Sdk.Model
                     this.UsernameField == input.UsernameField ||
                     (this.UsernameField != null &&
                     this.UsernameField.Equals(input.UsernameField))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -230,6 +238,10 @@ namespace Okta.Sdk.Model
                 if (this.UsernameField != null)
                 {
                     hashCode = (hashCode * 59) + this.UsernameField.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurityQuestion.cs
+++ b/src/Okta.Sdk/Model/SecurityQuestion.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string QuestionText { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Answer: ").Append(Answer).Append("\n");
             sb.Append("  Question: ").Append(Question).Append("\n");
             sb.Append("  QuestionText: ").Append(QuestionText).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.QuestionText == input.QuestionText ||
                     (this.QuestionText != null &&
                     this.QuestionText.Equals(input.QuestionText))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.QuestionText != null)
                 {
                     hashCode = (hashCode * 59) + this.QuestionText.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurityQuestionUserFactor.cs
+++ b/src/Okta.Sdk/Model/SecurityQuestionUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public SecurityQuestionUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class SecurityQuestionUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SecurityQuestionUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/SecurityQuestionUserFactorProfile.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string QuestionText { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Answer: ").Append(Answer).Append("\n");
             sb.Append("  Question: ").Append(Question).Append("\n");
             sb.Append("  QuestionText: ").Append(QuestionText).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.QuestionText == input.QuestionText ||
                     (this.QuestionText != null &&
                     this.QuestionText.Equals(input.QuestionText))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.QuestionText != null)
                 {
                     hashCode = (hashCode * 59) + this.QuestionText.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Session.cs
+++ b/src/Okta.Sdk/Model/Session.cs
@@ -172,6 +172,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -190,6 +196,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  UserId: ").Append(UserId).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -281,7 +288,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -336,6 +344,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SessionIdentityProvider.cs
+++ b/src/Okta.Sdk/Model/SessionIdentityProvider.cs
@@ -54,6 +54,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class SessionIdentityProvider {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -126,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SignInPage.cs
+++ b/src/Okta.Sdk/Model/SignInPage.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="SignInPage" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public SignInPage() { }
+        public SignInPage()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets PageContent
@@ -70,6 +73,12 @@ namespace Okta.Sdk.Model
         public string WidgetVersion { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -82,6 +91,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Url: ").Append(Url).Append("\n");
             sb.Append("  WidgetCustomizations: ").Append(WidgetCustomizations).Append("\n");
             sb.Append("  WidgetVersion: ").Append(WidgetVersion).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -141,7 +151,8 @@ namespace Okta.Sdk.Model
                     this.WidgetVersion == input.WidgetVersion ||
                     (this.WidgetVersion != null &&
                     this.WidgetVersion.Equals(input.WidgetVersion))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -172,6 +183,10 @@ namespace Okta.Sdk.Model
                 if (this.WidgetVersion != null)
                 {
                     hashCode = (hashCode * 59) + this.WidgetVersion.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SignInPageAllOfWidgetCustomizations.cs
+++ b/src/Okta.Sdk/Model/SignInPageAllOfWidgetCustomizations.cs
@@ -154,6 +154,12 @@ namespace Okta.Sdk.Model
         public string ClassicRecoveryFlowEmailOrUsernameLabel { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -181,6 +187,7 @@ namespace Okta.Sdk.Model
             sb.Append("  AuthenticatorPageCustomLinkLabel: ").Append(AuthenticatorPageCustomLinkLabel).Append("\n");
             sb.Append("  AuthenticatorPageCustomLinkUrl: ").Append(AuthenticatorPageCustomLinkUrl).Append("\n");
             sb.Append("  ClassicRecoveryFlowEmailOrUsernameLabel: ").Append(ClassicRecoveryFlowEmailOrUsernameLabel).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -313,7 +320,8 @@ namespace Okta.Sdk.Model
                     this.ClassicRecoveryFlowEmailOrUsernameLabel == input.ClassicRecoveryFlowEmailOrUsernameLabel ||
                     (this.ClassicRecoveryFlowEmailOrUsernameLabel != null &&
                     this.ClassicRecoveryFlowEmailOrUsernameLabel.Equals(input.ClassicRecoveryFlowEmailOrUsernameLabel))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -398,6 +406,10 @@ namespace Okta.Sdk.Model
                 if (this.ClassicRecoveryFlowEmailOrUsernameLabel != null)
                 {
                     hashCode = (hashCode * 59) + this.ClassicRecoveryFlowEmailOrUsernameLabel.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SignOnInlineHook.cs
+++ b/src/Okta.Sdk/Model/SignOnInlineHook.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Id { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class SignOnInlineHook {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Id == input.Id ||
                     (this.Id != null &&
                     this.Id.Equals(input.Id))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Id != null)
                 {
                     hashCode = (hashCode * 59) + this.Id.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SingleLogout.cs
+++ b/src/Okta.Sdk/Model/SingleLogout.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string LogoutUrl { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Enabled: ").Append(Enabled).Append("\n");
             sb.Append("  Issuer: ").Append(Issuer).Append("\n");
             sb.Append("  LogoutUrl: ").Append(LogoutUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -110,7 +117,8 @@ namespace Okta.Sdk.Model
                     this.LogoutUrl == input.LogoutUrl ||
                     (this.LogoutUrl != null &&
                     this.LogoutUrl.Equals(input.LogoutUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -130,6 +138,10 @@ namespace Okta.Sdk.Model
                 if (this.LogoutUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.LogoutUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SmsTemplate.cs
+++ b/src/Okta.Sdk/Model/SmsTemplate.cs
@@ -100,6 +100,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -114,6 +120,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Template: ").Append(Template).Append("\n");
             sb.Append("  Translations: ").Append(Translations).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -183,7 +190,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -222,6 +230,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SmsUserFactor.cs
+++ b/src/Okta.Sdk/Model/SmsUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public SmsUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class SmsUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SmsUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/SmsUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string PhoneNumber { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class SmsUserFactorProfile {\n");
             sb.Append("  PhoneNumber: ").Append(PhoneNumber).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.PhoneNumber == input.PhoneNumber ||
                     (this.PhoneNumber != null &&
                     this.PhoneNumber.Equals(input.PhoneNumber))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.PhoneNumber != null)
                 {
                     hashCode = (hashCode * 59) + this.PhoneNumber.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SocialAuthToken.cs
+++ b/src/Okta.Sdk/Model/SocialAuthToken.cs
@@ -86,6 +86,12 @@ namespace Okta.Sdk.Model
         public string TokenType { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -99,6 +105,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Token: ").Append(Token).Append("\n");
             sb.Append("  TokenAuthScheme: ").Append(TokenAuthScheme).Append("\n");
             sb.Append("  TokenType: ").Append(TokenType).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -164,7 +171,8 @@ namespace Okta.Sdk.Model
                     this.TokenType == input.TokenType ||
                     (this.TokenType != null &&
                     this.TokenType.Equals(input.TokenType))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -199,6 +207,10 @@ namespace Okta.Sdk.Model
                 if (this.TokenType != null)
                 {
                     hashCode = (hashCode * 59) + this.TokenType.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SpCertificate.cs
+++ b/src/Okta.Sdk/Model/SpCertificate.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<string> X5c { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class SpCertificate {\n");
             sb.Append("  X5c: ").Append(X5c).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.X5c != null &&
                     input.X5c != null &&
                     this.X5c.SequenceEqual(input.X5c)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.X5c != null)
                 {
                     hashCode = (hashCode * 59) + this.X5c.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Subscription.cs
+++ b/src/Okta.Sdk/Model/Subscription.cs
@@ -66,6 +66,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -77,6 +83,7 @@ namespace Okta.Sdk.Model
             sb.Append("  NotificationType: ").Append(NotificationType).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -133,7 +140,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -160,6 +168,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SwaApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/SwaApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public SwaApplicationSettingsApplication App { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.App == input.App ||
                     (this.App != null &&
                     this.App.Equals(input.App))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.App != null)
                 {
                     hashCode = (hashCode * 59) + this.App.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/SwaApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/SwaApplicationSettingsApplication.cs
@@ -112,6 +112,12 @@ namespace Okta.Sdk.Model
         public string UserNameSelector { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -132,6 +138,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Url: ").Append(Url).Append("\n");
             sb.Append("  UsernameField: ").Append(UsernameField).Append("\n");
             sb.Append("  UserNameSelector: ").Append(UserNameSelector).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -231,7 +238,8 @@ namespace Okta.Sdk.Model
                     this.UserNameSelector == input.UserNameSelector ||
                     (this.UserNameSelector != null &&
                     this.UserNameSelector.Equals(input.UserNameSelector))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -294,6 +302,10 @@ namespace Okta.Sdk.Model
                 if (this.UserNameSelector != null)
                 {
                     hashCode = (hashCode * 59) + this.UserNameSelector.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TempPassword.cs
+++ b/src/Okta.Sdk/Model/TempPassword.cs
@@ -48,6 +48,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +62,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class TempPassword {\n");
             sb.Append("  _TempPassword: ").Append(_TempPassword).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -95,7 +102,8 @@ namespace Okta.Sdk.Model
                     this._TempPassword == input._TempPassword ||
                     (this._TempPassword != null &&
                     this._TempPassword.Equals(input._TempPassword))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -110,6 +118,10 @@ namespace Okta.Sdk.Model
                 if (this._TempPassword != null)
                 {
                     hashCode = (hashCode * 59) + this._TempPassword.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/Theme.cs
+++ b/src/Okta.Sdk/Model/Theme.cs
@@ -110,6 +110,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -127,6 +133,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SecondaryColorHex: ").Append(SecondaryColorHex).Append("\n");
             sb.Append("  SignInPageTouchPointVariant: ").Append(SignInPageTouchPointVariant).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -212,7 +219,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -263,6 +271,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ThemeResponse.cs
+++ b/src/Okta.Sdk/Model/ThemeResponse.cs
@@ -152,6 +152,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -172,6 +178,7 @@ namespace Okta.Sdk.Model
             sb.Append("  SecondaryColorHex: ").Append(SecondaryColorHex).Append("\n");
             sb.Append("  SignInPageTouchPointVariant: ").Append(SignInPageTouchPointVariant).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -272,7 +279,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -335,6 +343,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/ThreatInsightConfiguration.cs
+++ b/src/Okta.Sdk/Model/ThreatInsightConfiguration.cs
@@ -88,6 +88,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -100,6 +106,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ExcludeZones: ").Append(ExcludeZones).Append("\n");
             sb.Append("  LastUpdated: ").Append(LastUpdated).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -161,7 +168,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -192,6 +200,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TokenAuthorizationServerPolicyRuleAction.cs
+++ b/src/Okta.Sdk/Model/TokenAuthorizationServerPolicyRuleAction.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public int RefreshTokenWindowMinutes { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  InlineHook: ").Append(InlineHook).Append("\n");
             sb.Append("  RefreshTokenLifetimeMinutes: ").Append(RefreshTokenLifetimeMinutes).Append("\n");
             sb.Append("  RefreshTokenWindowMinutes: ").Append(RefreshTokenWindowMinutes).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -120,7 +127,8 @@ namespace Okta.Sdk.Model
                 (
                     this.RefreshTokenWindowMinutes == input.RefreshTokenWindowMinutes ||
                     this.RefreshTokenWindowMinutes.Equals(input.RefreshTokenWindowMinutes)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -139,6 +147,10 @@ namespace Okta.Sdk.Model
                 }
                 hashCode = (hashCode * 59) + this.RefreshTokenLifetimeMinutes.GetHashCode();
                 hashCode = (hashCode * 59) + this.RefreshTokenWindowMinutes.GetHashCode();
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
+                }
                 return hashCode;
             }
         }

--- a/src/Okta.Sdk/Model/TokenAuthorizationServerPolicyRuleActionInlineHook.cs
+++ b/src/Okta.Sdk/Model/TokenAuthorizationServerPolicyRuleActionInlineHook.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Id { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class TokenAuthorizationServerPolicyRuleActionInlineHook {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Id == input.Id ||
                     (this.Id != null &&
                     this.Id.Equals(input.Id))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Id != null)
                 {
                     hashCode = (hashCode * 59) + this.Id.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TokenUserFactor.cs
+++ b/src/Okta.Sdk/Model/TokenUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public TokenUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class TokenUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TokenUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/TokenUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class TokenUserFactorProfile {\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TotpUserFactor.cs
+++ b/src/Okta.Sdk/Model/TotpUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public TotpUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class TotpUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TotpUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/TotpUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class TotpUserFactorProfile {\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TrustedOrigin.cs
+++ b/src/Okta.Sdk/Model/TrustedOrigin.cs
@@ -126,6 +126,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -143,6 +149,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Scopes: ").Append(Scopes).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -229,7 +236,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -280,6 +288,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/TrustedOriginScope.cs
+++ b/src/Okta.Sdk/Model/TrustedOriginScope.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class TrustedOriginScope {\n");
             sb.Append("  AllowedOktaApps: ").Append(AllowedOktaApps).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/U2fUserFactor.cs
+++ b/src/Okta.Sdk/Model/U2fUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public U2fUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class U2fUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/U2fUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/U2fUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class U2fUserFactorProfile {\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UpdateEmailDomain.cs
+++ b/src/Okta.Sdk/Model/UpdateEmailDomain.cs
@@ -36,7 +36,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="UpdateEmailDomain" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public UpdateEmailDomain() { }
+        public UpdateEmailDomain()
+        {
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
         
         /// <summary>
         /// Gets or Sets DisplayName
@@ -51,6 +54,12 @@ namespace Okta.Sdk.Model
         public string UserName { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -60,6 +69,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UpdateEmailDomain {\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");
             sb.Append("  UserName: ").Append(UserName).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -104,7 +114,8 @@ namespace Okta.Sdk.Model
                     this.UserName == input.UserName ||
                     (this.UserName != null &&
                     this.UserName.Equals(input.UserName))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -123,6 +134,10 @@ namespace Okta.Sdk.Model
                 if (this.UserName != null)
                 {
                     hashCode = (hashCode * 59) + this.UserName.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UpdateUserRequest.cs
+++ b/src/Okta.Sdk/Model/UpdateUserRequest.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public UserProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UpdateUserRequest {\n");
             sb.Append("  Credentials: ").Append(Credentials).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/User.cs
+++ b/src/Okta.Sdk/Model/User.cs
@@ -190,6 +190,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -211,6 +217,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -317,7 +324,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -384,6 +392,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserActivationToken.cs
+++ b/src/Okta.Sdk/Model/UserActivationToken.cs
@@ -62,6 +62,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -71,6 +77,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserActivationToken {\n");
             sb.Append("  ActivationToken: ").Append(ActivationToken).Append("\n");
             sb.Append("  ActivationUrl: ").Append(ActivationUrl).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -115,7 +122,8 @@ namespace Okta.Sdk.Model
                     this.ActivationUrl == input.ActivationUrl ||
                     (this.ActivationUrl != null &&
                     this.ActivationUrl.Equals(input.ActivationUrl))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.ActivationUrl != null)
                 {
                     hashCode = (hashCode * 59) + this.ActivationUrl.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserCondition.cs
+++ b/src/Okta.Sdk/Model/UserCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserCredentials.cs
+++ b/src/Okta.Sdk/Model/UserCredentials.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public RecoveryQuestionCredential RecoveryQuestion { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Password: ").Append(Password).Append("\n");
             sb.Append("  Provider: ").Append(Provider).Append("\n");
             sb.Append("  RecoveryQuestion: ").Append(RecoveryQuestion).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.RecoveryQuestion == input.RecoveryQuestion ||
                     (this.RecoveryQuestion != null &&
                     this.RecoveryQuestion.Equals(input.RecoveryQuestion))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -134,6 +142,10 @@ namespace Okta.Sdk.Model
                 if (this.RecoveryQuestion != null)
                 {
                     hashCode = (hashCode * 59) + this.RecoveryQuestion.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserFactor.cs
+++ b/src/Okta.Sdk/Model/UserFactor.cs
@@ -155,6 +155,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -171,6 +177,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Verify: ").Append(Verify).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -252,7 +259,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -299,6 +307,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserIdentifierConditionEvaluatorPattern.cs
+++ b/src/Okta.Sdk/Model/UserIdentifierConditionEvaluatorPattern.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserIdentifierConditionEvaluatorPattern {\n");
             sb.Append("  MatchType: ").Append(MatchType).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserIdentifierPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/UserIdentifierPolicyRuleCondition.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Attribute: ").Append(Attribute).Append("\n");
             sb.Append("  Patterns: ").Append(Patterns).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -112,7 +119,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -135,6 +143,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserIdentityProviderLinkRequest.cs
+++ b/src/Okta.Sdk/Model/UserIdentityProviderLinkRequest.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string ExternalId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class UserIdentityProviderLinkRequest {\n");
             sb.Append("  ExternalId: ").Append(ExternalId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.ExternalId == input.ExternalId ||
                     (this.ExternalId != null &&
                     this.ExternalId.Equals(input.ExternalId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.ExternalId != null)
                 {
                     hashCode = (hashCode * 59) + this.ExternalId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserLifecycleAttributePolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/UserLifecycleAttributePolicyRuleCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string MatchingValue { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserLifecycleAttributePolicyRuleCondition {\n");
             sb.Append("  AttributeName: ").Append(AttributeName).Append("\n");
             sb.Append("  MatchingValue: ").Append(MatchingValue).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.MatchingValue == input.MatchingValue ||
                     (this.MatchingValue != null &&
                     this.MatchingValue.Equals(input.MatchingValue))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.MatchingValue != null)
                 {
                     hashCode = (hashCode * 59) + this.MatchingValue.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/UserPolicyRuleCondition.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public UserLifecycleAttributePolicyRuleCondition UserLifecycleAttribute { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  LifecycleExpiration: ").Append(LifecycleExpiration).Append("\n");
             sb.Append("  PasswordExpiration: ").Append(PasswordExpiration).Append("\n");
             sb.Append("  UserLifecycleAttribute: ").Append(UserLifecycleAttribute).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -149,7 +156,8 @@ namespace Okta.Sdk.Model
                     this.UserLifecycleAttribute == input.UserLifecycleAttribute ||
                     (this.UserLifecycleAttribute != null &&
                     this.UserLifecycleAttribute.Equals(input.UserLifecycleAttribute))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -184,6 +192,10 @@ namespace Okta.Sdk.Model
                 if (this.UserLifecycleAttribute != null)
                 {
                     hashCode = (hashCode * 59) + this.UserLifecycleAttribute.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserProfile.cs
+++ b/src/Okta.Sdk/Model/UserProfile.cs
@@ -221,6 +221,12 @@ namespace Okta.Sdk.Model
         public string ZipCode { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -259,6 +265,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Title: ").Append(Title).Append("\n");
             sb.Append("  UserType: ").Append(UserType).Append("\n");
             sb.Append("  ZipCode: ").Append(ZipCode).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -448,7 +455,8 @@ namespace Okta.Sdk.Model
                     this.ZipCode == input.ZipCode ||
                     (this.ZipCode != null &&
                     this.ZipCode.Equals(input.ZipCode))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -583,6 +591,10 @@ namespace Okta.Sdk.Model
                 if (this.ZipCode != null)
                 {
                     hashCode = (hashCode * 59) + this.ZipCode.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchema.cs
+++ b/src/Okta.Sdk/Model/UserSchema.cs
@@ -150,6 +150,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -167,6 +173,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Title: ").Append(Title).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -252,7 +259,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -303,6 +311,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttribute.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttribute.cs
@@ -142,6 +142,12 @@ namespace Okta.Sdk.Model
         public string Unique { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -167,6 +173,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Union: ").Append(Union).Append("\n");
             sb.Append("  Unique: ").Append(Unique).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -291,7 +298,8 @@ namespace Okta.Sdk.Model
                     this.Unique == input.Unique ||
                     (this.Unique != null &&
                     this.Unique.Equals(input.Unique))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -365,6 +373,10 @@ namespace Okta.Sdk.Model
                 if (this.Unique != null)
                 {
                     hashCode = (hashCode * 59) + this.Unique.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttributeEnum.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttributeEnum.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Title { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserSchemaAttributeEnum {\n");
             sb.Append("  Const: ").Append(Const).Append("\n");
             sb.Append("  Title: ").Append(Title).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Title == input.Title ||
                     (this.Title != null &&
                     this.Title.Equals(input.Title))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Title != null)
                 {
                     hashCode = (hashCode * 59) + this.Title.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttributeItems.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttributeItems.cs
@@ -52,6 +52,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -62,6 +68,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Enum: ").Append(Enum).Append("\n");
             sb.Append("  OneOf: ").Append(OneOf).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -113,7 +120,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -136,6 +144,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttributeMaster.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttributeMaster.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserSchemaAttributeMaster {\n");
             sb.Append("  Priority: ").Append(Priority).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -100,7 +107,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -119,6 +127,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttributeMasterPriority.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttributeMasterPriority.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserSchemaAttributeMasterPriority {\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaAttributePermission.cs
+++ b/src/Okta.Sdk/Model/UserSchemaAttributePermission.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string Principal { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserSchemaAttributePermission {\n");
             sb.Append("  Action: ").Append(Action).Append("\n");
             sb.Append("  Principal: ").Append(Principal).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Principal == input.Principal ||
                     (this.Principal != null &&
                     this.Principal.Equals(input.Principal))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Principal != null)
                 {
                     hashCode = (hashCode * 59) + this.Principal.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaBase.cs
+++ b/src/Okta.Sdk/Model/UserSchemaBase.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -124,7 +131,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -151,6 +159,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaBaseProperties.cs
+++ b/src/Okta.Sdk/Model/UserSchemaBaseProperties.cs
@@ -220,6 +220,12 @@ namespace Okta.Sdk.Model
         public UserSchemaAttribute ZipCode { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -258,6 +264,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Title: ").Append(Title).Append("\n");
             sb.Append("  UserType: ").Append(UserType).Append("\n");
             sb.Append("  ZipCode: ").Append(ZipCode).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -447,7 +454,8 @@ namespace Okta.Sdk.Model
                     this.ZipCode == input.ZipCode ||
                     (this.ZipCode != null &&
                     this.ZipCode.Equals(input.ZipCode))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -582,6 +590,10 @@ namespace Okta.Sdk.Model
                 if (this.ZipCode != null)
                 {
                     hashCode = (hashCode * 59) + this.ZipCode.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaDefinitions.cs
+++ b/src/Okta.Sdk/Model/UserSchemaDefinitions.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public UserSchemaPublic Custom { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserSchemaDefinitions {\n");
             sb.Append("  Base: ").Append(Base).Append("\n");
             sb.Append("  Custom: ").Append(Custom).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.Custom == input.Custom ||
                     (this.Custom != null &&
                     this.Custom.Equals(input.Custom))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Custom != null)
                 {
                     hashCode = (hashCode * 59) + this.Custom.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaProperties.cs
+++ b/src/Okta.Sdk/Model/UserSchemaProperties.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public UserSchemaPropertiesProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class UserSchemaProperties {\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaPropertiesProfile.cs
+++ b/src/Okta.Sdk/Model/UserSchemaPropertiesProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public List<UserSchemaPropertiesProfileItem> AllOf { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class UserSchemaPropertiesProfile {\n");
             sb.Append("  AllOf: ").Append(AllOf).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -88,7 +95,8 @@ namespace Okta.Sdk.Model
                     this.AllOf != null &&
                     input.AllOf != null &&
                     this.AllOf.SequenceEqual(input.AllOf)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -103,6 +111,10 @@ namespace Okta.Sdk.Model
                 if (this.AllOf != null)
                 {
                     hashCode = (hashCode * 59) + this.AllOf.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaPropertiesProfileItem.cs
+++ b/src/Okta.Sdk/Model/UserSchemaPropertiesProfileItem.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Ref { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class UserSchemaPropertiesProfileItem {\n");
             sb.Append("  Ref: ").Append(Ref).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Ref == input.Ref ||
                     (this.Ref != null &&
                     this.Ref.Equals(input.Ref))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Ref != null)
                 {
                     hashCode = (hashCode * 59) + this.Ref.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserSchemaPublic.cs
+++ b/src/Okta.Sdk/Model/UserSchemaPublic.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Properties: ").Append(Properties).Append("\n");
             sb.Append("  Required: ").Append(Required).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -125,7 +132,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -152,6 +160,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserStatusPolicyRuleCondition.cs
+++ b/src/Okta.Sdk/Model/UserStatusPolicyRuleCondition.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class UserStatusPolicyRuleCondition {\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Value == input.Value ||
                     (this.Value != null &&
                     this.Value.Equals(input.Value))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Value != null)
                 {
                     hashCode = (hashCode * 59) + this.Value.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserType.cs
+++ b/src/Okta.Sdk/Model/UserType.cs
@@ -142,6 +142,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -159,6 +165,7 @@ namespace Okta.Sdk.Model
             sb.Append("  LastUpdatedBy: ").Append(LastUpdatedBy).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -243,7 +250,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -291,6 +299,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/UserTypeCondition.cs
+++ b/src/Okta.Sdk/Model/UserTypeCondition.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public List<string> Include { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class UserTypeCondition {\n");
             sb.Append("  Exclude: ").Append(Exclude).Append("\n");
             sb.Append("  Include: ").Append(Include).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,7 +108,8 @@ namespace Okta.Sdk.Model
                     this.Include != null &&
                     input.Include != null &&
                     this.Include.SequenceEqual(input.Include)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -120,6 +128,10 @@ namespace Okta.Sdk.Model
                 if (this.Include != null)
                 {
                     hashCode = (hashCode * 59) + this.Include.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/VerificationMethod.cs
+++ b/src/Okta.Sdk/Model/VerificationMethod.cs
@@ -58,6 +58,12 @@ namespace Okta.Sdk.Model
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,6 +75,7 @@ namespace Okta.Sdk.Model
             sb.Append("  FactorMode: ").Append(FactorMode).Append("\n");
             sb.Append("  ReauthenticateIn: ").Append(ReauthenticateIn).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -124,7 +131,8 @@ namespace Okta.Sdk.Model
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -151,6 +159,10 @@ namespace Okta.Sdk.Model
                 if (this.Type != null)
                 {
                     hashCode = (hashCode * 59) + this.Type.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/VerifyFactorRequest.cs
+++ b/src/Okta.Sdk/Model/VerifyFactorRequest.cs
@@ -82,6 +82,12 @@ namespace Okta.Sdk.Model
         public string StateToken { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -97,6 +103,7 @@ namespace Okta.Sdk.Model
             sb.Append("  PassCode: ").Append(PassCode).Append("\n");
             sb.Append("  RegistrationData: ").Append(RegistrationData).Append("\n");
             sb.Append("  StateToken: ").Append(StateToken).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -171,7 +178,8 @@ namespace Okta.Sdk.Model
                     this.StateToken == input.StateToken ||
                     (this.StateToken != null &&
                     this.StateToken.Equals(input.StateToken))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -214,6 +222,10 @@ namespace Okta.Sdk.Model
                 if (this.StateToken != null)
                 {
                     hashCode = (hashCode * 59) + this.StateToken.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/VerifyUserFactorResponse.cs
+++ b/src/Okta.Sdk/Model/VerifyUserFactorResponse.cs
@@ -88,6 +88,12 @@ namespace Okta.Sdk.Model
             return false;
         }
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -100,6 +106,7 @@ namespace Okta.Sdk.Model
             sb.Append("  FactorResultMessage: ").Append(FactorResultMessage).Append("\n");
             sb.Append("  Embedded: ").Append(Embedded).Append("\n");
             sb.Append("  Links: ").Append(Links).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -161,7 +168,8 @@ namespace Okta.Sdk.Model
                     this.Links != null &&
                     input.Links != null &&
                     this.Links.SequenceEqual(input.Links)
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -192,6 +200,10 @@ namespace Okta.Sdk.Model
                 if (this.Links != null)
                 {
                     hashCode = (hashCode * 59) + this.Links.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/VersionObject.cs
+++ b/src/Okta.Sdk/Model/VersionObject.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string Minimum { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class VersionObject {\n");
             sb.Append("  Minimum: ").Append(Minimum).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.Minimum == input.Minimum ||
                     (this.Minimum != null &&
                     this.Minimum.Equals(input.Minimum))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.Minimum != null)
                 {
                     hashCode = (hashCode * 59) + this.Minimum.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WebAuthnUserFactor.cs
+++ b/src/Okta.Sdk/Model/WebAuthnUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public WebAuthnUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class WebAuthnUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WebAuthnUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/WebAuthnUserFactorProfile.cs
@@ -46,6 +46,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -55,6 +61,7 @@ namespace Okta.Sdk.Model
             sb.Append("class WebAuthnUserFactorProfile {\n");
             sb.Append("  AuthenticatorName: ").Append(AuthenticatorName).Append("\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -99,7 +106,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WebUserFactor.cs
+++ b/src/Okta.Sdk/Model/WebUserFactor.cs
@@ -55,6 +55,12 @@ namespace Okta.Sdk.Model
         public WebUserFactorProfile Profile { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -64,6 +70,7 @@ namespace Okta.Sdk.Model
             sb.Append("class WebUserFactor {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Profile: ").Append(Profile).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -103,7 +110,8 @@ namespace Okta.Sdk.Model
                     this.Profile == input.Profile ||
                     (this.Profile != null &&
                     this.Profile.Equals(input.Profile))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -118,6 +126,10 @@ namespace Okta.Sdk.Model
                 if (this.Profile != null)
                 {
                     hashCode = (hashCode * 59) + this.Profile.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WebUserFactorProfile.cs
+++ b/src/Okta.Sdk/Model/WebUserFactorProfile.cs
@@ -40,6 +40,12 @@ namespace Okta.Sdk.Model
         public string CredentialId { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -48,6 +54,7 @@ namespace Okta.Sdk.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class WebUserFactorProfile {\n");
             sb.Append("  CredentialId: ").Append(CredentialId).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -87,7 +94,8 @@ namespace Okta.Sdk.Model
                     this.CredentialId == input.CredentialId ||
                     (this.CredentialId != null &&
                     this.CredentialId.Equals(input.CredentialId))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -102,6 +110,10 @@ namespace Okta.Sdk.Model
                 if (this.CredentialId != null)
                 {
                     hashCode = (hashCode * 59) + this.CredentialId.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WsFederationApplication.cs
+++ b/src/Okta.Sdk/Model/WsFederationApplication.cs
@@ -57,6 +57,12 @@ namespace Okta.Sdk.Model
         public WsFederationApplicationSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -67,6 +73,7 @@ namespace Okta.Sdk.Model
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("  Settings: ").Append(Settings).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -111,7 +118,8 @@ namespace Okta.Sdk.Model
                     this.Settings == input.Settings ||
                     (this.Settings != null &&
                     this.Settings.Equals(input.Settings))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -130,6 +138,10 @@ namespace Okta.Sdk.Model
                 if (this.Settings != null)
                 {
                     hashCode = (hashCode * 59) + this.Settings.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WsFederationApplicationSettings.cs
+++ b/src/Okta.Sdk/Model/WsFederationApplicationSettings.cs
@@ -70,6 +70,12 @@ namespace Okta.Sdk.Model
         public WsFederationApplicationSettingsApplication App { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,6 +89,7 @@ namespace Okta.Sdk.Model
             sb.Append("  Notes: ").Append(Notes).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("  App: ").Append(App).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -146,7 +153,8 @@ namespace Okta.Sdk.Model
                     this.App == input.App ||
                     (this.App != null &&
                     this.App.Equals(input.App))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -178,6 +186,10 @@ namespace Okta.Sdk.Model
                 if (this.App != null)
                 {
                     hashCode = (hashCode * 59) + this.App.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }

--- a/src/Okta.Sdk/Model/WsFederationApplicationSettingsApplication.cs
+++ b/src/Okta.Sdk/Model/WsFederationApplicationSettingsApplication.cs
@@ -106,6 +106,12 @@ namespace Okta.Sdk.Model
         public string WReplyURL { get; set; }
 
         /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -125,6 +131,7 @@ namespace Okta.Sdk.Model
             sb.Append("  UsernameAttribute: ").Append(UsernameAttribute).Append("\n");
             sb.Append("  WReplyOverride: ").Append(WReplyOverride).Append("\n");
             sb.Append("  WReplyURL: ").Append(WReplyURL).Append("\n");
+            sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -218,7 +225,8 @@ namespace Okta.Sdk.Model
                     this.WReplyURL == input.WReplyURL ||
                     (this.WReplyURL != null &&
                     this.WReplyURL.Equals(input.WReplyURL))
-                );
+                )
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && !this.AdditionalProperties.Except(input.AdditionalProperties).Any());
         }
 
         /// <summary>
@@ -274,6 +282,10 @@ namespace Okta.Sdk.Model
                 if (this.WReplyURL != null)
                 {
                     hashCode = (hashCode * 59) + this.WReplyURL.GetHashCode();
+                }
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
                 }
                 return hashCode;
             }


### PR DESCRIPTION
- Add support for additional Properties.
- Set "disallowAdditionalPropertiesIfNotPresent": false
- Update ITs to test dynamic props in UserProfile
- Fix OKTA-518586