### PR TITLE
Make IDP Discovery Rule Application Id property non-readonly

### DIFF
--- a/src/Okta.Sdk/Model/AppAndInstanceConditionEvaluatorAppOrInstance.cs
+++ b/src/Okta.Sdk/Model/AppAndInstanceConditionEvaluatorAppOrInstance.cs
@@ -46,7 +46,7 @@ namespace Okta.Sdk.Model
         /// </summary>
         /// <value>ID of the app</value>
         [DataMember(Name = "id", EmitDefaultValue = true)]
-        public string Id { get; private set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Returns false as Id should not be serialized given that it's read-only.


### PR DESCRIPTION
## Summary
<!-- Be concise with your summary, but explain what changed -->
Updated the discovery rule application id property to be non-readonly. We are using this library to create idp discovery rules. When we set the property `Type` of `AppAndInstanceConditionEvaluatorAppOrInstance` and call the api, we get an error that says the Id property of the app must be set. With this ID property being readonly, we are unable to send that to the api.
<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes: N/A

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)


## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

.NET Version: .NET 8
Os Version: Windows 10

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I checked StyleCop warnings on my code

![ReadonlyProperty](https://github.com/okta/okta-sdk-dotnet/assets/3507458/e9709bfc-4ebe-4362-944f-3cb15fcf624f)


Exception is thrown when I attempt to create a policy rule without the id field being set:
`await _policyApiAsync.CreatePolicyRuleAsync(...);`

Okta.Sdk.Client.ApiException: 'Error calling CreatePolicyRule: {"errorCode":"E0000001","errorSummary":"Api validation failed: conditions.app","errorLink":"E0000001","errorId":"oaeWdhyrRMnRmS4h6LAslVS6g","errorCauses":[{"errorSummary":"conditions.app: The condition 'app' requires an 'id' value if the type is APP."},{"errorSummary":"conditions.app: The condition 'app' requires an 'id' value if the type is APP."}]}'
