### PR TITLE
Add support for new Okta TLD domains (okta-gov.com, okta.mil, okta-miltest.com, trex-govcloud.com)

### DIFF
--- a/openapi3/management-noEnums.yaml
+++ b/openapi3/management-noEnums.yaml
@@ -29,6 +29,10 @@ servers:
           - okta.com
           - oktapreview.com
           - okta-emea.com
+          - okta-gov.com
+          - okta.mil
+          - okta-miltest.com
+          - trex-govcloud.com
         default: okta.com
         description: The okta domain of your organization.
   - url: https://{customDomain}

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -20,7 +20,7 @@ servers:
     variables:
       yourOktaDomain:
         default: subdomain.okta.com
-        description: The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, etc) or one of your configured custom domains.
+        description: The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, okta-gov.com, okta.mil, okta-miltest.com, trex-govcloud.com, etc) or one of your configured custom domains.
 tags:
   - name: AgentPools
     x-displayName: Agent Pools

--- a/openapi3/templates/Configuration.mustache
+++ b/openapi3/templates/Configuration.mustache
@@ -275,7 +275,11 @@ namespace {{packageName}}.Client
                 if (configuration.OktaDomain.IndexOf("-admin.okta.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     configuration.OktaDomain.IndexOf("-admin.oktapreview.com", StringComparison.OrdinalIgnoreCase) >=
                     0 ||
-                    configuration.OktaDomain.IndexOf("-admin.okta-emea.com", StringComparison.OrdinalIgnoreCase) >= 0)
+                    configuration.OktaDomain.IndexOf("-admin.okta-emea.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta-gov.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta.mil", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta-miltest.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.trex-govcloud.com", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     throw new ArgumentNullException(nameof(configuration.OktaDomain),
                         $"Your Okta domain should not contain -admin. Current value: {configuration.OktaDomain}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain");

--- a/src/Okta.Sdk.UnitTest/Client/OktaConfigurationShould.cs
+++ b/src/Okta.Sdk.UnitTest/Client/OktaConfigurationShould.cs
@@ -48,6 +48,10 @@ namespace Okta.Sdk.UnitTest.Client
         [InlineData("https://foo-admin.okta.com")]
         [InlineData("https://foo-admin.oktapreview.com")]
         [InlineData("https://https://foo-admin.okta-emea.com")]
+        [InlineData("https://foo-admin.okta-gov.com")]
+        [InlineData("https://foo-admin.okta.mil")]
+        [InlineData("https://foo-admin.okta-miltest.com")]
+        [InlineData("https://foo-admin.trex-govcloud.com")]
         public void FailIfOktaDomainContainsAdminKeyword(string oktaDomain)
         {
             var configuration = new Configuration();
@@ -121,6 +125,21 @@ namespace Okta.Sdk.UnitTest.Client
             configuration.OktaDomain = oktaDomain;
             configuration.Token = "foo";
             configuration.DisableHttpsCheck = true;
+
+            Action action = () => Configuration.Validate(configuration);
+            action.Should().NotThrow<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData("https://myOktaDomain.okta-gov.com")]
+        [InlineData("https://myOktaDomain.okta.mil")]
+        [InlineData("https://myOktaDomain.okta-miltest.com")]
+        [InlineData("https://myOktaDomain.trex-govcloud.com")]
+        public void NotFailForValidNewOktaDomains(string oktaDomain)
+        {
+            var configuration = new Configuration();
+            configuration.OktaDomain = oktaDomain;
+            configuration.Token = "foo";
 
             Action action = () => Configuration.Validate(configuration);
             action.Should().NotThrow<ArgumentException>();

--- a/src/Okta.Sdk/Client/Configuration.cs
+++ b/src/Okta.Sdk/Client/Configuration.cs
@@ -275,7 +275,11 @@ namespace Okta.Sdk.Client
                 if (configuration.OktaDomain.IndexOf("-admin.okta.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     configuration.OktaDomain.IndexOf("-admin.oktapreview.com", StringComparison.OrdinalIgnoreCase) >=
                     0 ||
-                    configuration.OktaDomain.IndexOf("-admin.okta-emea.com", StringComparison.OrdinalIgnoreCase) >= 0)
+                    configuration.OktaDomain.IndexOf("-admin.okta-emea.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta-gov.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta.mil", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.okta-miltest.com", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    configuration.OktaDomain.IndexOf("-admin.trex-govcloud.com", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     throw new ArgumentNullException(nameof(configuration.OktaDomain),
                         $"Your Okta domain should not contain -admin. Current value: {configuration.OktaDomain}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain");
@@ -403,7 +407,7 @@ namespace Okta.Sdk.Client
                             "variables", new Dictionary<string, object> {
                                 {
                                     "yourOktaDomain", new Dictionary<string, object> {
-                                        {"description", "The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, etc) or one of your configured custom domains."},
+                                        {"description", "The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, okta-gov.com, okta.mil, okta-miltest.com, trex-govcloud.com, etc) or one of your configured custom domains."},
                                         {"default_value", "subdomain.okta.com"},
                                     }
                                 }


### PR DESCRIPTION
## Summary
This PR adds support for new Okta TLD domains as part of the TG1 TLD Update initiative. The SDK now properly validates and accepts the following new domains:

- `okta-gov.com` - New production domain for OG1
- `okta.mil` - New production domain for OK15  
- `okta-miltest.com` - New test domain for testing transition
- `trex-govcloud.com` - New government cloud domain

## Changes Made
- **Domain Validation**: Updated Configuration.cs to include new domains in admin keyword validation
- **Templates**: Updated code generation templates to include new domains
- **OpenAPI Specs**: Updated management.yaml and management-noEnums.yaml with new domain enums

## Testing
- Added negative test cases to ensure URLs with `-admin` are rejected for new domains
- Added positive test cases to ensure URLs without `-admin` are accepted for new domains
- All existing tests continue to pass

## Security
Maintains existing security validations to prevent users from accidentally using admin URLs with the new domains.

## Issue Reference
Addresses TG1 TLD Update requirements for okta-sdk-dotnet repository.