### PR TITLE
fix: Resolve transient dependency conflict with Microsoft.IdentityModel.Protocols in JwtBearer authentication

### DIFF
--- a/openapi3/templates/netcore_project.mustache
+++ b/openapi3/templates/netcore_project.mustache
@@ -33,6 +33,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.4" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     {{/useGenericHost}}

--- a/src/Okta.Sdk/Okta.Sdk.csproj
+++ b/src/Okta.Sdk/Okta.Sdk.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.4" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="RestSharp" Version="112.0.0" />


### PR DESCRIPTION
Fixes #745

**Problem**

Applications using `Microsoft.AspNetCore.Authentication.JwtBearer` alongside Okta [[SDK.NET](http://sdk.net/)](http://sdk.net/) 8.2.0 encounter a runtime error (`IDX10500: Signature validation failed`) due to transient dependency mismatches. This occurs because the SDK indirectly references outdated versions of `Microsoft.IdentityModel.Protocols` and `Microsoft.IdentityModel.Protocols.OpenIdConnect`, breaking OpenID Connect metadata retrieval.

**Solution**

- Explicitly reference `Microsoft.IdentityModel.Protocols` (v8.2.0) and `Microsoft.IdentityModel.Protocols.OpenIdConnect` (v8.2.0) in the project file to enforce compatibility with `JwtBearer` 8.x.

**Impact**

- Restores correct signing key resolution for JWT validation.
- Prevents runtime failures in applications relying on `JwtBearer` authentication with Okta.

**Verification Steps**
Validate that `IDX10500` errors no longer occur during authentication.

---

### **Why This Works**

- The explicit package references override transitive dependencies, ensuring the correct versions of `Protocols` and `OpenIdConnect` are used.
- These packages contain critical logic for retrieving OpenID Connect metadata (e.g., signing keys), which resolves the `IDX10500` error.