### PR TITLE
Fix DPoP htu using template path (#825)

### DIFF
--- a/openapi3/templates/ApiClient.mustache
+++ b/openapi3/templates/ApiClient.mustache
@@ -653,7 +653,11 @@ namespace {{packageName}}.Client
 
                 if (token.IsDpopBound)
                 {
-                    dpopJwt = _authTokenProvider.GetDpopProofJwt(httpMethod: request.Method.ToString(), uri: request.Resource, accessToken: token.AccessToken);
+                    var expandedResource = request.Parameters
+                        .Where(p => p.Type == ParameterType.UrlSegment)
+                        .Aggregate(request.Resource, (current, param) => current.Replace("{" + param.Name + "}", param.Value?.ToString() ?? string.Empty));
+                    var absoluteUri = new Uri(new Uri(configuration.OktaDomain, UriKind.Absolute), new Uri(expandedResource, UriKind.RelativeOrAbsolute)).AbsoluteUri;
+                    dpopJwt = _authTokenProvider.GetDpopProofJwt(httpMethod: request.Method.ToString(), uri: absoluteUri, accessToken: token.AccessToken);
                 }
             }
 

--- a/openapi3/templates/DefaultOAuthTokenProvider.mustache
+++ b/openapi3/templates/DefaultOAuthTokenProvider.mustache
@@ -254,8 +254,10 @@ namespace {{packageName}}.Client
 
             if (tokenResponse.IsDpopBound)
             {
-                string requestUri = response.Result.Request.Parameters.Aggregate(response.Result.Request.Resource, (current, parameter) => current.Replace("{" + parameter.Name + "}", parameter.Value.ToString()));
-                var uri = new Uri(requestUri, UriKind.RelativeOrAbsolute);
+                string requestUri = response.Result.Request.Parameters
+                    .Where(p => p.Type == RestSharp.ParameterType.UrlSegment)
+                    .Aggregate(response.Result.Request.Resource, (current, parameter) => current.Replace("{" + parameter.Name + "}", parameter.Value?.ToString() ?? string.Empty));
+                var uri = new Uri(new Uri(this.Configuration.OktaDomain, UriKind.Absolute), new Uri(requestUri, UriKind.RelativeOrAbsolute));
                 
                 var dPopJwt = _defaultDpopJwtGenerator.GenerateJwt(
                     httpMethod: response.Result.Request.Method.ToString(), accessToken: tokenResponse.AccessToken,

--- a/openapi3/templates/OktaPagedCollectionEnumerator.mustache
+++ b/openapi3/templates/OktaPagedCollectionEnumerator.mustache
@@ -119,7 +119,8 @@ namespace {{packageName}}.Client
             
             if ({{packageName}}.Client.Configuration.IsPrivateKeyMode(_configuration))
             {
-                await _oAuthTokenProvider.AddOrUpdateAuthorizationHeader(_nextRequest, _nextPath, "GET", _cancellationToken);
+                var expandedPath = _nextRequest.PathParameters.Aggregate(_nextPath, (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+                await _oAuthTokenProvider.AddOrUpdateAuthorizationHeader(_nextRequest, expandedPath, "GET", _cancellationToken);
             }
             
             var response = await _client.GetAsync<IEnumerable<T>>(_nextPath, _nextRequest, _configuration, _cancellationToken).ConfigureAwait(false);

--- a/src/Okta.Sdk.UnitTest/Client/DpopPathParameterExpansionShould.cs
+++ b/src/Okta.Sdk.UnitTest/Client/DpopPathParameterExpansionShould.cs
@@ -1,0 +1,130 @@
+// <copyright file="DpopPathParameterExpansionShould.cs" company="Okta, Inc">
+// Copyright (c) 2014-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using RestSharp;
+using Xunit;
+
+namespace Okta.Sdk.UnitTest.Client
+{
+    /// <summary>
+    /// Tests for path parameter expansion in DPoP htu claim.
+    /// When using private key authentication with DPoP, the htu claim must use
+    /// the expanded path (e.g., /api/v1/groups/00g123/users) instead of the 
+    /// template path (e.g., /api/v1/groups/{groupId}/users).
+    /// </summary>
+    public class DpopPathParameterExpansionShould
+    {
+        [Theory]
+        [InlineData("/api/v1/groups/{groupId}/users", "groupId", "00g123abc", "/api/v1/groups/00g123abc/users")]
+        [InlineData("/api/v1/users/{userId}", "userId", "00u456def", "/api/v1/users/00u456def")]
+        [InlineData("/api/v1/apps/{appId}/users/{userId}", "appId", "0oa789ghi", "/api/v1/apps/0oa789ghi/users/{userId}")]
+        public void ExpandSinglePathParameter(string templatePath, string paramName, string paramValue, string expectedPath)
+        {
+            // Arrange
+            var pathParameters = new Dictionary<string, string> { { paramName, paramValue } };
+
+            // Act - This is the exact expansion logic used in OktaPagedCollectionEnumerator
+            var expandedPath = pathParameters.Aggregate(templatePath, 
+                (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+
+            // Assert
+            expandedPath.Should().Be(expectedPath);
+        }
+
+        [Fact]
+        public void ExpandMultiplePathParameters()
+        {
+            // Arrange
+            var templatePath = "/api/v1/apps/{appId}/users/{userId}";
+            var pathParameters = new Dictionary<string, string>
+            {
+                { "appId", "0oa789ghi" },
+                { "userId", "00u456def" }
+            };
+
+            // Act
+            var expandedPath = pathParameters.Aggregate(templatePath, 
+                (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+
+            // Assert
+            expandedPath.Should().Be("/api/v1/apps/0oa789ghi/users/00u456def");
+            expandedPath.Should().NotContain("{");
+            expandedPath.Should().NotContain("}");
+        }
+
+        [Fact]
+        public void ExpandPathParametersFromRestSharpRequest()
+        {
+            // Arrange - Simulates how RestSharp stores path parameters as UrlSegment
+            var templatePath = "/api/v1/groups/{groupId}/users";
+            var request = new RestRequest(templatePath);
+            request.AddUrlSegment("groupId", "00g123abc");
+
+            // Act - This is the exact expansion logic used in ApiClient and DefaultOAuthTokenProvider
+            var expandedPath = request.Parameters
+                .Where(p => p.Type == ParameterType.UrlSegment)
+                .Aggregate(request.Resource, 
+                    (current, param) => current.Replace("{" + param.Name + "}", param.Value?.ToString() ?? string.Empty));
+
+            // Assert
+            expandedPath.Should().Be("/api/v1/groups/00g123abc/users");
+        }
+
+        [Fact]
+        public void CreateCorrectAbsoluteUriForDpopHtu()
+        {
+            // Arrange
+            var oktaDomain = "https://example.okta.com";
+            var templatePath = "/api/v1/groups/{groupId}/users";
+            var request = new RestRequest(templatePath);
+            request.AddUrlSegment("groupId", "00g123abc");
+
+            // Act - Simulates the full URI construction used for DPoP htu
+            var expandedResource = request.Parameters
+                .Where(p => p.Type == ParameterType.UrlSegment)
+                .Aggregate(request.Resource, 
+                    (current, param) => current.Replace("{" + param.Name + "}", param.Value?.ToString() ?? string.Empty));
+            var absoluteUri = new System.Uri(new System.Uri(oktaDomain, System.UriKind.Absolute), 
+                new System.Uri(expandedResource, System.UriKind.RelativeOrAbsolute)).AbsoluteUri;
+
+            // Assert
+            absoluteUri.Should().Be("https://example.okta.com/api/v1/groups/00g123abc/users");
+            absoluteUri.Should().NotContain("{groupId}");
+        }
+
+        [Fact]
+        public void HandleEmptyPathParameters()
+        {
+            // Arrange
+            var templatePath = "/api/v1/users";
+            var pathParameters = new Dictionary<string, string>();
+
+            // Act
+            var expandedPath = pathParameters.Aggregate(templatePath, 
+                (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+
+            // Assert
+            expandedPath.Should().Be("/api/v1/users");
+        }
+
+        [Fact]
+        public void HandlePathWithNoPlaceholders()
+        {
+            // Arrange
+            var path = "/api/v1/users";
+            var pathParameters = new Dictionary<string, string> { { "unusedParam", "value" } };
+
+            // Act
+            var expandedPath = pathParameters.Aggregate(path, 
+                (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+
+            // Assert
+            expandedPath.Should().Be("/api/v1/users");
+        }
+    }
+}

--- a/src/Okta.Sdk/Client/ApiClient.cs
+++ b/src/Okta.Sdk/Client/ApiClient.cs
@@ -646,7 +646,11 @@ namespace Okta.Sdk.Client
 
                 if (token.IsDpopBound)
                 {
-                    dpopJwt = _authTokenProvider.GetDpopProofJwt(httpMethod: request.Method.ToString(), uri: request.Resource, accessToken: token.AccessToken);
+                    var expandedResource = request.Parameters
+                        .Where(p => p.Type == ParameterType.UrlSegment)
+                        .Aggregate(request.Resource, (current, param) => current.Replace("{" + param.Name + "}", param.Value?.ToString() ?? string.Empty));
+                    var absoluteUri = new Uri(new Uri(configuration.OktaDomain, UriKind.Absolute), new Uri(expandedResource, UriKind.RelativeOrAbsolute)).AbsoluteUri;
+                    dpopJwt = _authTokenProvider.GetDpopProofJwt(httpMethod: request.Method.ToString(), uri: absoluteUri, accessToken: token.AccessToken);
                 }
             }
 

--- a/src/Okta.Sdk/Client/DefaultOAuthTokenProvider.cs
+++ b/src/Okta.Sdk/Client/DefaultOAuthTokenProvider.cs
@@ -268,8 +268,10 @@ namespace Okta.Sdk.Client
 
             if (tokenResponse.IsDpopBound)
             {
-                string requestUri = response.Result.Request.Parameters.Aggregate(response.Result.Request.Resource, (current, parameter) => current.Replace("{" + parameter.Name + "}", parameter.Value.ToString()));
-                var uri = new Uri(requestUri, UriKind.RelativeOrAbsolute);
+                string requestUri = response.Result.Request.Parameters
+                    .Where(p => p.Type == RestSharp.ParameterType.UrlSegment)
+                    .Aggregate(response.Result.Request.Resource, (current, parameter) => current.Replace("{" + parameter.Name + "}", parameter.Value?.ToString() ?? string.Empty));
+                var uri = new Uri(new Uri(this.Configuration.OktaDomain, UriKind.Absolute), new Uri(requestUri, UriKind.RelativeOrAbsolute));
                 
                 var dPopJwt = _defaultDpopJwtGenerator.GenerateJwt(
                     httpMethod: response.Result.Request.Method.ToString(), accessToken: tokenResponse.AccessToken,

--- a/src/Okta.Sdk/Client/OktaPagedCollectionEnumerator.cs
+++ b/src/Okta.Sdk/Client/OktaPagedCollectionEnumerator.cs
@@ -133,7 +133,8 @@ namespace Okta.Sdk.Client
             
             if (Okta.Sdk.Client.Configuration.IsPrivateKeyMode(_configuration))
             {
-                await _oAuthTokenProvider.AddOrUpdateAuthorizationHeader(_nextRequest, _nextPath, "GET", _cancellationToken);
+                var expandedPath = _nextRequest.PathParameters.Aggregate(_nextPath, (current, param) => current.Replace("{" + param.Key + "}", param.Value));
+                await _oAuthTokenProvider.AddOrUpdateAuthorizationHeader(_nextRequest, expandedPath, "GET", _cancellationToken);
             }
             
             var response = await _client.GetAsync<IEnumerable<T>>(_nextPath, _nextRequest, _configuration, _cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #825

**Problem:** DPoP `htu` claim used template paths like `/api/v1/groups/{groupId}/users` instead of expanded paths, causing 400 errors during pagination.

**Fix:** Expand path parameters before generating DPoP JWTs in:
- `OktaPagedCollectionEnumerator.MoveNextAsync()`
- `ApiClient.ExecuteAsyncWithRetryHeadersAsync()`
- `DefaultOAuthTokenProvider.OnOAuthRetryAsync()`

**Tests:** Added 8 unit tests for path expansion logic.