### PR TITLE
Fix Application name serialization for enum-typed properties

### DIFF
--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -59219,6 +59219,7 @@ components:
             name:
               type: string
               description: '`template_basic_auth` is the key name for a Basic Authentication scheme app instance'
+              x-override-parent: true
               enum:
                 - template_basic_auth
             settings:
@@ -59379,6 +59380,7 @@ components:
             name:
               type: string
               description: '`bookmark` is the key name for a Bookmark app'
+              x-override-parent: true
               enum:
                 - bookmark
             settings:
@@ -59528,6 +59530,7 @@ components:
             name:
               type: string
               description: The key name for the app definition
+              x-override-parent: true
               enum:
                 - template_swa
                 - template_swa3field
@@ -68845,6 +68848,7 @@ components:
             name:
               type: string
               description: '`oidc_client` is the key name for an OAuth 2.0 client app instance'
+              x-override-parent: true
               enum:
                 - oidc_client
             settings:
@@ -74134,6 +74138,7 @@ components:
             name:
               type: string
               description: '`template_sps` is the key name for a SWA app instance that uses HTTP POST and doesn''t require a browser plugin'
+              x-override-parent: true
               enum:
                 - template_sps
             settings:
@@ -79631,6 +79636,7 @@ components:
             name:
               type: string
               description: '`template_wsfed` is the key name for a WS-Federated app instance with a SAML 2.0 token'
+              x-override-parent: true
               enum:
                 - template_wsfed
             settings:

--- a/openapi3/templates/ApiClient.mustache
+++ b/openapi3/templates/ApiClient.mustache
@@ -56,7 +56,11 @@ namespace {{packageName}}.Client
                     OverrideSpecifiedNames = false
                 }
             },
-            NullValueHandling = NullValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = new List<JsonConverter>
+            {
+                new {{{packageName}}}.{{modelPackage}}.StringEnumSerializingConverter()
+            }
         };
 
         internal JsonSerializerSettings JsonSerializer
@@ -208,7 +212,11 @@ namespace {{packageName}}.Client
                     OverrideSpecifiedNames = false
                 }
             },
-            NullValueHandling = NullValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = new List<JsonConverter>
+            {
+                new {{{packageName}}}.{{modelPackage}}.StringEnumSerializingConverter()
+            }
         };
 
         /// <summary>

--- a/openapi3/templates/StringEnumSerializingConverter.mustache
+++ b/openapi3/templates/StringEnumSerializingConverter.mustache
@@ -31,9 +31,15 @@ namespace {{packageName}}.Model
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var enumValue = (value as StringEnum)?.Value ?? string.Empty;
+            var stringEnum = value as StringEnum;
+            
+            if (stringEnum == null || string.IsNullOrEmpty(stringEnum.Value))
+            {
+                writer.WriteNull();
+                return;
+            }
 
-            serializer.Serialize(writer, enumValue);
+            writer.WriteValue(stringEnum.Value);
         }
     }
 }

--- a/openapi3/templates/modelGeneric.mustache
+++ b/openapi3/templates/modelGeneric.mustache
@@ -50,8 +50,20 @@
         [Obsolete]
         {{/deprecated}}
         
