### PR TITLE
fix: propagate NullValueHandling.Ignore through oneOf JSON converters (fixes #872)

### DIFF
--- a/openapi3/templates/modelOneOf.mustache
+++ b/openapi3/templates/modelOneOf.mustache
@@ -248,7 +248,21 @@
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof({{classname}}).GetMethod("ToJson").Invoke(value, null)));
+            var instance = (({{classname}})value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is {{classname}}JsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk.IntegrationTest/IdentityProviderApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/IdentityProviderApiTests.cs
@@ -198,6 +198,50 @@ namespace Okta.Sdk.IntegrationTest
             createEx.ErrorCode.Should().Be(400);
         }
 
+        [Fact]
+        public async Task ReplaceIdentityProviderAsync_WithOidcProtocolFetchedFromApi_DoesNotThrow500()
+        {
+            // Calling ReplaceIdentityProviderAsync with an IdentityProvider object returned by
+            // GetIdentityProviderAsync previously caused HTTP 500 because null fields in the
+            // oneOf IdentityProviderProtocol wrapper were incorrectly serialized as explicit nulls
+            // instead of being omitted.
+            string idpId = null;
+            try
+            {
+                // Arrange — create an OIDC IdP
+                var template = CreateTestIdpTemplate("Automated OIDC IdP - NullFieldsRegressionTest");
+                var created = await _idpApi.CreateIdentityProviderAsync(template);
+                idpId = created.Id;
+                idpId.Should().NotBeNullOrEmpty();
+
+                // Act — fetch the IdP and immediately replace it (this was the failing scenario)
+                var fetched = await _idpApi.GetIdentityProviderAsync(idpId);
+                fetched.Name = "Automated OIDC IdP - NullFieldsRegressionTest (updated)";
+
+                // Assert — should succeed without throwing ApiException (HTTP 500)
+                var replaced = await _idpApi.ReplaceIdentityProviderAsync(idpId, fetched);
+                replaced.Should().NotBeNull();
+                replaced.Id.Should().Be(idpId);
+                replaced.Name.Should().Be("Automated OIDC IdP - NullFieldsRegressionTest (updated)");
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(idpId))
+                {
+                    try
+                    {
+                        var current = await _idpApi.GetIdentityProviderAsync(idpId);
+                        if (current.Status == LifecycleStatus.ACTIVE)
+                            await _idpApi.DeactivateIdentityProviderAsync(idpId);
+                    }
+                    catch (ApiException) { }
+
+                    try { await _idpApi.DeleteIdentityProviderAsync(idpId); }
+                    catch (ApiException) { }
+                }
+            }
+        }
+
         /// <summary>
         /// Helper method to generate a valid IdentityProvider payload for testing
         /// </summary>

--- a/src/Okta.Sdk.UnitTest/Api/ApplicationFeaturesApiTests.cs
+++ b/src/Okta.Sdk.UnitTest/Api/ApplicationFeaturesApiTests.cs
@@ -612,7 +612,10 @@ namespace Okta.Sdk.UnitTest.Api
             var featuresApi = new ApplicationFeaturesApi(mockClient, new Configuration { BasePath = BaseUrl });
 
             var updateRequest = new UpdateFeatureForApplicationRequest(
-                new CapabilitiesInboundProvisioningObject());
+                new CapabilitiesInboundProvisioningObject
+                {
+                    ImportSettings = new CapabilitiesImportSettingsObject()
+                });
 
             // Act
             var feature = await featuresApi.UpdateFeatureForApplicationAsync(_appId, ApplicationFeatureType.INBOUNDPROVISIONING, updateRequest);

