### PR TITLE
OKTA-821867: fix AppLink definition by removing duplicate incorrect entry from spec

### DIFF
--- a/docs/AppLink.md
+++ b/docs/AppLink.md
@@ -4,8 +4,16 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Login** | [**HrefObjectAppLink**](HrefObjectAppLink.md) |  | [optional] 
-**Logo** | [**HrefObjectLogoLink**](HrefObjectLogoLink.md) |  | [optional] 
+**AppAssignmentId** | **string** |  | [optional] [readonly] 
+**AppInstanceId** | **string** |  | [optional] [readonly] 
+**AppName** | **string** |  | [optional] [readonly] 
+**CredentialsSetup** | **bool** |  | [optional] [readonly] 
+**Hidden** | **bool** |  | [optional] [readonly] 
+**Id** | **string** |  | [optional] [readonly] 
+**Label** | **string** |  | [optional] [readonly] 
+**LinkUrl** | **string** |  | [optional] [readonly] 
+**LogoUrl** | **string** |  | [optional] [readonly] 
+**SortOrder** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -47751,14 +47751,6 @@ components:
         siteDomain:
           type: string
           description: Your Zscaler domain
-    appLink:
-      type: object
-      properties:
-        login:
-          $ref: '#/components/schemas/HrefObjectAppLink'
-        logo:
-          $ref: '#/components/schemas/HrefObjectLogoLink'
-      readOnly: true
     createdProperty:
       description: Timestamp when the object was created
       format: date-time

--- a/src/Okta.Sdk/Model/AppLink.cs
+++ b/src/Okta.Sdk/Model/AppLink.cs
@@ -29,23 +29,151 @@ namespace Okta.Sdk.Model
     /// Template: ModelGeneric
     /// AppLink
     /// </summary>
