### PR TITLE
Rename `removeRecoveryEnrollment` query param to match API docs.

### DIFF
--- a/docs/UserFactorApi.md
+++ b/docs/UserFactorApi.md
@@ -102,7 +102,7 @@ Name | Type | Description  | Notes
 
 <a name="deletefactor"></a>
 # **DeleteFactor**
-> void DeleteFactor (string userId, string factorId, bool? removeEnrollmentRecovery = null)
+> void DeleteFactor (string userId, string factorId, bool? removeRecoveryEnrollment = null)
 
 Delete a Factor
 
@@ -132,12 +132,12 @@ namespace Example
             var apiInstance = new UserFactorApi(config);
             var userId = "userId_example";  // string | 
             var factorId = "factorId_example";  // string | 
-            var removeEnrollmentRecovery = false;  // bool? |  (optional)  (default to false)
+            var removeRecoveryEnrollment = false;  // bool? |  (optional)  (default to false)
 
             try
             {
                 // Delete a Factor
-                apiInstance.DeleteFactor(userId, factorId, removeEnrollmentRecovery);
+                apiInstance.DeleteFactor(userId, factorId, removeRecoveryEnrollment);
             }
             catch (ApiException  e)
             {
@@ -156,7 +156,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **userId** | **string**|  | 
  **factorId** | **string**|  | 
- **removeEnrollmentRecovery** | **bool?**|  | [optional] [default to false]
+ **removeRecoveryEnrollment** | **bool?**|  | [optional] [default to false]
 
 ### Return type
 

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -14745,7 +14745,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: removeEnrollmentRecovery
+        - name: removeRecoveryEnrollment
           in: query
           schema:
             type: boolean

--- a/src/Okta.Sdk/Api/UserFactorApi.cs
+++ b/src/Okta.Sdk/Api/UserFactorApi.cs
@@ -63,10 +63,10 @@ namespace Okta.Sdk.Api
         /// <exception cref="Okta.Sdk.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="userId"></param>
         /// <param name="factorId"></param>
-        /// <param name="removeEnrollmentRecovery"> (optional, default to false)</param>
+        /// <param name="removeRecoveryEnrollment"> (optional, default to false)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task DeleteFactorAsync(  string userId ,   string factorId ,   bool? removeEnrollmentRecovery = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task DeleteFactorAsync(  string userId ,   string factorId ,   bool? removeRecoveryEnrollment = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Delete a Factor
         /// </summary>
@@ -76,10 +76,10 @@ namespace Okta.Sdk.Api
         /// <exception cref="Okta.Sdk.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="userId"></param>
         /// <param name="factorId"></param>
-        /// <param name="removeEnrollmentRecovery"> (optional, default to false)</param>
+        /// <param name="removeRecoveryEnrollment"> (optional, default to false)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteFactorWithHttpInfoAsync(  string userId ,   string factorId ,   bool? removeEnrollmentRecovery = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteFactorWithHttpInfoAsync(  string userId ,   string factorId ,   bool? removeRecoveryEnrollment = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Enroll a Factor
         /// </summary>
@@ -501,12 +501,12 @@ namespace Okta.Sdk.Api
         /// <exception cref="Okta.Sdk.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="userId"></param>
         /// <param name="factorId"></param>
-        /// <param name="removeEnrollmentRecovery"> (optional, default to false)</param>
+        /// <param name="removeRecoveryEnrollment"> (optional, default to false)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteFactorAsync(  string userId ,   string factorId ,   bool? removeEnrollmentRecovery = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task DeleteFactorAsync(  string userId ,   string factorId ,   bool? removeRecoveryEnrollment = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            await DeleteFactorWithHttpInfoAsync(userId, factorId, removeEnrollmentRecovery, cancellationToken).ConfigureAwait(false);
+            await DeleteFactorWithHttpInfoAsync(userId, factorId, removeRecoveryEnrollment, cancellationToken).ConfigureAwait(false);
         }
         /// <summary>
         /// Delete a Factor Unenrolls an existing factor for the specified user, allowing the user to enroll a new factor.
@@ -514,10 +514,10 @@ namespace Okta.Sdk.Api
         /// <exception cref="Okta.Sdk.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="userId"></param>
         /// <param name="factorId"></param>
-        /// <param name="removeEnrollmentRecovery"> (optional, default to false)</param>
+        /// <param name="removeRecoveryEnrollment"> (optional, default to false)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Object>> DeleteFactorWithHttpInfoAsync(  string userId ,   string factorId ,   bool? removeEnrollmentRecovery = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Object>> DeleteFactorWithHttpInfoAsync(  string userId ,   string factorId ,   bool? removeRecoveryEnrollment = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'userId' is set
             if (userId == null)
@@ -556,9 +556,9 @@ namespace Okta.Sdk.Api
 
             localVarRequestOptions.PathParameters.Add("userId", Okta.Sdk.Client.ClientUtils.ParameterToString(userId)); // path parameter
             localVarRequestOptions.PathParameters.Add("factorId", Okta.Sdk.Client.ClientUtils.ParameterToString(factorId)); // path parameter
-            if (removeEnrollmentRecovery != null)
+            if (removeRecoveryEnrollment != null)
             {
-                localVarRequestOptions.QueryParameters.Add(Okta.Sdk.Client.ClientUtils.ParameterToMultiMap("", "removeEnrollmentRecovery", removeEnrollmentRecovery));
+                localVarRequestOptions.QueryParameters.Add(Okta.Sdk.Client.ClientUtils.ParameterToMultiMap("", "removeRecoveryEnrollment", removeRecoveryEnrollment));
             }
 
             // authentication (apiToken) required


### PR DESCRIPTION
- Per [docs](https://developer.okta.com/docs/reference/api/factors/#request-parameters-13):

removeRecoveryEnrollment | An optional parameter that allows removal of the the phone factor (SMS/Voice) as both a recovery method and a factor. |

- Fix #630 
- Official spec PR: https://github.com/okta/okta-oas3/pull/441