--- a/src/Okta.Sdk.UnitTest/Api/IdentityProviderApiTests.cs
+++ b/src/Okta.Sdk.UnitTest/Api/IdentityProviderApiTests.cs
@@ -438,3 +438,166 @@
 //         }
 //     }
 // }
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Okta.Sdk.Api;
+using Okta.Sdk.Client;
+using Okta.Sdk.Model;
+using Okta.Sdk.UnitTest.Internal;
+using Xunit;
+
+namespace Okta.Sdk.UnitTest.Api
+{
+    /// <summary>
+    /// Unit tests for IdentityProviderApi covering serialization correctness.
+    /// Specifically validates that oneOf wrapper types (IdentityProviderProtocol) correctly
+    /// propagate NullValueHandling.Ignore from the outer serializer.
+    /// </summary>
+    public class IdentityProviderApiTests
+    {
+        private const string BaseUrl = "https://test.okta.com";
+
+        private static string BuildIdpResponseJson(string id = "0oatest1234567890id0", string name = "Test OIDC IdP")
+            => $@"{{
+                ""id"": ""{id}"",
+                ""name"": ""{name}"",
+                ""type"": ""OIDC"",
+                ""status"": ""ACTIVE"",
+                ""protocol"": {{
+                    ""type"": ""OIDC"",
+                    ""scopes"": [""openid"", ""profile"", ""email""],
+                    ""credentials"": {{
+                        ""client"": {{
+                            ""client_id"": ""test-client-id"",
+                            ""client_secret"": ""test-client-secret""
+                        }}
+                    }},
+                    ""endpoints"": {{
+                        ""authorization"": {{ ""url"": ""https://idp.example.com/authorize"", ""binding"": ""HTTP-REDIRECT"" }},
+                        ""token"": {{ ""url"": ""https://idp.example.com/token"", ""binding"": ""HTTP-POST"" }},
+                        ""userInfo"": {{ ""url"": ""https://idp.example.com/userinfo"", ""binding"": ""HTTP-REDIRECT"" }},
+                        ""jwks"": {{ ""url"": ""https://idp.example.com/keys"", ""binding"": ""HTTP-REDIRECT"" }}
+                    }},
+                    ""issuer"": {{ ""url"": ""https://idp.example.com"" }}
+                }},
+                ""policy"": {{
+                    ""provisioning"": {{
+                        ""action"": ""AUTO"",
+                        ""profileMaster"": false,
+                        ""groups"": {{ ""action"": ""NONE"" }},
+                        ""conditions"": {{
+                            ""deprovisioned"": {{ ""action"": ""NONE"" }},
+                            ""suspended"": {{ ""action"": ""NONE"" }}
+                        }}
+                    }},
+                    ""accountLink"": {{ ""action"": ""AUTO"" }},
+                    ""subject"": {{
+                        ""matchType"": ""USERNAME"",
+                        ""userNameTemplate"": {{ ""template"": ""idpuser.email"" }}
+                    }},
+                    ""maxClockSkew"": 0
+                }}
+            }}";
+
+        private static IdentityProvider BuildOidcIdp(string name = "Test OIDC IdP")
+            => new IdentityProvider
+            {
+                Type = IdentityProviderType.OIDC,
+                Name = name,
+                Protocol = new IdentityProviderProtocol(new ProtocolOidc
+                {
+                    Type = ProtocolOidc.TypeEnum.OIDC,
+                    Endpoints = new OAuthEndpoints
+                    {
+                        Authorization = new() { Url = "https://idp.example.com/authorize", Binding = "HTTP-REDIRECT" },
+                        Token = new() { Url = "https://idp.example.com/token", Binding = "HTTP-POST" },
+                        UserInfo = new() { Url = "https://idp.example.com/userinfo", Binding = "HTTP-REDIRECT" },
+                        Jwks = new() { Url = "https://idp.example.com/keys", Binding = "HTTP-REDIRECT" },
+                    },
+                    Scopes = new List<string> { "openid", "profile", "email" },
+                    Issuer = new ProtocolEndpointOidcIssuer { Url = "https://idp.example.com" },
+                    Credentials = new OAuthCredentials
+                    {
+                        _Client = new() { ClientId = "test-client-id", ClientSecret = "test-client-secret" }
+                    }
+                }),
+                Policy = new IdentityProviderPolicy
+                {
+                    Provisioning = new Provisioning
+                    {
+                        Action = "AUTO",
+                        ProfileMaster = false,
+                        Groups = new() { Action = "NONE" },
+                        Conditions = new()
+                        {
+                            Deprovisioned = new() { Action = "NONE" },
+                            Suspended = new() { Action = "NONE" }
+                        }
+                    },
+                    AccountLink = new PolicyAccountLink { Action = "AUTO" },
+                    Subject = new PolicySubject
+                    {
+                        MatchType = "USERNAME",
+                        UserNameTemplate = new PolicyUserNameTemplate { Template = "idpuser.email" }
+                    },
+                    MaxClockSkew = 0
+                }
+            };
+
+        [Fact]
+        public async Task CreateIdentityProviderAsync_WithOidcProtocol_DoesNotSerializeNullProtocolFields()
+        {
+            // null fields in ProtocolOidc (algorithms, settings, signing,
+            // slo, oktaIdpOrgUrl, token_endpoint_auth_method) must not appear in the request body.
+            var mockClient = new MockAsyncClient(BuildIdpResponseJson(), HttpStatusCode.OK);
+            var api = new IdentityProviderApi(mockClient, new Configuration { BasePath = BaseUrl });
+            var idp = BuildOidcIdp();
+
+            // Act
+            var result = await api.CreateIdentityProviderAsync(idp);
+
+            // Assert — verify required fields are present
+            result.Should().NotBeNull();
+            result.Id.Should().NotBeNullOrEmpty();
+            mockClient.ReceivedPath.Should().Be("/api/v1/idps");
+
+            // Assert — null Protocol fields must NOT appear in the serialized request body
+            mockClient.ReceivedBody.Should().NotContain("\"algorithms\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"settings\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"signing\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"slo\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"oktaIdpOrgUrl\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"token_endpoint_auth_method\":null");
+        }
+
+        [Fact]
+        public async Task ReplaceIdentityProviderAsync_WithOidcProtocol_DoesNotSerializeNullProtocolFields()
+        {
+            // same null-field problem must not appear on PUT (replace) either.
+            const string idpId = "0oatest1234567890id0";
+            var responseJson = BuildIdpResponseJson(idpId, "Updated OIDC IdP");
+            var mockClient = new MockAsyncClient(responseJson, HttpStatusCode.OK);
+            var api = new IdentityProviderApi(mockClient, new Configuration { BasePath = BaseUrl });
+            var idp = BuildOidcIdp("Updated OIDC IdP");
+
+            // Act
+            var result = await api.ReplaceIdentityProviderAsync(idpId, idp);
+
+            // Assert — verify required fields are present
+            result.Should().NotBeNull();
+            result.Name.Should().Be("Updated OIDC IdP");
+            mockClient.ReceivedPath.Should().Be("/api/v1/idps/{idpId}");
+
+            // Assert — null Protocol fields must NOT appear in the serialized request body
+            mockClient.ReceivedBody.Should().NotContain("\"algorithms\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"settings\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"signing\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"slo\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"oktaIdpOrgUrl\":null");
+            mockClient.ReceivedBody.Should().NotContain("\"token_endpoint_auth_method\":null");
+        }
+    }
+}

--- a/src/Okta.Sdk/Model/AddJwk201Response.cs
+++ b/src/Okta.Sdk/Model/AddJwk201Response.cs
@@ -286,7 +286,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AddJwk201Response).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AddJwk201Response)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AddJwk201ResponseJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/AddJwkRequest.cs
+++ b/src/Okta.Sdk/Model/AddJwkRequest.cs
@@ -286,7 +286,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AddJwkRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AddJwkRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AddJwkRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/AppUserUpdateRequest.cs
+++ b/src/Okta.Sdk/Model/AppUserUpdateRequest.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AppUserUpdateRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AppUserUpdateRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AppUserUpdateRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/AssignRoleToGroupRequest.cs
+++ b/src/Okta.Sdk/Model/AssignRoleToGroupRequest.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AssignRoleToGroupRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AssignRoleToGroupRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AssignRoleToGroupRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/AssignRoleToUser201Response.cs
+++ b/src/Okta.Sdk/Model/AssignRoleToUser201Response.cs
@@ -322,7 +322,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AssignRoleToUser201Response).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AssignRoleToUser201Response)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AssignRoleToUser201ResponseJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/AssignRoleToUserRequest.cs
+++ b/src/Okta.Sdk/Model/AssignRoleToUserRequest.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(AssignRoleToUserRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((AssignRoleToUserRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is AssignRoleToUserRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/DeviceIntegrationsMetadata.cs
+++ b/src/Okta.Sdk/Model/DeviceIntegrationsMetadata.cs
@@ -302,7 +302,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(DeviceIntegrationsMetadata).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((DeviceIntegrationsMetadata)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is DeviceIntegrationsMetadataJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/ExecuteInlineHook200Response.cs
+++ b/src/Okta.Sdk/Model/ExecuteInlineHook200Response.cs
@@ -440,7 +440,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(ExecuteInlineHook200Response).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((ExecuteInlineHook200Response)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is ExecuteInlineHook200ResponseJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/ExecuteInlineHookRequest.cs
+++ b/src/Okta.Sdk/Model/ExecuteInlineHookRequest.cs
@@ -440,7 +440,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(ExecuteInlineHookRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((ExecuteInlineHookRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is ExecuteInlineHookRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/GetJwk200Response.cs
+++ b/src/Okta.Sdk/Model/GetJwk200Response.cs
@@ -286,7 +286,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(GetJwk200Response).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((GetJwk200Response)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is GetJwk200ResponseJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/GracePeriodExpiry.cs
+++ b/src/Okta.Sdk/Model/GracePeriodExpiry.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(GracePeriodExpiry).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((GracePeriodExpiry)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is GracePeriodExpiryJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/IdentityProviderProtocol.cs
+++ b/src/Okta.Sdk/Model/IdentityProviderProtocol.cs
@@ -442,7 +442,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(IdentityProviderProtocol).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((IdentityProviderProtocol)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is IdentityProviderProtocolJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/ListGroupAssignedRoles200ResponseInner.cs
+++ b/src/Okta.Sdk/Model/ListGroupAssignedRoles200ResponseInner.cs
@@ -322,7 +322,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(ListGroupAssignedRoles200ResponseInner).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((ListGroupAssignedRoles200ResponseInner)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is ListGroupAssignedRoles200ResponseInnerJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/ListSubscriptionsRoleRoleRefParameter.cs
+++ b/src/Okta.Sdk/Model/ListSubscriptionsRoleRoleRefParameter.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(ListSubscriptionsRoleRoleRefParameter).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((ListSubscriptionsRoleRoleRefParameter)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is ListSubscriptionsRoleRoleRefParameterJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/OAuth2ClientJsonSigningKeyRequest.cs
+++ b/src/Okta.Sdk/Model/OAuth2ClientJsonSigningKeyRequest.cs
@@ -286,7 +286,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(OAuth2ClientJsonSigningKeyRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((OAuth2ClientJsonSigningKeyRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is OAuth2ClientJsonSigningKeyRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/OAuth2ClientJsonSigningKeyResponse.cs
+++ b/src/Okta.Sdk/Model/OAuth2ClientJsonSigningKeyResponse.cs
@@ -286,7 +286,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(OAuth2ClientJsonSigningKeyResponse).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((OAuth2ClientJsonSigningKeyResponse)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is OAuth2ClientJsonSigningKeyResponseJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/SAMLHookResponseCommandsInnerValueInnerValue.cs
+++ b/src/Okta.Sdk/Model/SAMLHookResponseCommandsInnerValueInnerValue.cs
@@ -302,7 +302,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(SAMLHookResponseCommandsInnerValueInnerValue).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((SAMLHookResponseCommandsInnerValueInnerValue)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is SAMLHookResponseCommandsInnerValueInnerValueJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/SecurityEventsProviderRequestSettings.cs
+++ b/src/Okta.Sdk/Model/SecurityEventsProviderRequestSettings.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(SecurityEventsProviderRequestSettings).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((SecurityEventsProviderRequestSettings)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is SecurityEventsProviderRequestSettingsJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/StreamConfigurationAud.cs
+++ b/src/Okta.Sdk/Model/StreamConfigurationAud.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(StreamConfigurationAud).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((StreamConfigurationAud)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is StreamConfigurationAudJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/TokenHookResponseCommandsInnerValueInnerValue.cs
+++ b/src/Okta.Sdk/Model/TokenHookResponseCommandsInnerValueInnerValue.cs
@@ -302,7 +302,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(TokenHookResponseCommandsInnerValueInnerValue).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((TokenHookResponseCommandsInnerValueInnerValue)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is TokenHookResponseCommandsInnerValueInnerValueJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/UpdateDefaultProvisioningConnectionForApplicationRequest.cs
+++ b/src/Okta.Sdk/Model/UpdateDefaultProvisioningConnectionForApplicationRequest.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(UpdateDefaultProvisioningConnectionForApplicationRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((UpdateDefaultProvisioningConnectionForApplicationRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is UpdateDefaultProvisioningConnectionForApplicationRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/UpdateFeatureForApplicationRequest.cs
+++ b/src/Okta.Sdk/Model/UpdateFeatureForApplicationRequest.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(UpdateFeatureForApplicationRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((UpdateFeatureForApplicationRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is UpdateFeatureForApplicationRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/UserFactorActivateRequest.cs
+++ b/src/Okta.Sdk/Model/UserFactorActivateRequest.cs
@@ -486,7 +486,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(UserFactorActivateRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((UserFactorActivateRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is UserFactorActivateRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/UserFactorTokenVerify.cs
+++ b/src/Okta.Sdk/Model/UserFactorTokenVerify.cs
@@ -256,7 +256,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(UserFactorTokenVerify).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((UserFactorTokenVerify)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is UserFactorTokenVerifyJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>

--- a/src/Okta.Sdk/Model/UserFactorVerifyRequest.cs
+++ b/src/Okta.Sdk/Model/UserFactorVerifyRequest.cs
@@ -670,7 +670,21 @@ namespace Okta.Sdk.Model
         /// <param name="serializer">JSON Serializer</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue((string)(typeof(UserFactorVerifyRequest).GetMethod("ToJson").Invoke(value, null)));
+            var instance = ((UserFactorVerifyRequest)value).ActualInstance;
+            if (instance == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = serializer.ContractResolver,
+                NullValueHandling = serializer.NullValueHandling,
+                Formatting = serializer.Formatting,
+                DateParseHandling = serializer.DateParseHandling,
+                Converters = serializer.Converters.Where(c => !(c is UserFactorVerifyRequestJsonConverter)).ToList()
+            };
+            JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes #872.

### Problem
`CreateIdentityProviderAsync` and `ReplaceIdentityProviderAsync` returned HTTP 500 when the `IdentityProviderProtocol` oneOf wrapper was serialized. Null fields such as `algorithms`, `settings`, `signing`, `slo`, `oktaIdpOrgUrl`, and `token_endpoint_auth_method` were included explicitly in the request body (e.g. `"algorithms":null`) instead of being omitted, causing the Okta API to reject the payload.

### Root Cause
The `WriteJson` method in every generated `*JsonConverter` class (produced by `openapi3/templates/modelOneOf.mustache`) called `ToJson()` via reflection:

```csharp
writer.WriteRawValue((string)(typeof(ClassName).GetMethod("ToJson").Invoke(value, null)));
```

`ToJson()` always used `AbstractOpenAPISchema.SerializerSettings`, which does **not** set `NullValueHandling = NullValueHandling.Ignore`. This bypassed the outer `CustomJsonCodec` serializer settings that do carry `NullValueHandling.Ignore`, so null fields leaked into the request body.

### Fix
Updated `modelOneOf.mustache` so `WriteJson` inherits the calling serializer's settings (including `NullValueHandling`) using the `JToken.FromObject` pattern — the same approach used by `ApplicationJsonConverter`:

```csharp
public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
{
    var instance = ((ClassName)value).ActualInstance;
    if (instance == null) { writer.WriteNull(); return; }
    var settings = new JsonSerializerSettings
    {
        ContractResolver  = serializer.ContractResolver,
        NullValueHandling = serializer.NullValueHandling,
        Formatting        = serializer.Formatting,
        DateParseHandling = serializer.DateParseHandling,
        Converters        = serializer.Converters.Where(c => !(c is ClassNameJsonConverter)).ToList()
    };
    JToken.FromObject(instance, JsonSerializer.Create(settings)).WriteTo(writer);
}
```

All 26 affected oneOf model classes were regenerated.

### Reproduction
Confirmed via POC against `https://dotnet-sdk-dcp.oktapreview.com`:

**Before fix** — Protocol JSON contained explicit nulls:
```json
"protocol": {
  "type": "OIDC",
  "algorithms": null,
  "settings": null,
  "signing": null,
  "slo": null,
  "oktaIdpOrgUrl": null,
  "token_endpoint_auth_method": null,
  ...
}
```

**After fix** — null fields are omitted; Create and Replace both succeed.

### Verification
```
✅ Unit tests:       2 passed (CreateIdentityProviderAsync / ReplaceIdentityProviderAsync)
✅ Integration test: 1 passed (ReplaceIdentityProviderAsync_WithOidcProtocolFetchedFromApi_DoesNotThrow500)
```