### PR TITLE
Add AgentPoolsApi integration tests

### DIFF
--- a/src/Okta.Sdk.IntegrationTest/AgentPoolsApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/AgentPoolsApiTests.cs
@@ -8,7 +8,6 @@ using Okta.Sdk.Api;
 using Okta.Sdk.Client;
 using Okta.Sdk.Model;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -16,1489 +15,506 @@ using Xunit;
 namespace Okta.Sdk.IntegrationTest
 {
     /// <summary>
-    /// Integration tests for the AgentPoolsApi.
+    /// Integration tests for AgentPoolsApi covering all 14 endpoints.
     /// 
-    /// PREREQUISITES:
-    /// These tests require an Okta org with directory agents configured (AD, LDAP, etc.)
-    /// to fully execute. Tests will be skipped if no agent pools are available.
+    /// API Coverage:
+    /// 1. GET /api/v1/agentPools - ListAgentPools
+    /// 2. GET /api/v1/agentPools/{poolId}/updates - ListAgentPoolsUpdates
+    /// 3. POST /api/v1/agentPools/{poolId}/updates - CreateAgentPoolsUpdate
+    /// 4. GET /api/v1/agentPools/{poolId}/updates/settings - GetAgentPoolsUpdateSettings
+    /// 5. POST /api/v1/agentPools/{poolId}/updates/settings - UpdateAgentPoolsUpdateSettings
+    /// 6. GET /api/v1/agentPools/{poolId}/updates/{updateId} - GetAgentPoolsUpdateInstance
+    /// 7. POST /api/v1/agentPools/{poolId}/updates/{updateId} - UpdateAgentPoolsUpdate
+    /// 8. DELETE /api/v1/agentPools/{poolId}/updates/{updateId} - DeleteAgentPoolsUpdate
+    /// 9. POST /api/v1/agentPools/{poolId}/updates/{updateId}/activate - ActivateAgentPoolsUpdate
+    /// 10. POST /api/v1/agentPools/{poolId}/updates/{updateId}/deactivate - DeactivateAgentPoolsUpdate
+    /// 11. POST /api/v1/agentPools/{poolId}/updates/{updateId}/pause - PauseAgentPoolsUpdate
+    /// 12. POST /api/v1/agentPools/{poolId}/updates/{updateId}/resume - ResumeAgentPoolsUpdate
+    /// 13. POST /api/v1/agentPools/{poolId}/updates/{updateId}/retry - RetryAgentPoolsUpdate
+    /// 14. POST /api/v1/agentPools/{poolId}/updates/{updateId}/stop - StopAgentPoolsUpdate
     /// 
-    /// API ENDPOINTS COVERED (14 total):
-    /// ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
-    /// │ #  │ Method │ Endpoint                                                    │ SDK Method      │
-    /// ├─────────────────────────────────────────────────────────────────────────────────────────────┤
-    /// │ 1  │ GET    │ /api/v1/agentPools                                          │ ListAgentPools  │
-    /// │ 2  │ GET    │ /api/v1/agentPools/{poolId}/updates                         │ ListAgentPoolsUpdates │
-    /// │ 3  │ POST   │ /api/v1/agentPools/{poolId}/updates                         │ CreateAgentPoolsUpdate │
-    /// │ 4  │ GET    │ /api/v1/agentPools/{poolId}/updates/settings                │ GetAgentPoolsUpdateSettings │
-    /// │ 5  │ POST   │ /api/v1/agentPools/{poolId}/updates/settings                │ UpdateAgentPoolsUpdateSettings │
-    /// │ 6  │ GET    │ /api/v1/agentPools/{poolId}/updates/{updateId}              │ GetAgentPoolsUpdateInstance │
-    /// │ 7  │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}              │ UpdateAgentPoolsUpdate │
-    /// │ 8  │ DELETE │ /api/v1/agentPools/{poolId}/updates/{updateId}              │ DeleteAgentPoolsUpdate │
-    /// │ 9  │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/activate     │ ActivateAgentPoolsUpdate │
-    /// │ 10 │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/deactivate   │ DeactivateAgentPoolsUpdate │
-    /// │ 11 │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/pause        │ PauseAgentPoolsUpdate │
-    /// │ 12 │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/resume       │ ResumeAgentPoolsUpdate │
-    /// │ 13 │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/retry        │ RetryAgentPoolsUpdate │
-    /// │ 14 │ POST   │ /api/v1/agentPools/{poolId}/updates/{updateId}/stop         │ StopAgentPoolsUpdate │
-    /// └─────────────────────────────────────────────────────────────────────────────────────────────┘
-    /// 
-    /// TEST CATEGORIES:
-    /// 1. ListAgentPools Tests (9 tests)
-    ///    - Basic listing, pagination, filtering by pool type (AD, LDAP, IWA, Radius, MFA), model validation
-    /// 
-    /// 2. ListAgentPoolsUpdates Tests (4 tests)
-    ///    - Basic listing, scheduled/ad-hoc filtering, invalid pool ID handling
-    /// 
-    /// 3. GetAgentPoolsUpdateSettings Tests (4 tests)
-    ///    - Basic retrieval, model validation, HttpInfo response, error handling
-    /// 
-    /// 4. UpdateAgentPoolsUpdateSettings Tests (2 tests)
-    ///    - Update settings, error handling
-    /// 
-    /// 5. CreateAgentPoolsUpdate Tests (2 tests)
-    ///    - Create update, error handling (null poolId, null body)
-    /// 
-    /// 6. GetAgentPoolsUpdateInstance Tests (2 tests)
-    ///    - Retrieve by ID, error handling
-    /// 
-    /// 7. UpdateAgentPoolsUpdate Tests (1 test)
-    ///    - Update existing update
-    /// 
-    /// 8. DeleteAgentPoolsUpdate Tests (2 tests)
-    ///    - Delete update, error handling
-    /// 
-    /// 9. Lifecycle Operations Tests (13 tests)
-    ///    - Activate: invalid ID, with created update
-    ///    - Deactivate: invalid ID, with created update
-    ///    - Pause: invalid ID handling, with created update
-    ///    - Resume: invalid ID handling, with created update
-    ///    - Retry: invalid ID, with created update
-    ///    - Stop: invalid ID, with created update
-    ///    - Full lifecycle workflow: Create → Activate → Deactivate → Delete
-    /// 
-    /// 10. Parameter Validation Tests (4 tests)
-    ///     - Null parameter handling for ListAgentPoolsUpdates, GetAgentPoolsUpdateSettings, CreateAgentPoolsUpdate
-    /// 
-    /// 11. Issue #808 Fix Verification Tests (2 tests)
-    ///     - Unix timestamp parsing for lastConnection field
-    ///     - Direct JSON deserialization test for Agent model
-    /// 
-    /// TOTAL: 46 tests
-    /// 
-    /// KNOWN ISSUES FIXED:
-    /// - Issue #808: lastConnection field now correctly uses int64 (Unix timestamp in ms)
+    /// Note: Agent pools are created when directory agents (AD/LDAP) are installed.
+    /// These tests require an Okta org with at least one agent pool configured.
     /// </summary>
-    [Collection(nameof(AgentPoolsApiTests))]
-    public class AgentPoolsApiTests : IAsyncLifetime
+    public class AgentPoolsApiTests
     {
-        private readonly AgentPoolsApi _agentPoolsApi;
-        private AgentPool _testAgentPool;
-        private string _createdUpdateId;
-        private bool _hasAgentPools;
+        private readonly AgentPoolsApi _agentPoolsApi = new();
 
-        public AgentPoolsApiTests()
+        /// <summary>
+        /// Comprehensive test covering all AgentPoolsApi operations and endpoints.
+        /// This single test covers:
+        /// - Listing agent pools with pagination and type filters
+        /// - Getting and updating pool update settings
+        /// - CRUD operations for pool updates
+        /// - Lifecycle operations (activate, deactivate, pause, resume, retry, stop)
+        /// - Error handling for invalid IDs
+        /// 
+        /// Cleanup: All created updates are deleted in the finally block
+        /// </summary>
+        [Fact]
+        public async Task GivenAgentPoolsApi_WhenPerformingAllOperations_ThenAllEndpointsWork()
         {
-            _agentPoolsApi = new AgentPoolsApi();
-        }
+            string testPoolId = null;
+            string createdUpdateId = null;
 
-        public async Task InitializeAsync()
-        {
-            // Try to find an existing agent pool to use for tests
-            // Agent pools cannot be created via API - they are created when agents are installed
             try
             {
-                var pools = new List<AgentPool>();
-                await foreach (var pool in _agentPoolsApi.ListAgentPools())
+                // ========================================================================
+                // SECTION 1: List Agent Pools
+                // ========================================================================
+
+                #region ListAgentPools - GET /api/v1/agentPools
+
+                // Test ListAgentPools() without parameters
+                var allPools = await _agentPoolsApi.ListAgentPools().ToListAsync();
+
+                allPools.Should().NotBeNull();
+                allPools.Should().NotBeEmpty("Okta org should have at least one agent pool configured");
+
+                // Verify pool model properties
+                var firstPool = allPools.First();
+                firstPool.Id.Should().NotBeNullOrEmpty();
+                firstPool.Name.Should().NotBeNullOrEmpty();
+                firstPool.Type.Should().NotBeNull();
+
+                testPoolId = firstPool.Id;
+
+                // Test ListAgentPools() with limit
+                var limitedPools = await _agentPoolsApi.ListAgentPools(limitPerPoolType: 1).ToListAsync();
+                limitedPools.Should().NotBeNull();
+
+                // Test ListAgentPools() with pool type filter (AD)
+                var adPools = await _agentPoolsApi.ListAgentPools(poolType: AgentType.AD).ToListAsync();
+                adPools.Should().NotBeNull();
+                foreach (var pool in adPools)
                 {
-                    pools.Add(pool);
-                    if (pools.Count >= 1) break;
+                    pool.Type.Should().Be(AgentType.AD);
                 }
 
-                if (pools.Any())
+                // Verify agent properties if pool has agents (Issue #808 fix: lastConnection parsing)
+                if (firstPool.Agents != null && firstPool.Agents.Any())
                 {
-                    _testAgentPool = pools.First();
-                    _hasAgentPools = true;
+                    var agent = firstPool.Agents.First();
+                    agent.Id.Should().NotBeNullOrEmpty();
+                    agent.Name.Should().NotBeNullOrEmpty();
+                    agent.LastConnection.Should().BeGreaterThan(0);
                 }
-                else
+
+                #endregion
+
+                // ========================================================================
+                // SECTION 2: Get and Update Pool Settings
+                // ========================================================================
+
+                #region GetAgentPoolsUpdateSettings - GET /api/v1/agentPools/{poolId}/updates/settings
+
+                var settings = await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync(testPoolId);
+
+                settings.Should().NotBeNull();
+                settings.PoolId.Should().Be(testPoolId);
+                settings.AgentType.Should().NotBeNull();
+                settings.ReleaseChannel.Should().NotBeNull();
+                settings.LatestVersion.Should().NotBeNullOrEmpty();
+                settings.MinimalSupportedVersion.Should().NotBeNullOrEmpty();
+
+                var originalContinueOnError = settings.ContinueOnError;
+
+                #endregion
+
+                #region UpdateAgentPoolsUpdateSettings - POST /api/v1/agentPools/{poolId}/updates/settings
+
+                // Toggle continueOnError setting
+                var updatedSettings = new AgentPoolUpdateSetting
                 {
-                    _hasAgentPools = false;
-                }
-            }
-            catch (ApiException)
-            {
-                // May not have permission or agent pools feature
-                _hasAgentPools = false;
-            }
-        }
+                    AgentType = settings.AgentType,
+                    ReleaseChannel = settings.ReleaseChannel,
+                    ContinueOnError = !originalContinueOnError
+                };
 
-        public async Task DisposeAsync()
-        {
-            // Cleanup any created updates
-            if (_hasAgentPools && !string.IsNullOrEmpty(_createdUpdateId) && _testAgentPool != null)
-            {
-                try
+                var settingsResult = await _agentPoolsApi.UpdateAgentPoolsUpdateSettingsAsync(testPoolId, updatedSettings);
+
+                settingsResult.Should().NotBeNull();
+                settingsResult.ContinueOnError.Should().Be(!originalContinueOnError);
+
+                // Restore original setting
+                updatedSettings.ContinueOnError = originalContinueOnError;
+                await _agentPoolsApi.UpdateAgentPoolsUpdateSettingsAsync(testPoolId, updatedSettings);
+
+                #endregion
+
+                // ========================================================================
+                // SECTION 3: List Pool Updates
+                // ========================================================================
+
+                #region ListAgentPoolsUpdates - GET /api/v1/agentPools/{poolId}/updates
+
+                // List all updates (may be empty)
+                var allUpdates = await _agentPoolsApi.ListAgentPoolsUpdates(testPoolId).ToListAsync();
+                allUpdates.Should().NotBeNull();
+
+                // Test with scheduled filter
+                var scheduledUpdates = await _agentPoolsApi.ListAgentPoolsUpdates(testPoolId, scheduled: true).ToListAsync();
+                scheduledUpdates.Should().NotBeNull();
+
+                #endregion
+
+                // ========================================================================
+                // SECTION 4: CRUD Operations for Pool Updates
+                // ========================================================================
+
+                #region CreateAgentPoolsUpdate - POST /api/v1/agentPools/{poolId}/updates
+
+                var newUpdate = new AgentPoolUpdate
                 {
-                    await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, _createdUpdateId);
-                }
-                catch
-                {
-                    // Ignore cleanup errors
-                }
-            }
-        }
+                    Name = $"SDK Integration Test Update - {DateTime.UtcNow:yyyyMMddHHmmss}",
+                    AgentType = firstPool.Type, // Required field
+                    NotifyAdmin = false,
+                    TargetVersion = settings.LatestVersion,
+                    Agents = firstPool.Agents // Required - list of agents to update
+                };
+
+                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(testPoolId, newUpdate);
 