-    [DataContract(Name = "appLink")]
+    [DataContract(Name = "AppLink")]
     
     public partial class AppLink : IEquatable<AppLink>
     {
         
         /// <summary>
-        /// Gets or Sets Login
+        /// Gets or Sets AppAssignmentId
         /// </summary>
-        [DataMember(Name = "login", EmitDefaultValue = true)]
-        public HrefObjectAppLink Login { get; set; }
+        [DataMember(Name = "appAssignmentId", EmitDefaultValue = true)]
+        public string AppAssignmentId { get; private set; }
 
         /// <summary>
-        /// Gets or Sets Logo
+        /// Returns false as AppAssignmentId should not be serialized given that it's read-only.
         /// </summary>
-        [DataMember(Name = "logo", EmitDefaultValue = true)]
-        public HrefObjectLogoLink Logo { get; set; }
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeAppAssignmentId()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets AppInstanceId
+        /// </summary>
+        [DataMember(Name = "appInstanceId", EmitDefaultValue = true)]
+        public string AppInstanceId { get; private set; }
 
+        /// <summary>
+        /// Returns false as AppInstanceId should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeAppInstanceId()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets AppName
+        /// </summary>
+        [DataMember(Name = "appName", EmitDefaultValue = true)]
+        public string AppName { get; private set; }
+
+        /// <summary>
+        /// Returns false as AppName should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeAppName()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets CredentialsSetup
+        /// </summary>
+        [DataMember(Name = "credentialsSetup", EmitDefaultValue = true)]
+        public bool CredentialsSetup { get; private set; }
+
+        /// <summary>
+        /// Returns false as CredentialsSetup should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeCredentialsSetup()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets Hidden
+        /// </summary>
+        [DataMember(Name = "hidden", EmitDefaultValue = true)]
+        public bool Hidden { get; private set; }
+
+        /// <summary>
+        /// Returns false as Hidden should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeHidden()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets Id
+        /// </summary>
+        [DataMember(Name = "id", EmitDefaultValue = true)]
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Returns false as Id should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeId()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets Label
+        /// </summary>
+        [DataMember(Name = "label", EmitDefaultValue = true)]
+        public string Label { get; private set; }
+
+        /// <summary>
+        /// Returns false as Label should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeLabel()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets LinkUrl
+        /// </summary>
+        [DataMember(Name = "linkUrl", EmitDefaultValue = true)]
+        public string LinkUrl { get; private set; }
+
+        /// <summary>
+        /// Returns false as LinkUrl should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeLinkUrl()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets LogoUrl
+        /// </summary>
+        [DataMember(Name = "logoUrl", EmitDefaultValue = true)]
+        public string LogoUrl { get; private set; }
+
+        /// <summary>
+        /// Returns false as LogoUrl should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeLogoUrl()
+        {
+            return false;
+        }
+        /// <summary>
+        /// Gets or Sets SortOrder
+        /// </summary>
+        [DataMember(Name = "sortOrder", EmitDefaultValue = true)]
+        public int SortOrder { get; private set; }
+
+        /// <summary>
+        /// Returns false as SortOrder should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeSortOrder()
+        {
+            return false;
+        }
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
@@ -54,8 +182,16 @@ namespace Okta.Sdk.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class AppLink {\n");
-            sb.Append("  Login: ").Append(Login).Append("\n");
-            sb.Append("  Logo: ").Append(Logo).Append("\n");
+            sb.Append("  AppAssignmentId: ").Append(AppAssignmentId).Append("\n");
+            sb.Append("  AppInstanceId: ").Append(AppInstanceId).Append("\n");
+            sb.Append("  AppName: ").Append(AppName).Append("\n");
+            sb.Append("  CredentialsSetup: ").Append(CredentialsSetup).Append("\n");
+            sb.Append("  Hidden: ").Append(Hidden).Append("\n");
+            sb.Append("  Id: ").Append(Id).Append("\n");
+            sb.Append("  Label: ").Append(Label).Append("\n");
+            sb.Append("  LinkUrl: ").Append(LinkUrl).Append("\n");
+            sb.Append("  LogoUrl: ").Append(LogoUrl).Append("\n");
+            sb.Append("  SortOrder: ").Append(SortOrder).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -92,14 +228,51 @@ namespace Okta.Sdk.Model
             }
             return 
                 (
-                    this.Login == input.Login ||
-                    (this.Login != null &&
-                    this.Login.Equals(input.Login))
+                    this.AppAssignmentId == input.AppAssignmentId ||
+                    (this.AppAssignmentId != null &&
+                    this.AppAssignmentId.Equals(input.AppAssignmentId))
                 ) && 
                 (
-                    this.Logo == input.Logo ||
-                    (this.Logo != null &&
-                    this.Logo.Equals(input.Logo))
+                    this.AppInstanceId == input.AppInstanceId ||
+                    (this.AppInstanceId != null &&
+                    this.AppInstanceId.Equals(input.AppInstanceId))
+                ) && 
+                (
+                    this.AppName == input.AppName ||
+                    (this.AppName != null &&
+                    this.AppName.Equals(input.AppName))
+                ) && 
+                (
+                    this.CredentialsSetup == input.CredentialsSetup ||
+                    this.CredentialsSetup.Equals(input.CredentialsSetup)
+                ) && 
+                (
+                    this.Hidden == input.Hidden ||
+                    this.Hidden.Equals(input.Hidden)
+                ) && 
+                (
+                    this.Id == input.Id ||
+                    (this.Id != null &&
+                    this.Id.Equals(input.Id))
+                ) && 
+                (
+                    this.Label == input.Label ||
+                    (this.Label != null &&
+                    this.Label.Equals(input.Label))
+                ) && 
+                (
+                    this.LinkUrl == input.LinkUrl ||
+                    (this.LinkUrl != null &&
+                    this.LinkUrl.Equals(input.LinkUrl))
+                ) && 
+                (
+                    this.LogoUrl == input.LogoUrl ||
+                    (this.LogoUrl != null &&
+                    this.LogoUrl.Equals(input.LogoUrl))
+                ) && 
+                (
+                    this.SortOrder == input.SortOrder ||
+                    this.SortOrder.Equals(input.SortOrder)
                 );
         }
 
@@ -113,14 +286,37 @@ namespace Okta.Sdk.Model
             {
                 int hashCode = 41;
                 
-                if (this.Login != null)
+                if (this.AppAssignmentId != null)
                 {
-                    hashCode = (hashCode * 59) + this.Login.GetHashCode();
+                    hashCode = (hashCode * 59) + this.AppAssignmentId.GetHashCode();
                 }
-                if (this.Logo != null)
+                if (this.AppInstanceId != null)
                 {
-                    hashCode = (hashCode * 59) + this.Logo.GetHashCode();
+                    hashCode = (hashCode * 59) + this.AppInstanceId.GetHashCode();
                 }
+                if (this.AppName != null)
+                {
+                    hashCode = (hashCode * 59) + this.AppName.GetHashCode();
+                }
+                hashCode = (hashCode * 59) + this.CredentialsSetup.GetHashCode();
+                hashCode = (hashCode * 59) + this.Hidden.GetHashCode();
+                if (this.Id != null)
+                {
+                    hashCode = (hashCode * 59) + this.Id.GetHashCode();
+                }
+                if (this.Label != null)
+                {
+                    hashCode = (hashCode * 59) + this.Label.GetHashCode();
+                }
+                if (this.LinkUrl != null)
+                {
+                    hashCode = (hashCode * 59) + this.LinkUrl.GetHashCode();
+                }
+                if (this.LogoUrl != null)
+                {
+                    hashCode = (hashCode * 59) + this.LogoUrl.GetHashCode();
+                }
+                hashCode = (hashCode * 59) + this.SortOrder.GetHashCode();
                 return hashCode;
             }
         }


### PR DESCRIPTION
Correct the AppLink class definition by deleting invalid duplicate definition from the spec.

Fixes #750 