### PR TITLE
Fix: Make samlAssertionLifetimeSeconds nullable

### DIFF
--- a/docs/OINSaml20ApplicationSettingsSignOn.md
+++ b/docs/OINSaml20ApplicationSettingsSignOn.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **DefaultRelayState** | **string** | Identifies a specific application resource in an IdP-initiated SSO scenario | [optional] 
 **DestinationOverride** | **string** | Destination override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
 **RecipientOverride** | **string** | Recipient override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
-**SamlAssertionLifetimeSeconds** | **int** | Determines the SAML app session lifetimes with Okta | [optional] 
+**SamlAssertionLifetimeSeconds** | **int?** | Determines the SAML app session lifetimes with Okta | [optional] 
 **SsoAcsUrlOverride** | **string** | Assertion Consumer Service (ACS) URL override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/SamlApplicationSettingsSignOn.md
+++ b/docs/SamlApplicationSettingsSignOn.md
@@ -26,7 +26,7 @@ Name | Type | Description | Notes
 **RecipientOverride** | **string** | Recipient override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
 **RequestCompressed** | **bool** | Determines whether the SAML request is expected to be compressed | 
 **ResponseSigned** | **bool** | Determines whether the SAML authentication response message is digitally signed by the IdP &gt; **Note:** Either (or both) &#x60;responseSigned&#x60; or &#x60;assertionSigned&#x60; must be &#x60;TRUE&#x60;. | 
-**SamlAssertionLifetimeSeconds** | **int** | Determines the SAML app session lifetimes with Okta | [optional] 
+**SamlAssertionLifetimeSeconds** | **int?** | Determines the SAML app session lifetimes with Okta | [optional] 
 **SignatureAlgorithm** | **string** | Determines the signing algorithm used to digitally sign the SAML assertion and response | 
 **Slo** | [**SingleLogout**](SingleLogout.md) |  | [optional] 
 **SpCertificate** | [**SamlSpCertificate**](SamlSpCertificate.md) |  | [optional] 

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -67864,6 +67864,7 @@ components:
             lifecycle: GA
             isGenerallyAvailable: true
           type: integer
+          nullable: true
           description: Determines the SAML app session lifetimes with Okta
           example: 3600
         ssoAcsUrlOverride:
@@ -73393,6 +73394,7 @@ components:
             lifecycle: GA
             isGenerallyAvailable: true
           type: integer
+          nullable: true
           description: Determines the SAML app session lifetimes with Okta
           example: 3600
         signatureAlgorithm:

--- a/src/Okta.Sdk/Model/OINSaml20ApplicationSettingsSignOn.cs
+++ b/src/Okta.Sdk/Model/OINSaml20ApplicationSettingsSignOn.cs
@@ -79,7 +79,7 @@ namespace Okta.Sdk.Model
         /// </summary>
         /// <value>Determines the SAML app session lifetimes with Okta</value>
         [DataMember(Name = "samlAssertionLifetimeSeconds", EmitDefaultValue = true)]
-        public int SamlAssertionLifetimeSeconds { get; set; }
+        public int? SamlAssertionLifetimeSeconds { get; set; }
 
         /// <summary>
         /// Assertion Consumer Service (ACS) URL override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm).
@@ -166,7 +166,8 @@ namespace Okta.Sdk.Model
                 ) && 
                 (
                     this.SamlAssertionLifetimeSeconds == input.SamlAssertionLifetimeSeconds ||
-                    this.SamlAssertionLifetimeSeconds.Equals(input.SamlAssertionLifetimeSeconds)
+                    (this.SamlAssertionLifetimeSeconds != null &&
+                    this.SamlAssertionLifetimeSeconds.Equals(input.SamlAssertionLifetimeSeconds))
                 ) && 
                 (
                     this.SsoAcsUrlOverride == input.SsoAcsUrlOverride ||
@@ -205,7 +206,10 @@ namespace Okta.Sdk.Model
                 {
                     hashCode = (hashCode * 59) + this.RecipientOverride.GetHashCode();
                 }
-                hashCode = (hashCode * 59) + this.SamlAssertionLifetimeSeconds.GetHashCode();
+                if (this.SamlAssertionLifetimeSeconds != null)
+                {
+                    hashCode = (hashCode * 59) + this.SamlAssertionLifetimeSeconds.GetHashCode();
+                }
                 if (this.SsoAcsUrlOverride != null)
                 {
                     hashCode = (hashCode * 59) + this.SsoAcsUrlOverride.GetHashCode();

--- a/src/Okta.Sdk/Model/SamlApplicationSettingsSignOn.cs
+++ b/src/Okta.Sdk/Model/SamlApplicationSettingsSignOn.cs
@@ -404,7 +404,7 @@ namespace Okta.Sdk.Model
         /// </summary>
         /// <value>Determines the SAML app session lifetimes with Okta</value>
         [DataMember(Name = "samlAssertionLifetimeSeconds", EmitDefaultValue = true)]
-        public int SamlAssertionLifetimeSeconds { get; set; }
+        public int? SamlAssertionLifetimeSeconds { get; set; }
 
         /// <summary>
         /// Gets or Sets Slo
@@ -623,7 +623,8 @@ namespace Okta.Sdk.Model
                 ) && 
                 (
                     this.SamlAssertionLifetimeSeconds == input.SamlAssertionLifetimeSeconds ||
-                    this.SamlAssertionLifetimeSeconds.Equals(input.SamlAssertionLifetimeSeconds)
+                    (this.SamlAssertionLifetimeSeconds != null &&
+                    this.SamlAssertionLifetimeSeconds.Equals(input.SamlAssertionLifetimeSeconds))
                 ) && 
                 (
                     this.SignatureAlgorithm == input.SignatureAlgorithm ||
@@ -744,7 +745,10 @@ namespace Okta.Sdk.Model
                 }
                 hashCode = (hashCode * 59) + this.RequestCompressed.GetHashCode();
                 hashCode = (hashCode * 59) + this.ResponseSigned.GetHashCode();
-                hashCode = (hashCode * 59) + this.SamlAssertionLifetimeSeconds.GetHashCode();
+                if (this.SamlAssertionLifetimeSeconds != null)
+                {
+                    hashCode = (hashCode * 59) + this.SamlAssertionLifetimeSeconds.GetHashCode();
+                }
                 if (this.SignatureAlgorithm != null)
                 {
                     hashCode = (hashCode * 59) + this.SignatureAlgorithm.GetHashCode();


### PR DESCRIPTION
Fixes serialization issue where samlAssertionLifetimeSeconds was always sending 0 causing API 400 errors.

Changes:
- Added `nullable: true` to OpenAPI spec for samlAssertionLifetimeSeconds
- Changed property type from `int` to `int?` in generated models
- Aligns with Go, Python, and Java SDK implementations

Resolves: OKTA-1062696