### PR TITLE
Fix "Invalid audience" issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Running changelog of releases since `3.1.1`
 ## 6.0.1
 
 - Make `AppUser.PasswordChanged` property nullable (#599)
+- Fix "invalid audience" issue (#600)
 
 ## 6.0.0
 

--- a/openapi3/templates/ClientUtils.mustache
+++ b/openapi3/templates/ClientUtils.mustache
@@ -272,5 +272,22 @@ namespace {{packageName}}.Client
         /// </returns>
         public static IEnumerable<WebLink> Parse(IEnumerable<string> headerValues)
             => Parse(headerValues?.ToArray() ?? new string[0]);
+
+        /// <summary>
+        /// Ensures that this URI ends with a trailing slash <c>/</c>.
+        /// </summary>
+        /// <param name="uri">The URI string.</param>
+        /// <returns>The URI string, appended with <c>/</c> if necessary.</returns>
+        public static string EnsureTrailingSlash(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return uri.EndsWith("/")
+                ? uri
+                : $"{uri}/";
+        }
     }
 }

--- a/openapi3/templates/DefaultJwtGenerator.mustache
+++ b/openapi3/templates/DefaultJwtGenerator.mustache
@@ -90,7 +90,7 @@ namespace {{packageName}}.Client
                     { "iat", (int)timeSpanIat.TotalSeconds },
                     { "exp", (int)timeSpanExp.TotalSeconds },
                     { "iss", _configuration.ClientId },
-                    { "aud", $"{_configuration.OktaDomain}/oauth2/v1/token" },
+                    { "aud", $"{ClientUtils.EnsureTrailingSlash(_configuration.OktaDomain)}oauth2/v1/token" },
                     { "jti", Guid.NewGuid() },
                 };
 

--- a/src/Okta.Sdk/Client/ClientUtils.cs
+++ b/src/Okta.Sdk/Client/ClientUtils.cs
@@ -263,5 +263,22 @@ namespace Okta.Sdk.Client
         /// </returns>
         public static IEnumerable<WebLink> Parse(IEnumerable<string> headerValues)
             => Parse(headerValues?.ToArray() ?? new string[0]);
+
+        /// <summary>
+        /// Ensures that this URI ends with a trailing slash <c>/</c>.
+        /// </summary>
+        /// <param name="uri">The URI string.</param>
+        /// <returns>The URI string, appended with <c>/</c> if necessary.</returns>
+        public static string EnsureTrailingSlash(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return uri.EndsWith("/")
+                ? uri
+                : $"{uri}/";
+        }
     }
 }

--- a/src/Okta.Sdk/Client/DefaultJwtGenerator.cs
+++ b/src/Okta.Sdk/Client/DefaultJwtGenerator.cs
@@ -99,7 +99,7 @@ namespace Okta.Sdk.Client
                     { "iat", (int)timeSpanIat.TotalSeconds },
                     { "exp", (int)timeSpanExp.TotalSeconds },
                     { "iss", _configuration.ClientId },
-                    { "aud", $"{_configuration.OktaDomain}/oauth2/v1/token" },
+                    { "aud", $"{ClientUtils.EnsureTrailingSlash(_configuration.OktaDomain)}oauth2/v1/token" },
                     { "jti", Guid.NewGuid() },
                 };
 


### PR DESCRIPTION
The issue was caused due to an extra "/" in the Okta domain URL. Now, we make sure to sanitize the URL.

_Before_

```
  "aud": "https://<MY_ORG_URL>//oauth2/v1/token"
```

_Now_

```
  "aud": "https://<MY_ORG_URL>/oauth2/v1/token"
```
Fix #600 