-        public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}{{^isEnum}}?{{/isEnum}}{{/required}}{{/isContainer}} {{name}} { get; set; }
+        public {{#vendorExtensions.x-override-parent}}new {{/vendorExtensions.x-override-parent}}{{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}{{^isEnum}}?{{/isEnum}}{{/required}}{{/isContainer}} {{name}} { get; set; }
+        {{#vendorExtensions.x-override-parent}}
+
+        /// <summary>
+        /// Returns true if {{name}} should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if {{name}} has a value, false otherwise</returns>
+        public new bool ShouldSerialize{{name}}()
+        {
+            return {{name}} != null && !string.IsNullOrEmpty({{name}}.Value);
+        }
+        {{/vendorExtensions.x-override-parent}}
         {{#isReadOnly}}
+        {{^vendorExtensions.x-override-parent}}
 
         /// <summary>
         /// Returns false as {{name}} should not be serialized given that it's read-only.
@@ -61,6 +73,7 @@
         {
             return false;
         }
+        {{/vendorExtensions.x-override-parent}}
         {{/isReadOnly}}
         {{/conditionalSerialization}}
         {{#conditionalSerialization}}

--- a/src/Okta.Sdk.IntegrationTest/ApplicationApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/ApplicationApiTests.cs
@@ -111,7 +111,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = $"dotnet-sdk-test: BookmarkApp {guid}",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication
@@ -144,7 +153,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "template_basic_auth",
                     Label = $"dotnet-sdk-test: BasicAuthApp {guid}",
-                    SignOnMode = "BASIC_AUTH",
+                    SignOnMode = ApplicationSignOnMode.BASICAUTH,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BasicApplicationSettings
                     {
                         App = new BasicApplicationSettingsApplication
@@ -177,7 +195,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = $"dotnet-sdk-test: InactiveApp {guid}",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication
@@ -199,7 +226,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "oidc_client",
                     Label = $"dotnet-sdk-test: OIDCApp {guid}",
-                    SignOnMode = "OPENID_CONNECT",
+                    SignOnMode = ApplicationSignOnMode.OPENIDCONNECT,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Credentials = new OAuthApplicationCredentials
                     {
                         OauthClient = new ApplicationCredentialsOAuthClient
@@ -241,7 +277,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "template_swa",
                     Label = $"dotnet-sdk-test: BrowserPluginApp {guid}",
-                    SignOnMode = "BROWSER_PLUGIN",
+                    SignOnMode = ApplicationSignOnMode.BROWSERPLUGIN,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new SwaApplicationSettings
                     {
                         App = new SwaApplicationSettingsApplication
@@ -541,7 +586,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = "Dummy",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication
@@ -570,7 +624,16 @@ namespace Okta.Sdk.IntegrationTest
                         {
                             Name = "bookmark",
                             Label = $"dotnet-sdk-test: PaginationApp-{i}-{guid}",
-                            SignOnMode = "BOOKMARK",
+                            SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                            Visibility = new ApplicationVisibility
+                            {
+                                AutoSubmitToolbar = false,
+                                Hide = new ApplicationVisibilityHide
+                                {
+                                    IOS = false,
+                                    Web = false
+                                }
+                            },
                             Settings = new BookmarkApplicationSettings
                             {
                                 App = new BookmarkApplicationSettingsApplication
@@ -632,7 +695,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = $"dotnet-sdk-test: ActiveDeleteTest {guid}",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication
@@ -700,7 +772,16 @@ namespace Okta.Sdk.IntegrationTest
                     {
                         Name = "bookmark",
                         Label = $"dotnet-sdk-test: EnumerationTest-{i}-{guid}",
-                        SignOnMode = "BOOKMARK",
+                        SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                        Visibility = new ApplicationVisibility
+                        {
+                            AutoSubmitToolbar = false,
+                            Hide = new ApplicationVisibilityHide
+                            {
+                                IOS = false,
+                                Web = false
+                            }
+                        },
                         Settings = new BookmarkApplicationSettings
                         {
                             App = new BookmarkApplicationSettingsApplication
@@ -774,7 +855,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = $"dotnet-sdk-test: MinimalApp {guid}",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication

--- a/src/Okta.Sdk.IntegrationTest/ApplicationConnectionsApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/ApplicationConnectionsApiTests.cs
@@ -107,7 +107,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "oidc_client",
                     Label = $"dotnet-sdk-test-conn: ProvisioningTestApp {guid}",
-                    SignOnMode = "OPENID_CONNECT",
+                    SignOnMode = ApplicationSignOnMode.OPENIDCONNECT,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Credentials = new OAuthApplicationCredentials
                     {
                         OauthClient = new ApplicationCredentialsOAuthClient
@@ -538,7 +547,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "bookmark",
                     Label = $"dotnet-sdk-test-conn: BookmarkApp {guid}",
-                    SignOnMode = "BOOKMARK",
+                    SignOnMode = ApplicationSignOnMode.BOOKMARK,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Settings = new BookmarkApplicationSettings
                     {
                         App = new BookmarkApplicationSettingsApplication
@@ -618,7 +636,16 @@ namespace Okta.Sdk.IntegrationTest
                 {
                     Name = "oidc_client",
                     Label = $"dotnet-sdk-test-conn: EdgeCaseApp {guid}",
-                    SignOnMode = "OPENID_CONNECT",
+                    SignOnMode = ApplicationSignOnMode.OPENIDCONNECT,
+                    Visibility = new ApplicationVisibility
+                    {
+                        AutoSubmitToolbar = false,
+                        Hide = new ApplicationVisibilityHide
+                        {
+                            IOS = false,
+                            Web = false
+                        }
+                    },
                     Credentials = new OAuthApplicationCredentials
                     {
                         OauthClient = new ApplicationCredentialsOAuthClient

--- a/src/Okta.Sdk.IntegrationTest/ProfileMappingApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/ProfileMappingApiTests.cs
@@ -35,7 +35,16 @@ namespace Okta.Sdk.IntegrationTest
             {
                 Name = "oidc_client",
                 Label = $"SDK Test ProfileMapping {Guid.NewGuid()}",
-                SignOnMode = "OPENID_CONNECT",
+                SignOnMode = ApplicationSignOnMode.OPENIDCONNECT,
+                Visibility = new ApplicationVisibility
+                {
+                    AutoSubmitToolbar = false,
+                    Hide = new ApplicationVisibilityHide
+                    {
+                        IOS = false,
+                        Web = false
+                    }
+                },
                 Credentials = new OAuthApplicationCredentials
                 {
                     OauthClient = new ApplicationCredentialsOAuthClient

--- a/src/Okta.Sdk/Client/ApiClient.cs
+++ b/src/Okta.Sdk/Client/ApiClient.cs
@@ -65,7 +65,11 @@ namespace Okta.Sdk.Client
                     OverrideSpecifiedNames = false
                 }
             },
-            NullValueHandling = NullValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = new List<JsonConverter>
+            {
+                new Okta.Sdk.Model.StringEnumSerializingConverter()
+            }
         };
 
         internal JsonSerializerSettings JsonSerializer
@@ -216,7 +220,11 @@ namespace Okta.Sdk.Client
                     OverrideSpecifiedNames = false
                 }
             },
-            NullValueHandling = NullValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = new List<JsonConverter>
+            {
+                new Okta.Sdk.Model.StringEnumSerializingConverter()
+            }
         };
 
         /// <summary>

--- a/src/Okta.Sdk/Model/BasicAuthApplication.cs
+++ b/src/Okta.Sdk/Model/BasicAuthApplication.cs
@@ -86,7 +86,16 @@ namespace Okta.Sdk.Model
         /// <value>&#x60;template_basic_auth&#x60; is the key name for a Basic Authentication scheme app instance</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="BasicAuthApplication" /> class.
         /// </summary>

--- a/src/Okta.Sdk/Model/BookmarkApplication.cs
+++ b/src/Okta.Sdk/Model/BookmarkApplication.cs
@@ -86,7 +86,16 @@ namespace Okta.Sdk.Model
         /// <value>&#x60;bookmark&#x60; is the key name for a Bookmark app</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="BookmarkApplication" /> class.
         /// </summary>

--- a/src/Okta.Sdk/Model/BrowserPluginApplication.cs
+++ b/src/Okta.Sdk/Model/BrowserPluginApplication.cs
@@ -92,7 +92,16 @@ namespace Okta.Sdk.Model
         /// <value>The key name for the app definition</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="BrowserPluginApplication" /> class.
         /// </summary>

--- a/src/Okta.Sdk/Model/OpenIdConnectApplication.cs
+++ b/src/Okta.Sdk/Model/OpenIdConnectApplication.cs
@@ -86,7 +86,16 @@ namespace Okta.Sdk.Model
         /// <value>&#x60;oidc_client&#x60; is the key name for an OAuth 2.0 client app instance</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenIdConnectApplication" /> class.
         /// </summary>

--- a/src/Okta.Sdk/Model/SecurePasswordStoreApplication.cs
+++ b/src/Okta.Sdk/Model/SecurePasswordStoreApplication.cs
@@ -86,7 +86,16 @@ namespace Okta.Sdk.Model
         /// <value>&#x60;template_sps&#x60; is the key name for a SWA app instance that uses HTTP POST and doesn&#39;t require a browser plugin</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="SecurePasswordStoreApplication" /> class.
         /// </summary>

--- a/src/Okta.Sdk/Model/StringEnumSerializingConverter.cs
+++ b/src/Okta.Sdk/Model/StringEnumSerializingConverter.cs
@@ -45,9 +45,15 @@ namespace Okta.Sdk.Model
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var enumValue = (value as StringEnum)?.Value ?? string.Empty;
+            var stringEnum = value as StringEnum;
+            
+            if (stringEnum == null || string.IsNullOrEmpty(stringEnum.Value))
+            {
+                writer.WriteNull();
+                return;
+            }
 
-            serializer.Serialize(writer, enumValue);
+            writer.WriteValue(stringEnum.Value);
         }
     }
 }

--- a/src/Okta.Sdk/Model/WsFederationApplication.cs
+++ b/src/Okta.Sdk/Model/WsFederationApplication.cs
@@ -86,7 +86,16 @@ namespace Okta.Sdk.Model
         /// <value>&#x60;template_wsfed&#x60; is the key name for a WS-Federated app instance with a SAML 2.0 token</value>
         [DataMember(Name = "name", EmitDefaultValue = true)]
         
-        public NameEnum Name { get; set; }
+        public new NameEnum Name { get; set; }
+
+        /// <summary>
+        /// Returns true if Name should be serialized (overrides base class behavior when present).
+        /// </summary>
+        /// <returns>true if Name has a value, false otherwise</returns>
+        public new bool ShouldSerializeName()
+        {
+            return Name != null && !string.IsNullOrEmpty(Name.Value);
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="WsFederationApplication" /> class.
         /// </summary>


### PR DESCRIPTION
Fixes serialization issue where Application subclasses with enum `name` properties (e.g., BookmarkApplication, OpenIdConnectApplication) were not serializing the name field.

**Root cause:** Parent Application class has `readOnly: true` on name, causing `ShouldSerializeName()` to return false.

**Solution:** Added `x-override-parent` vendor extension to override parent serialization behavior for affected models.

**Changes:**
- Updated templates to support `x-override-parent` vendor extension
- Added `new` keyword and custom `ShouldSerializeName()` for 6 application types
- Fixed StringEnumSerializingConverter to write null instead of empty string