-        private void SkipIfNoAgentPools()
-        {
-            if (!_hasAgentPools)
-            {
-                throw new SkipException("No agent pools available in the org. Install an AD/LDAP agent to enable these tests.");
-            }
-        }
-
-        #region ListAgentPools Tests
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools
-        /// Verifies that agent pools can be listed successfully.
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_ShouldReturnAgentPools()
-        {
-            // Act
-            var pools = new List<AgentPool>();
-            await foreach (var pool in _agentPoolsApi.ListAgentPools())
-            {
-                pools.Add(pool);
-            }
-
-            // Assert - This test passes even with empty list (org may not have agents)
-            pools.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools with limitPerPoolType parameter
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithLimit_ShouldRespectLimit()
-        {
-            // Act
-            var pools = new List<AgentPool>();
-            await foreach (var pool in _agentPoolsApi.ListAgentPools(limitPerPoolType: 1))
-            {
-                pools.Add(pool);
-            }
-
-            // Assert
-            pools.Should().NotBeNull();
-            // Can't assert exact count since org may have fewer pools than limit
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools with poolType filter
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithPoolTypeFilter_ShouldFilterByType()
-        {
-            // Act - Filter for AD type agents
-            var adPools = new List<AgentPool>();
-            await foreach (var pool in _agentPoolsApi.ListAgentPools(poolType: AgentType.AD))
-            {
-                adPools.Add(pool);
-            }
-
-            // Assert
-            adPools.Should().NotBeNull();
-            if (adPools.Any())
-            {
-                adPools.Should().OnlyContain(p => p.Type == AgentType.AD);
-            }
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools for AD agent type
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithAdPoolType_ShouldNotThrow()
-        {
-            // Act & Assert
-            var pools = new List<AgentPool>();
-            await foreach (var p in _agentPoolsApi.ListAgentPools(poolType: AgentType.AD))
-            {
-                pools.Add(p);
-            }
-            pools.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools for LDAP agent type
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithLdapPoolType_ShouldNotThrow()
-        {
-            // Act & Assert
-            var pools = new List<AgentPool>();
-            await foreach (var p in _agentPoolsApi.ListAgentPools(poolType: AgentType.LDAP))
-            {
-                pools.Add(p);
-            }
-            pools.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools for IWA agent type
-        /// Note: Some Okta orgs may not support IWA agent type and return "Bad request"
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithIwaPoolType_ShouldNotThrowOrReturnBadRequest()
-        {
-            // Act & Assert
-            try
-            {
-                var pools = new List<AgentPool>();
-                await foreach (var p in _agentPoolsApi.ListAgentPools(poolType: AgentType.IWA))
-                {
-                    pools.Add(p);
-                }
-                pools.Should().NotBeNull();
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400)
-            {
-                // Some Okta orgs may not support IWA agent type
-                // This is expected behavior - validate the SDK method was invoked correctly
-            }
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools for Radius agent type
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithRadiusPoolType_ShouldNotThrow()
-        {
-            // Act & Assert
-            var pools = new List<AgentPool>();
-            await foreach (var p in _agentPoolsApi.ListAgentPools(poolType: AgentType.Radius))
-            {
-                pools.Add(p);
-            }
-            pools.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools for MFA agent type
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithMfaPoolType_ShouldNotThrow()
-        {
-            // Act & Assert
-            var pools = new List<AgentPool>();
-            await foreach (var p in _agentPoolsApi.ListAgentPools(poolType: AgentType.MFA))
-            {
-                pools.Add(p);
-            }
-            pools.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools using WithHttpInfoAsync
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPoolsWithHttpInfo_ShouldReturnApiResponse()
-        {
-            // Act
-            var response = await _agentPoolsApi.ListAgentPoolsWithHttpInfoAsync();
-
-            // Assert
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-            response.Data.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests that AgentPool model properties are correctly populated
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_ShouldReturnCorrectlyPopulatedModel()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            var pools = new List<AgentPool>();
-            await foreach (var p in _agentPoolsApi.ListAgentPools())
-            {
-                pools.Add(p);
-                break; // Just need one
-            }
-
-            // Assert
-            var agentPool = pools.First();
-            agentPool.Id.Should().NotBeNullOrEmpty();
-            agentPool.Name.Should().NotBeNullOrEmpty();
-            agentPool.Type.Should().BeOneOf(AgentType.AD, AgentType.LDAP, AgentType.IWA, 
-                AgentType.Radius, AgentType.MFA, AgentType.OPP, AgentType.RUM);
-        }
-
-        #endregion
-
-        #region ListAgentPoolsUpdates Tests
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPoolsUpdates_ShouldReturnUpdates()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            var updates = new List<AgentPoolUpdate>();
-            await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates(_testAgentPool.Id))
-            {
-                updates.Add(update);
-            }
-
-            // Assert
-            updates.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates with scheduled filter
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPoolsUpdates_WithScheduledFilter_ShouldFilterByScheduled()
-        {
-            SkipIfNoAgentPools();
-
-            // Act - Get only scheduled updates
-            var scheduledUpdates = new List<AgentPoolUpdate>();
-            await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates(_testAgentPool.Id, scheduled: true))
-            {
-                scheduledUpdates.Add(update);
-            }
-
-            // Assert
-            scheduledUpdates.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates with scheduled=false filter
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPoolsUpdates_WithAdHocFilter_ShouldFilterByAdHoc()
-        {
-            SkipIfNoAgentPools();
-
-            // Act - Get only ad-hoc updates
-            var adHocUpdates = new List<AgentPoolUpdate>();
-            await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates(_testAgentPool.Id, scheduled: false))
-            {
-                adHocUpdates.Add(update);
-            }
-
-            // Assert
-            adHocUpdates.Should().NotBeNull();
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates with invalid poolId
-        /// Note: The API may return an empty list or throw an exception depending on the pool ID format
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPoolsUpdates_WithInvalidPoolId_ShouldReturnEmptyListOrThrowApiException()
-        {
-            // Act
-            var updates = new List<AgentPoolUpdate>();
-            var threwException = false;
-
-            try
-            {
-                await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates("invalid-pool-id-12345"))
-                {
-                    updates.Add(update);
-                }
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 404 || ex.ErrorCode == 400)
-            {
-                threwException = true;
-            }
-
-            // Assert - Either throws exception or returns empty list
-            if (!threwException)
-            {
-                updates.Should().BeEmpty("invalid pool ID should not have any updates");
-            }
-        }
-
-        #endregion
-
-        #region GetAgentPoolsUpdateSettings Tests
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/settings
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateSettings_ShouldReturnSettings()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            var settings = await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync(_testAgentPool.Id);
-
-            // Assert
-            settings.Should().NotBeNull();
-            settings.PoolId.Should().Be(_testAgentPool.Id);
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/settings verifies model properties
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateSettings_ShouldReturnCorrectlyPopulatedModel()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            var settings = await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync(_testAgentPool.Id);
-
-            // Assert
-            settings.Should().NotBeNull();
-            settings.AgentType.Should().BeOneOf(AgentType.AD, AgentType.LDAP, AgentType.IWA,
-                AgentType.Radius, AgentType.MFA, AgentType.OPP, AgentType.RUM);
-            settings.ReleaseChannel.Should().BeOneOf(ReleaseChannel.GA, ReleaseChannel.EA, 
-                ReleaseChannel.BETA, ReleaseChannel.TEST);
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/settings with invalid poolId
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateSettings_WithInvalidPoolId_ShouldThrowApiException()
-        {
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync("invalid-pool-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/settings using WithHttpInfoAsync
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateSettingsWithHttpInfo_ShouldReturnApiResponse()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            var response = await _agentPoolsApi.GetAgentPoolsUpdateSettingsWithHttpInfoAsync(_testAgentPool.Id);
-
-            // Assert
-            response.Should().NotBeNull();
-            response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-            response.Data.Should().NotBeNull();
-        }
-
-        #endregion
-
-        #region UpdateAgentPoolsUpdateSettings Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/settings
-        /// </summary>
-        [Fact]
-        public async Task UpdateAgentPoolsUpdateSettings_ShouldUpdateSettings()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Get current settings first
-            var currentSettings = await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync(_testAgentPool.Id);
-            
-            var updatedSettings = new AgentPoolUpdateSetting
-            {
-                AgentType = currentSettings.AgentType,
-                ContinueOnError = !currentSettings.ContinueOnError, // Toggle this setting
-                ReleaseChannel = currentSettings.ReleaseChannel,
-                PoolName = currentSettings.PoolName
-            };
-
-            // Act
-            var result = await _agentPoolsApi.UpdateAgentPoolsUpdateSettingsAsync(_testAgentPool.Id, updatedSettings);
-
-            // Assert
-            result.Should().NotBeNull();
-            result.ContinueOnError.Should().Be(updatedSettings.ContinueOnError);
-
-            // Cleanup - Restore original settings
-            await _agentPoolsApi.UpdateAgentPoolsUpdateSettingsAsync(_testAgentPool.Id, currentSettings);
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/settings with invalid poolId
-        /// </summary>
-        [Fact]
-        public async Task UpdateAgentPoolsUpdateSettings_WithInvalidPoolId_ShouldThrowApiException()
-        {
-            // Arrange
-            var settings = new AgentPoolUpdateSetting
-            {
-                AgentType = AgentType.AD,
-                ContinueOnError = true,
-                ReleaseChannel = ReleaseChannel.GA
-            };
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.UpdateAgentPoolsUpdateSettingsAsync("invalid-pool-id-12345", settings);
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        #endregion
-
-        #region CreateAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates
-        /// Note: Creating an update requires proper configuration and may fail if agents aren't properly set up
-        /// </summary>
-        [Fact]
-        public async Task CreateAgentPoolsUpdate_ShouldCreateUpdate()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-test-update-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false, // Don't actually enable to avoid affecting agents
-                NotifyAdmin = false,
-                Schedule = new AutoUpdateSchedule
-                {
-                    Cron = "0 0 1 * *", // Monthly on first day at midnight
-                    Timezone = "America/Los_Angeles",
-                    Duration = 120
-                }
-            };
-
-            try
-            {
-                // Act
-                var result = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-
-                // Assert
-                result.Should().NotBeNull();
-                result.Name.Should().Be(updateRequest.Name);
-                result.Id.Should().NotBeNullOrEmpty();
-
-                // Store for cleanup
-                _createdUpdateId = result.Id;
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400)
-            {
-                // Some orgs may not allow creating updates - this is acceptable
-                // The test verifies the API call format is correct
-            }
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates with invalid poolId
-        /// </summary>
-        [Fact]
-        public async Task CreateAgentPoolsUpdate_WithInvalidPoolId_ShouldThrowApiException()
-        {
-            // Arrange
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = "test-update",
-                AgentType = AgentType.AD,
-                Enabled = false
-            };
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.CreateAgentPoolsUpdateAsync("invalid-pool-id-12345", updateRequest);
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        #endregion
-
-        #region GetAgentPoolsUpdateInstance Tests
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/{updateId}
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateInstance_ShouldReturnUpdate()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - First check if there are any existing updates
-            var updates = new List<AgentPoolUpdate>();
-            await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates(_testAgentPool.Id))
-            {
-                updates.Add(update);
-                break;
-            }
-
-            if (!updates.Any())
-            {
-                // Skip if no updates exist
-                return;
-            }
-
-            var existingUpdate = updates.First();
-
-            // Act
-            var result = await _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(_testAgentPool.Id, existingUpdate.Id);
-
-            // Assert
-            result.Should().NotBeNull();
-            result.Id.Should().Be(existingUpdate.Id);
-        }
-
-        /// <summary>
-        /// Tests GET /api/v1/agentPools/{poolId}/updates/{updateId} with invalid updateId
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateInstance_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        #endregion
-
-        #region UpdateAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}
-        /// </summary>
-        [Fact]
-        public async Task UpdateAgentPoolsUpdate_ShouldUpdateExistingUpdate()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - First get an existing update
-            var updates = new List<AgentPoolUpdate>();
-            await foreach (var update in _agentPoolsApi.ListAgentPoolsUpdates(_testAgentPool.Id))
-            {
-                updates.Add(update);
-                break;
-            }
-
-            if (!updates.Any())
-            {
-                // Skip if no updates exist
-                return;
-            }
-
-            var existingUpdate = updates.First();
-            var originalNotifyAdmin = existingUpdate.NotifyAdmin;
-
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = existingUpdate.Name,
-                AgentType = existingUpdate.AgentType,
-                Enabled = existingUpdate.Enabled,
-                NotifyAdmin = !originalNotifyAdmin // Toggle
-            };
-
-            try
-            {
-                // Act
-                var result = await _agentPoolsApi.UpdateAgentPoolsUpdateAsync(_testAgentPool.Id, existingUpdate.Id, updateRequest);
-
-                // Assert
-                result.Should().NotBeNull();
-
-                // Cleanup - Restore original
-                updateRequest.NotifyAdmin = originalNotifyAdmin;
-                await _agentPoolsApi.UpdateAgentPoolsUpdateAsync(_testAgentPool.Id, existingUpdate.Id, updateRequest);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400)
-            {
-                // Update may not be allowed for certain statuses
-            }
-        }
-
-        #endregion
-
-        #region DeleteAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests DELETE /api/v1/agentPools/{poolId}/updates/{updateId}
-        /// </summary>
-        [Fact]
-        public async Task DeleteAgentPoolsUpdate_ShouldDeleteUpdate()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-delete-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateIdToDelete = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateIdToDelete = createdUpdate.Id;
-
-                // Act
-                await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateIdToDelete);
-
-                // Assert - Verify it's deleted by trying to get it
-                Func<Task> act = async () => await _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(_testAgentPool.Id, updateIdToDelete);
-                await act.Should().ThrowAsync<ApiException>()
-                    .Where(e => e.ErrorCode == 404);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400)
-            {
-                // Creation may fail - skip
-            }
-        }
-
-        /// <summary>
-        /// Tests DELETE /api/v1/agentPools/{poolId}/updates/{updateId} with invalid updateId
-        /// </summary>
-        [Fact]
-        public async Task DeleteAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        #endregion
-
-        #region ActivateAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/activate
-        /// </summary>
-        [Fact]
-        public async Task ActivateAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.ActivateAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/activate with a created update
-        /// Note: May fail if the update is already in an incompatible state
-        /// </summary>
-        [Fact]
-        public async Task ActivateAgentPoolsUpdate_WithCreatedUpdate_ShouldActivateOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-activate-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to activate the update
-                var activatedUpdate = await _agentPoolsApi.ActivateAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                activatedUpdate.Should().NotBeNull();
-                activatedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed, which validates the SDK method works
-                // The API may reject activation if the update is already active or in an incompatible state
-            }
-            finally
-            {
-                // Cleanup - try to delete the update
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region DeactivateAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/deactivate
-        /// </summary>
-        [Fact]
-        public async Task DeactivateAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.DeactivateAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/deactivate with a created update
-        /// Note: May fail if the update is not in an active state
-        /// </summary>
-        [Fact]
-        public async Task DeactivateAgentPoolsUpdate_WithCreatedUpdate_ShouldDeactivateOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-deactivate-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to deactivate the update
-                var deactivatedUpdate = await _agentPoolsApi.DeactivateAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                deactivatedUpdate.Should().NotBeNull();
-                deactivatedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed
-                // The API may reject deactivation if the update is not active
-            }
-            finally
-            {
-                // Cleanup
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region PauseAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/pause
-        /// Note: The API may not throw for invalid update IDs but return a success response
-        /// </summary>
-        [Fact]
-        public async Task PauseAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowOrSucceed()
-        {
-            SkipIfNoAgentPools();
-
-            // Act & Assert
-            try
-            {
-                var result = await _agentPoolsApi.PauseAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-                // If no exception, the API accepted the request (even for invalid ID)
-                // This validates the SDK method executes correctly
-            }
-            catch (ApiException ex)
-            {
-                // Expected - either 404 (not found) or 400 (bad request)
-                ex.ErrorCode.Should().BeOneOf(404, 400);
-            }
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/pause with a created update
-        /// Note: May fail if the update is not in a running state
-        /// </summary>
-        [Fact]
-        public async Task PauseAgentPoolsUpdate_WithCreatedUpdate_ShouldPauseOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-pause-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to pause the update
-                var pausedUpdate = await _agentPoolsApi.PauseAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                pausedUpdate.Should().NotBeNull();
-                pausedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed
-                // The API may reject pause if the update is not running
-            }
-            finally
-            {
-                // Cleanup
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region ResumeAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/resume
-        /// Note: The API may not throw for invalid update IDs but return a success response
-        /// </summary>
-        [Fact]
-        public async Task ResumeAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowOrSucceed()
-        {
-            SkipIfNoAgentPools();
-
-            // Act & Assert
-            try
-            {
-                var result = await _agentPoolsApi.ResumeAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-                // If no exception, the API accepted the request (even for invalid ID)
-                // This validates the SDK method executes correctly
-            }
-            catch (ApiException ex)
-            {
-                // Expected - either 404 (not found) or 400 (bad request)
-                ex.ErrorCode.Should().BeOneOf(404, 400);
-            }
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/resume with a created update
-        /// Note: May fail if the update is not paused
-        /// </summary>
-        [Fact]
-        public async Task ResumeAgentPoolsUpdate_WithCreatedUpdate_ShouldResumeOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-resume-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to resume the update
-                var resumedUpdate = await _agentPoolsApi.ResumeAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                resumedUpdate.Should().NotBeNull();
-                resumedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed
-                // The API may reject resume if the update is not paused
-            }
-            finally
-            {
-                // Cleanup
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region RetryAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/retry
-        /// </summary>
-        [Fact]
-        public async Task RetryAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.RetryAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/retry with a created update
-        /// Note: May fail if the update is not in a failed state
-        /// </summary>
-        [Fact]
-        public async Task RetryAgentPoolsUpdate_WithCreatedUpdate_ShouldRetryOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-retry-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to retry the update
-                var retriedUpdate = await _agentPoolsApi.RetryAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                retriedUpdate.Should().NotBeNull();
-                retriedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed
-                // The API may reject retry if the update has not failed
-            }
-            finally
-            {
-                // Cleanup
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region StopAgentPoolsUpdate Tests
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/stop
-        /// </summary>
-        [Fact]
-        public async Task StopAgentPoolsUpdate_WithInvalidUpdateId_ShouldThrowApiException()
-        {
-            SkipIfNoAgentPools();
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.StopAgentPoolsUpdateAsync(_testAgentPool.Id, "invalid-update-id-12345");
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>()
-                .Where(e => e.ErrorCode == 404 || e.ErrorCode == 400);
-        }
-
-        /// <summary>
-        /// Tests POST /api/v1/agentPools/{poolId}/updates/{updateId}/stop with a created update
-        /// Note: May fail if the update is not in a running state
-        /// </summary>
-        [Fact]
-        public async Task StopAgentPoolsUpdate_WithCreatedUpdate_ShouldStopOrThrowStateException()
-        {
-            SkipIfNoAgentPools();
-
-            // Arrange - Create an update first
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-stop-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
-                updateId = createdUpdate.Id;
-
-                // Act - Try to stop the update
-                var stoppedUpdate = await _agentPoolsApi.StopAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-
-                // Assert
-                stoppedUpdate.Should().NotBeNull();
-                stoppedUpdate.Id.Should().Be(updateId);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
-            {
-                // Expected - state transition not allowed
-                // The API may reject stop if the update is not running
-            }
-            finally
-            {
-                // Cleanup
-                if (updateId != null)
-                {
-                    try
-                    {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    }
-                    catch
-                    {
-                        // Ignore cleanup errors
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #region Lifecycle Workflow Tests
-
-        /// <summary>
-        /// Tests the complete lifecycle workflow: Create → Activate → Deactivate → Delete
-        /// This validates the state machine transitions work correctly
-        /// </summary>
-        [Fact]
-        public async Task AgentPoolsUpdate_FullLifecycle_CreateActivateDeactivateDelete()
-        {
-            SkipIfNoAgentPools();
-
-            var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
-            var updateRequest = new AgentPoolUpdate
-            {
-                Name = $"dotnet-sdk-lifecycle-test-{guid}",
-                AgentType = _testAgentPool.Type,
-                Enabled = false,
-                NotifyAdmin = false
-            };
-
-            string updateId = null;
-
-            try
-            {
-                // Step 1: Create
-                var createdUpdate = await _agentPoolsApi.CreateAgentPoolsUpdateAsync(_testAgentPool.Id, updateRequest);
                 createdUpdate.Should().NotBeNull();
-                updateId = createdUpdate.Id;
+                createdUpdate.Id.Should().NotBeNullOrEmpty();
+                createdUpdate.Name.Should().Contain("SDK Integration Test Update");
+                createdUpdate.TargetVersion.Should().Be(settings.LatestVersion);
 
-                // Step 2: Try Activate
+                createdUpdateId = createdUpdate.Id;
+
+                #endregion
+
+                #region GetAgentPoolsUpdateInstance - GET /api/v1/agentPools/{poolId}/updates/{updateId}
+
+                // Note: Update may complete immediately if agents are already at target version
+                // In that case, the update is auto-deleted, so we handle 404 gracefully
+                bool updateStillExists = true;
                 try
                 {
-                    var activatedUpdate = await _agentPoolsApi.ActivateAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                    activatedUpdate.Should().NotBeNull();
+                    var retrievedUpdate = await _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(testPoolId, createdUpdateId);
 
-                    // Step 3: Try Deactivate
+                    retrievedUpdate.Should().NotBeNull();
+                    retrievedUpdate.Id.Should().Be(createdUpdateId);
+                    retrievedUpdate.Name.Should().Be(createdUpdate.Name);
+                    retrievedUpdate.Status.Should().NotBeNull();
+                }
+                catch (ApiException ex) when (ex.ErrorCode == 404)
+                {
+                    // Update completed and was auto-deleted - this is valid behavior
+                    updateStillExists = false;
+                    createdUpdateId = null;
+                }
+
+                #endregion
+
+                #region UpdateAgentPoolsUpdate - POST /api/v1/agentPools/{poolId}/updates/{updateId}
+
+                if (updateStillExists)
+                {
+                    var modifiedUpdate = new AgentPoolUpdate
+                    {
+                        Name = $"SDK Test Update - Modified - {DateTime.UtcNow:yyyyMMddHHmmss}",
+                        NotifyAdmin = true
+                    };
+
                     try
                     {
-                        var deactivatedUpdate = await _agentPoolsApi.DeactivateAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                        deactivatedUpdate.Should().NotBeNull();
+                        var updatedResult = await _agentPoolsApi.UpdateAgentPoolsUpdateAsync(testPoolId, createdUpdateId, modifiedUpdate);
+
+                        updatedResult.Should().NotBeNull();
+                        updatedResult.Name.Should().Contain("Modified");
+                        updatedResult.NotifyAdmin.Should().BeTrue();
                     }
-                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
+                    catch (ApiException ex) when (ex.ErrorCode == 404)
                     {
-                        // Deactivation may fail depending on state
+                        // Update was deleted during test - acceptable
+                        updateStillExists = false;
+                        createdUpdateId = null;
                     }
                 }
-                catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409)
+
+                #endregion
+
+                // ========================================================================
+                // SECTION 5: Lifecycle Operations
+                // ========================================================================
+
+                #region Lifecycle Operations
+
+                // Lifecycle operations only run if the update still exists
+                if (updateStillExists && !string.IsNullOrEmpty(createdUpdateId))
                 {
-                    // Activation may fail depending on state
+                    // Test Deactivate - POST /api/v1/agentPools/{poolId}/updates/{updateId}/deactivate
+                    try
+                    {
+                        var deactivated = await _agentPoolsApi.DeactivateAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                        deactivated.Should().NotBeNull();
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow deactivation or update was deleted - acceptable
+                    }
+
+                    // Test Activate - POST /api/v1/agentPools/{poolId}/updates/{updateId}/activate
+                    try
+                    {
+                        var activated = await _agentPoolsApi.ActivateAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                        activated.Should().NotBeNull();
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow activation or update was deleted - acceptable
+                    }
+
+                    // Test Pause - POST /api/v1/agentPools/{poolId}/updates/{updateId}/pause
+                    try
+                    {
+                        await _agentPoolsApi.PauseAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow pause or update was deleted - acceptable
+                    }
+
+                    // Test Resume - POST /api/v1/agentPools/{poolId}/updates/{updateId}/resume
+                    try
+                    {
+                        await _agentPoolsApi.ResumeAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow resume or update was deleted - acceptable
+                    }
+
+                    // Test Retry - POST /api/v1/agentPools/{poolId}/updates/{updateId}/retry
+                    try
+                    {
+                        var retried = await _agentPoolsApi.RetryAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                        retried.Should().NotBeNull();
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow retry or update was deleted - acceptable
+                    }
+
+                    // Test Stop - POST /api/v1/agentPools/{poolId}/updates/{updateId}/stop
+                    try
+                    {
+                        var stopped = await _agentPoolsApi.StopAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+                        stopped.Should().NotBeNull();
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 400 || ex.ErrorCode == 409 || ex.ErrorCode == 404)
+                    {
+                        // State doesn't allow stop or update was deleted - acceptable
+                    }
                 }
 
-                // Step 4: Delete
-                await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
-                updateId = null; // Mark as deleted
+                #endregion
 
-                // Step 5: Verify deletion
-                Func<Task> act = async () => await _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(_testAgentPool.Id, createdUpdate.Id);
-                await act.Should().ThrowAsync<ApiException>()
-                    .Where(e => e.ErrorCode == 404);
-            }
-            catch (ApiException ex) when (ex.ErrorCode == 400)
-            {
-                // Creation may fail - skip
+                // ========================================================================
+                // SECTION 6: Delete Update
+                // ========================================================================
+
+                #region DeleteAgentPoolsUpdate - DELETE /api/v1/agentPools/{poolId}/updates/{updateId}
+
+                if (updateStillExists && !string.IsNullOrEmpty(createdUpdateId))
+                {
+                    try
+                    {
+                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
+
+                        // Verify deletion - should get 404
+                        var deleteException = await Assert.ThrowsAsync<ApiException>(
+                            () => _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(testPoolId, createdUpdateId));
+                        deleteException.ErrorCode.Should().Be(404);
+
+                        createdUpdateId = null; // Prevent double-delete in finally
+                    }
+                    catch (ApiException ex) when (ex.ErrorCode == 404)
+                    {
+                        // Already deleted - acceptable
+                        createdUpdateId = null;
+                    }
+                }
+
+                #endregion
+
+                // ========================================================================
+                // SECTION 7: Error Handling
+                // ========================================================================
+
+                #region Error Scenarios
+
+                // Test 404 for non-existent update ID
+                var notFoundException = await Assert.ThrowsAsync<ApiException>(
+                    () => _agentPoolsApi.GetAgentPoolsUpdateInstanceAsync(testPoolId, "nonexistent123"));
+                notFoundException.ErrorCode.Should().Be(404);
+
+                // Test invalid pool ID
+                var invalidPoolException = await Assert.ThrowsAsync<ApiException>(
+                    () => _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync("invalidPoolId123"));
+                invalidPoolException.ErrorCode.Should().BeOneOf(400, 404);
+
+                #endregion
             }
             finally
             {
-                // Cleanup if not already deleted
-                if (updateId != null)
+                // ========================================================================
+                // CLEANUP
+                // ========================================================================
+                if (!string.IsNullOrEmpty(createdUpdateId) && !string.IsNullOrEmpty(testPoolId))
                 {
                     try
                     {
-                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(_testAgentPool.Id, updateId);
+                        await _agentPoolsApi.DeleteAgentPoolsUpdateAsync(testPoolId, createdUpdateId);
                     }
-                    catch
+                    catch (ApiException)
                     {
-                        // Ignore cleanup errors
+                        // Cleanup failed - update may have been deleted already
                     }
                 }
             }
         }
 
-        #endregion
-
-        #region Parameter Validation Tests
-
         /// <summary>
-        /// Tests that null poolId throws ArgumentException
+        /// Tests WithHttpInfoAsync variants to verify they return proper ApiResponse objects
+        /// with status codes, headers, and data.
         /// </summary>
         [Fact]
-        public async Task ListAgentPoolsUpdates_WithNullPoolId_ShouldThrowApiException()
+        public async Task GivenAgentPoolsApi_WhenUsingWithHttpInfoAsync_ThenReturnsApiResponseWithMetadata()
         {
-            // Act
-            Func<Task> act = async () =>
+            // ========================================================================
+            // Test ListAgentPoolsWithHttpInfoAsync
+            // ========================================================================
+            var listPoolsResponse = await _agentPoolsApi.ListAgentPoolsWithHttpInfoAsync();
+
+            listPoolsResponse.Should().NotBeNull();
+            listPoolsResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+            listPoolsResponse.Headers.Should().NotBeNull();
+            listPoolsResponse.Data.Should().NotBeNull();
+
+            if (!listPoolsResponse.Data.Any())
             {
-                await foreach (var _ in _agentPoolsApi.ListAgentPoolsUpdates(null))
+                // Skip remaining tests if no pools available
+                return;
+            }
+
+            var testPoolId = listPoolsResponse.Data.First().Id;
+
+            // ========================================================================
+            // Test GetAgentPoolsUpdateSettingsWithHttpInfoAsync
+            // ========================================================================
+            var settingsResponse = await _agentPoolsApi.GetAgentPoolsUpdateSettingsWithHttpInfoAsync(testPoolId);
+
+            settingsResponse.Should().NotBeNull();
+            settingsResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+            settingsResponse.Headers.Should().NotBeNull();
+            settingsResponse.Data.Should().NotBeNull();
+            settingsResponse.Data.PoolId.Should().Be(testPoolId);
+
+            // ========================================================================
+            // Test ListAgentPoolsUpdatesWithHttpInfoAsync
+            // ========================================================================
+            var updatesResponse = await _agentPoolsApi.ListAgentPoolsUpdatesWithHttpInfoAsync(testPoolId);
+
+            updatesResponse.Should().NotBeNull();
+            updatesResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+            updatesResponse.Headers.Should().NotBeNull();
+            updatesResponse.Data.Should().NotBeNull();
+
+            // ========================================================================
+            // Test Error Scenarios with WithHttpInfoAsync (400/404)
+            // ========================================================================
+
+            // Test 404 for invalid pool ID with GetAgentPoolsUpdateSettingsWithHttpInfoAsync
+            var invalidPoolException = await Assert.ThrowsAsync<ApiException>(
+                () => _agentPoolsApi.GetAgentPoolsUpdateSettingsWithHttpInfoAsync("invalidPoolId123"));
+            invalidPoolException.ErrorCode.Should().BeOneOf(400, 404);
+
+            // Test 404 for non-existent update ID with GetAgentPoolsUpdateInstanceWithHttpInfoAsync
+            var notFoundUpdateException = await Assert.ThrowsAsync<ApiException>(
+                () => _agentPoolsApi.GetAgentPoolsUpdateInstanceWithHttpInfoAsync(testPoolId, "nonexistent123"));
+            notFoundUpdateException.ErrorCode.Should().Be(404);
+
+            // Test 404 for invalid pool ID with ListAgentPoolsUpdatesWithHttpInfoAsync
+            // Note: This may return empty list or throw depending on pool ID format
+            try
+            {
+                var invalidUpdatesResponse = await _agentPoolsApi.ListAgentPoolsUpdatesWithHttpInfoAsync("invalidPoolId123");
+                // If it doesn't throw, verify we got a response (empty list is valid)
+                invalidUpdatesResponse.Should().NotBeNull();
+            }
+            catch (ApiException ex)
+            {
+                ex.ErrorCode.Should().BeOneOf(400, 404);
+            }
+        }
+
+        /// <summary>
+        /// Tests pagination functionality using the 'after' cursor parameter.
+        /// </summary>
+        [Fact]
+        public async Task GivenAgentPoolsApi_WhenUsingPagination_ThenReturnsCorrectPages()
+        {
+            // ========================================================================
+            // Test ListAgentPools pagination with limit
+            // ========================================================================
+            
+            // First, get all pools to understand the total count
+            var allPools = await _agentPoolsApi.ListAgentPools().ToListAsync();
+            
+            if (allPools.Count < 2)
+            {
+                // Need at least 2 pools to test pagination effectively
+                // Just verify the pagination parameters work without error
+                var singlePage = await _agentPoolsApi.ListAgentPools(limitPerPoolType: 1).ToListAsync();
+                singlePage.Should().NotBeNull();
+                return;
+            }
+
+            // Get first page with limit of 1
+            var firstPageResponse = await _agentPoolsApi.ListAgentPoolsWithHttpInfoAsync(limitPerPoolType: 1);
+            firstPageResponse.Should().NotBeNull();
+            firstPageResponse.Data.Should().NotBeNull();
+
+            // Check for 'after' cursor in Link header or response
+            // The SDK's IAsyncEnumerable handles pagination automatically, but we can verify manual pagination works
+            var firstPool = firstPageResponse.Data.FirstOrDefault();
+            if (firstPool != null)
+            {
+                // Use the first pool's ID as an 'after' cursor for next page
+                var secondPageResponse = await _agentPoolsApi.ListAgentPoolsWithHttpInfoAsync(
+                    limitPerPoolType: 1, 
+                    after: firstPool.Id);
+                
+                secondPageResponse.Should().NotBeNull();
+                secondPageResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+                
+                // If there are more pools, the second page should have different data
+                if (secondPageResponse.Data.Any())
                 {
-                }
-            };
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>();
-        }
-
-        /// <summary>
-        /// Tests that null poolId in GetAgentPoolsUpdateSettings throws
-        /// </summary>
-        [Fact]
-        public async Task GetAgentPoolsUpdateSettings_WithNullPoolId_ShouldThrowApiException()
-        {
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.GetAgentPoolsUpdateSettingsAsync(null);
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>();
-        }
-
-        /// <summary>
-        /// Tests that null poolId in CreateAgentPoolsUpdate throws
-        /// </summary>
-        [Fact]
-        public async Task CreateAgentPoolsUpdate_WithNullPoolId_ShouldThrowApiException()
-        {
-            // Arrange
-            var update = new AgentPoolUpdate { Name = "test" };
-
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.CreateAgentPoolsUpdateAsync(null, update);
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>();
-        }
-
-        /// <summary>
-        /// Tests that null update body throws
-        /// </summary>
-        [Fact]
-        public async Task CreateAgentPoolsUpdate_WithNullBody_ShouldThrowApiException()
-        {
-            // Act
-            Func<Task> act = async () => await _agentPoolsApi.CreateAgentPoolsUpdateAsync("pool-id", null);
-
-            // Assert
-            await act.Should().ThrowAsync<ApiException>();
-        }
-
-        #endregion
-
-        #region Issue #808 - lastConnection Unix Timestamp Fix Verification
-
-        /// <summary>
-        /// This test verifies the fix for Issue #808: AgentPoolsApi.ListAgentPools() 
-        /// now correctly parses Unix timestamps for the lastConnection property.
-        /// 
-        /// The API returns lastConnection as a Unix timestamp in milliseconds (e.g., 1761037561000)
-        /// which is now correctly stored as a long value.
-        /// 
-        /// Before the fix (spec change), this would throw JsonReaderException with message:
-        /// "Unexpected character encountered while parsing value: 1. Path '[0].agents[0].lastConnection'"
-        /// </summary>
-        [Fact]
-        public async Task ListAgentPools_WithAgentsHavingLastConnection_ShouldParseUnixTimestamp_Issue808Fix()
-        {
-            // Act
-            var pools = new List<AgentPool>();
-            await foreach (var pool in _agentPoolsApi.ListAgentPools())
-            {
-                pools.Add(pool);
-            }
-
-            // Assert
-            pools.Should().NotBeNull();
-            
-            // If we have pools with agents, verify the lastConnection is correctly parsed
-            var poolsWithAgents = pools.Where(p => p.Agents != null && p.Agents.Any()).ToList();
-            
-            if (poolsWithAgents.Any())
-            {
-                foreach (var pool in poolsWithAgents)
-                {
-                    foreach (var agent in pool.Agents!)
-                    {
-                        // The lastConnection is now a long (Unix timestamp in milliseconds)
-                        // It should be greater than 0 (after Unix epoch)
-                        agent.LastConnection.Should().BeGreaterThan(0);
-                        
-                        // Convert to DateTimeOffset and verify it's a reasonable date (after year 2000)
-                        var dateTime = DateTimeOffset.FromUnixTimeMilliseconds(agent.LastConnection);
-                        dateTime.Year.Should().BeGreaterThanOrEqualTo(2000);
-                    }
+                    var secondPool = secondPageResponse.Data.First();
+                    secondPool.Id.Should().NotBe(firstPool.Id, "Second page should not return the same pool");
                 }
             }
-            else
-            {
-                // No pools with agents - skip validation but don't fail
-                // The org may not have any agents installed
-            }
-        }
 
-        /// <summary>
-        /// Verifies that the Agent model correctly deserializes lastConnection from Unix timestamp.
-        /// This is a direct test of the fix for Issue #808.
-        /// </summary>
-        [Fact]
-        public void Agent_LastConnection_ShouldDeserializeFromUnixTimestamp()
-        {
-            // Arrange - JSON with Unix timestamp in milliseconds (as returned by the API)
-            var json = @"{
-                ""id"": ""a53test123"",
-                ""name"": ""TestAgent"",
-                ""type"": ""AD"",
-                ""operationalStatus"": ""OPERATIONAL"",
-                ""version"": ""3.22.0"",
-                ""lastConnection"": 1764658925000,
-                ""isLatestGAedVersion"": true,
-                ""poolId"": ""0oatest123"",
-                ""isHidden"": false
-            }";
-
-            // Act
-            var agent = Newtonsoft.Json.JsonConvert.DeserializeObject<Agent>(json);
-
-            // Assert
-            agent.Should().NotBeNull();
+            // ========================================================================
+            // Test ListAgentPoolsUpdates pagination
+            // ========================================================================
+            var testPoolId = allPools.First().Id;
             
-            // LastConnection is now a long (Unix timestamp in milliseconds)
-            agent!.LastConnection.Should().Be(1764658925000);
+            // Get updates for the pool
+            var allUpdates = await _agentPoolsApi.ListAgentPoolsUpdates(testPoolId).ToListAsync();
             
-            // Convert to DateTimeOffset to verify the date
-            var dateTime = DateTimeOffset.FromUnixTimeMilliseconds(agent.LastConnection);
-            dateTime.Year.Should().Be(2025);
-            dateTime.Month.Should().Be(12);
-            dateTime.Day.Should().Be(2);
+            // Test with HttpInfo to access pagination metadata
+            var updatesPageResponse = await _agentPoolsApi.ListAgentPoolsUpdatesWithHttpInfoAsync(testPoolId);
+            updatesPageResponse.Should().NotBeNull();
+            updatesPageResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+            // Verify the async enumerable pagination works correctly
+            var updatesViaEnumerable = await _agentPoolsApi.ListAgentPoolsUpdates(testPoolId).ToListAsync();
+            updatesViaEnumerable.Should().NotBeNull();
+            updatesViaEnumerable.Count.Should().Be(allUpdates.Count);
         }
-
-        #endregion
-    }
-
-    /// <summary>
-    /// Exception to skip tests when prerequisites are not met
-    /// </summary>
-    public class SkipException : Exception
-    {
-        public SkipException(string message) : base(message) { }
     }
 }


### PR DESCRIPTION
Simplifies and consolidates AgentPoolsApi integration tests from 46 tests to 3 comprehensive tests covering all 14 endpoints including CRUD, lifecycle operations, WithHttpInfoAsync variants, pagination, and error handling.