### PR TITLE
Fix null type serialization in AuthorizationServerPolicyRuleRequest

### DIFF
--- a/docs/AuthorizationServerPolicyRule.md
+++ b/docs/AuthorizationServerPolicyRule.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **Priority** | **int** | Priority of the rule | [optional] 
 **Status** | **string** | Status of the rule | [optional] 
 **System** | **bool** | Set to &#x60;true&#x60; for system rules. You can&#39;t delete system rules. | [optional] 
-**Type** | **string** | Rule type | [optional] 
+**Type** | **string** | Rule type | [optional] [default to TypeEnum.RESOURCEACCESS]
 **Links** | [**AuthorizationServerPolicyRuleLinks**](AuthorizationServerPolicyRuleLinks.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/AuthorizationServerPolicyRuleRequest.md
+++ b/docs/AuthorizationServerPolicyRuleRequest.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **Priority** | **int** | Priority of the rule | [optional] 
 **Status** | **string** | Status of the rule | [optional] 
 **System** | **bool** | Set to &#x60;true&#x60; for system rules. You can&#39;t delete system rules. | [optional] 
-**Type** | **string** | Rule type | 
+**Type** | **string** | Rule type | [default to TypeEnum.RESOURCEACCESS]
 **Links** | [**AuthorizationServerPolicyRuleLinks**](AuthorizationServerPolicyRuleLinks.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -58858,6 +58858,7 @@ components:
           description: Rule type
           enum:
             - RESOURCE_ACCESS
+          default: RESOURCE_ACCESS
         _links:
           allOf:
             - $ref: '#/components/schemas/LinksSelfAndLifecycle'
@@ -58887,6 +58888,7 @@ components:
           items:
             type: string
     AuthorizationServerPolicyRuleRequest:
+      x-constructor-init: true
       allOf:
         - $ref: '#/components/schemas/AuthorizationServerPolicyRule'
         - type: object

--- a/openapi3/templates/modelGeneric.mustache
+++ b/openapi3/templates/modelGeneric.mustache
@@ -118,7 +118,21 @@
         /// </summary>
         [JsonConstructorAttribute]
         {{^isAdditionalPropertiesTrue}}
+        {{#vendorExtensions.x-constructor-init}}
+        public {{classname}}()
+        {
+            {{#vars}}
+            {{#isEnum}}
+            {{#defaultValue}}
+            this.{{name}} = {{{defaultValue}}};
+            {{/defaultValue}}
+            {{/isEnum}}
+            {{/vars}}
+        }
+        {{/vendorExtensions.x-constructor-init}}
+        {{^vendorExtensions.x-constructor-init}}
         public {{classname}}() { }
+        {{/vendorExtensions.x-constructor-init}}
         {{/isAdditionalPropertiesTrue}}
         {{#isAdditionalPropertiesTrue}}
         public {{classname}}()

--- a/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleRequest.cs
+++ b/src/Okta.Sdk/Model/AuthorizationServerPolicyRuleRequest.cs
@@ -124,7 +124,10 @@ namespace Okta.Sdk.Model
         /// Initializes a new instance of the <see cref="AuthorizationServerPolicyRuleRequest" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public AuthorizationServerPolicyRuleRequest() { }
+        public AuthorizationServerPolicyRuleRequest()
+        {
+            this.Type = TypeEnum.RESOURCEACCESS;
+        }
         
         /// <summary>
         /// Gets or Sets Actions


### PR DESCRIPTION
Fixes #850

**Problem:** `ReplaceAuthorizationServerPolicyRuleAsync` fails with E0000003 because `type` serializes as `null` when not explicitly set.

**Solution:** Initialize `Type` to `RESOURCE_ACCESS` in constructor via OpenAPI spec default and template change.