### PR TITLE
chore: Move artifact publishing to internal pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
           paths:
             - src
             - .git
-            - artifacts
 
   transform-regenerate:
     description: transform spec, regenerate the SDK, build and run tests

--- a/build.cake
+++ b/build.cake
@@ -62,7 +62,6 @@ Task("Test")
 .Does(() =>
 {
     var testProjects = new[] { "Okta.Sdk.UnitTest" };
-    //Run Integration tests on internal repo
     foreach (var name in testProjects)
     {
         DotNetCoreTest(string.Format("./src/{0}/{0}.csproj", name));
@@ -75,8 +74,6 @@ Task("IntegrationTest")
 .Does(() =>
 {
     var testProjects = new[] { "Okta.Sdk.IntegrationTest" };
-    // Run integration tests in nightly CI cron job
-
     foreach (var name in testProjects)
     {
         DotNetCoreTest(string.Format("./src/{0}/{0}.csproj", name));
@@ -90,8 +87,7 @@ Task("Default")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
-    .IsDependentOn("Test")
-    .IsDependentOn("Pack");
+    .IsDependentOn("Test");
 
 Task("DefaultIT")
     .IsDependentOn("Clean")


### PR DESCRIPTION
Moves NuGet package publishing from the public pipeline to the internal pipeline only.

## Changes
- Remove artifact upload step from public pipeline
- Remove Pack from Default build target (public uses Default, internal uses DefaultIT which includes Pack)
- Update workflow and job naming to match sdk-abstractions pattern
- Internal pipeline uses `win-helpers/nuget-push-to-artifactory` to publish packages

## Related
Requires corresponding changes in okta-sdk-dotnet-internal repo.