### PR TITLE
fix: restore Policy as request body for createPolicy/replacePolicy

### DIFF
--- a/docs/PolicyApi.md
+++ b/docs/PolicyApi.md
@@ -267,7 +267,7 @@ Name | Type | Description  | Notes
 
 <a name="createpolicy"></a>
 # **CreatePolicy**
-> Policy CreatePolicy (CreateOrUpdatePolicy policy, bool? activate = null)
+> Policy CreatePolicy (Policy policy, bool? activate = null)
 
 Create a policy
 
@@ -295,7 +295,7 @@ namespace Example
             config.AccessToken = "YOUR_ACCESS_TOKEN";
 
             var apiInstance = new PolicyApi(config);
-            var policy = new CreateOrUpdatePolicy(); // CreateOrUpdatePolicy | 
+            var policy = new Policy(); // Policy | 
             var activate = true;  // bool? | This query parameter is only valid for Classic Engine orgs. (optional)  (default to true)
 
             try
@@ -319,7 +319,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **policy** | [**CreateOrUpdatePolicy**](CreateOrUpdatePolicy.md)|  | 
+ **policy** | [**Policy**](Policy.md)|  | 
  **activate** | **bool?**| This query parameter is only valid for Classic Engine orgs. | [optional] [default to true]
 
 ### Return type
@@ -1567,7 +1567,7 @@ Name | Type | Description  | Notes
 
 <a name="replacepolicy"></a>
 # **ReplacePolicy**
-> Policy ReplacePolicy (string policyId, CreateOrUpdatePolicy policy)
+> Policy ReplacePolicy (string policyId, Policy policy)
 
 Replace a policy
 
@@ -1596,7 +1596,7 @@ namespace Example
 
             var apiInstance = new PolicyApi(config);
             var policyId = 00plrilJ7jZ66Gn0X0g3;  // string | `id` of the Policy
-            var policy = new CreateOrUpdatePolicy(); // CreateOrUpdatePolicy | 
+            var policy = new Policy(); // Policy | 
 
             try
             {
@@ -1620,7 +1620,7 @@ namespace Example
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **policyId** | **string**| &#x60;id&#x60; of the Policy | 
- **policy** | [**CreateOrUpdatePolicy**](CreateOrUpdatePolicy.md)|  | 
+ **policy** | [**Policy**](Policy.md)|  | 
 
 ### Return type
 

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -19589,7 +19589,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateOrUpdatePolicy'
+              $ref: '#/components/schemas/Policy'
         required: true
       responses:
         '200':
@@ -19743,7 +19743,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateOrUpdatePolicy'
+              $ref: '#/components/schemas/Policy'
         required: true
       responses:
         '200':

--- a/src/Okta.Sdk.IntegrationTest/ApplicationPoliciesApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/ApplicationPoliciesApiTests.cs
@@ -66,7 +66,7 @@ namespace Okta.Sdk.IntegrationTest
             _testAppId = createdApp.Id;
 
             // Create a test authentication policy
-            var testPolicy = new CreateOrUpdatePolicy
+            var testPolicy = new Policy
             {
                 Type = PolicyType.ACCESSPOLICY,
                 Status = LifecycleStatus.ACTIVE,
@@ -146,7 +146,7 @@ namespace Okta.Sdk.IntegrationTest
         public async Task GivenExistingPolicy_WhenAssigningNewPolicy_ThenExistingPolicyIsReplaced()
         {
             // Arrange - Create second policy
-            var secondPolicy = new CreateOrUpdatePolicy
+            var secondPolicy = new Policy
             {
                 Type = PolicyType.ACCESSPOLICY,
                 Status = LifecycleStatus.ACTIVE,

--- a/src/Okta.Sdk.IntegrationTest/PolicyApiTests.cs
+++ b/src/Okta.Sdk.IntegrationTest/PolicyApiTests.cs
@@ -41,7 +41,7 @@ namespace Okta.Sdk.IntegrationTest
                 #region Create Policy - POST /api/v1/policies
                 
                 // Test CreatePolicyAsync() 
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-Test-Policy-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -123,7 +123,7 @@ namespace Okta.Sdk.IntegrationTest
                 #region Replace Policy - PUT /api/v1/policies/{policyId}
                 
                 // Test ReplacePolicyAsync() 
-                var updatedPolicyData = new CreateOrUpdatePolicy()
+                var updatedPolicyData = new Policy()
                 {
                     Name = $"SDK-Test-Policy-Updated-{guid}".Substring(0, 50),
                     Description = "Updated description for comprehensive test",
@@ -416,7 +416,7 @@ namespace Okta.Sdk.IntegrationTest
 
                 #region Test Password Policy
                 
-                var passwordPolicy = new CreateOrUpdatePolicy()
+                var passwordPolicy = new Policy()
                 {
                     Name = $"SDK-Test-PasswordPolicy-{guid}".Substring(0, 50),
                     Type = PolicyType.PASSWORD,
@@ -435,7 +435,7 @@ namespace Okta.Sdk.IntegrationTest
 
                 #region Test Profile Enrollment Policy
                 
-                var profilePolicy = new CreateOrUpdatePolicy()
+                var profilePolicy = new Policy()
                 {
                     Name = $"SDK-Test-ProfilePolicy-{guid}".Substring(0, 50),
                     Type = PolicyType.PROFILEENROLLMENT,
@@ -756,7 +756,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create a test policy with a unique name for searching
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-QueryTest-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -839,7 +839,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create password policy
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-PasswordPolicy-{guid}".Substring(0, 50),
                     Type = PolicyType.PASSWORD,
@@ -1006,7 +1006,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create a test policy
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-PriorityTest-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1120,7 +1120,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create test policy
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-NetworkTest-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1205,7 +1205,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create test policy
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-SessionTest-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1351,7 +1351,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create a valid policy for testing invalid operations
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-ErrorTest-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1399,7 +1399,7 @@ namespace Okta.Sdk.IntegrationTest
             {
                 // Test 49 characters (should work)
                 var name49 = new string('A', 49);
-                var policy1 = new CreateOrUpdatePolicy()
+                var policy1 = new Policy()
                 {
                     Name = name49,
                     Type = PolicyType.OKTASIGNON,
@@ -1414,7 +1414,7 @@ namespace Okta.Sdk.IntegrationTest
 
                 // Test exactly 50 characters (should work)
                 var name50 = new string('B', 50);
-                var policy2 = new CreateOrUpdatePolicy()
+                var policy2 = new Policy()
                 {
                     Name = name50,
                     Type = PolicyType.OKTASIGNON,
@@ -1429,7 +1429,7 @@ namespace Okta.Sdk.IntegrationTest
 
                 // Test 51 characters (API doesn't enforce a strict 50-char limit, it accepts 51+)
                 var name51 = new string('C', 51);
-                var policy3 = new CreateOrUpdatePolicy()
+                var policy3 = new Policy()
                 {
                     Name = name51,
                     Type = PolicyType.OKTASIGNON,
@@ -1483,7 +1483,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // Create a test policy for simulation
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-Test-Simulation-Policy-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1617,7 +1617,7 @@ namespace Okta.Sdk.IntegrationTest
             try
             {
                 // CreatePolicyWithHttpInfo
-                var policy = new CreateOrUpdatePolicy()
+                var policy = new Policy()
                 {
                     Name = $"SDK-HttpInfo-Test-{guid}".Substring(0, 50),
                     Type = PolicyType.OKTASIGNON,
@@ -1654,7 +1654,7 @@ namespace Okta.Sdk.IntegrationTest
                 listResponse.Data.Should().Contain(p => p.Id == policy1.Id);
 
                 // ReplacePolicyWithHttpInfo
-                var updatePolicy = new CreateOrUpdatePolicy()
+                var updatePolicy = new Policy()
                 {
                     Name = createdPolicy.Name,
                     Type = PolicyType.OKTASIGNON,

--- a/src/Okta.Sdk.UnitTest/Api/PolicyApiTests.cs
+++ b/src/Okta.Sdk.UnitTest/Api/PolicyApiTests.cs
@@ -57,7 +57,7 @@ namespace Okta.Sdk.UnitTest.Api
             var mockClient = new MockAsyncClient(responseJson);
             var policyApi = new PolicyApi(mockClient, new Configuration { BasePath = BaseUrl });
 
-            var policy = new CreateOrUpdatePolicy
+            var policy = new OktaSignOnPolicy
             {
                 Name = policyName,
                 Type = PolicyType.OKTASIGNON,
@@ -96,7 +96,7 @@ namespace Okta.Sdk.UnitTest.Api
             var mockClient = new MockAsyncClient(responseJson);
             var policyApi = new PolicyApi(mockClient, new Configuration { BasePath = BaseUrl });
 
-            var policy = new CreateOrUpdatePolicy
+            var policy = new PasswordPolicy
             {
                 Name = "Password Policy",
                 Type = PolicyType.PASSWORD
@@ -274,7 +274,7 @@ namespace Okta.Sdk.UnitTest.Api
             var mockClient = new MockAsyncClient(responseJson);
             var policyApi = new PolicyApi(mockClient, new Configuration { BasePath = BaseUrl });
 
-            var policy = new CreateOrUpdatePolicy
+            var policy = new OktaSignOnPolicy
             {
                 Name = updatedName,
                 Type = PolicyType.OKTASIGNON,
@@ -308,7 +308,7 @@ namespace Okta.Sdk.UnitTest.Api
             var mockClient = new MockAsyncClient(responseJson);
             var policyApi = new PolicyApi(mockClient, new Configuration { BasePath = BaseUrl });
 
-            var policy = new CreateOrUpdatePolicy { Name = "Replaced Policy", Type = PolicyType.PASSWORD };
+            var policy = new PasswordPolicy { Name = "Replaced Policy", Type = PolicyType.PASSWORD };
 
             // Act
             var response = await policyApi.ReplacePolicyWithHttpInfoAsync(_policyId, policy);

--- a/src/Okta.Sdk/Api/PolicyApi.cs
+++ b/src/Okta.Sdk/Api/PolicyApi.cs
@@ -112,7 +112,7 @@ namespace Okta.Sdk.Api
         /// <param name="activate">This query parameter is only valid for Classic Engine orgs. (optional, default to true)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of Policy</returns>
-        System.Threading.Tasks.Task<Policy> CreatePolicyAsync(  CreateOrUpdatePolicy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Policy> CreatePolicyAsync(  Policy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Create a policy
         /// </summary>
@@ -124,7 +124,7 @@ namespace Okta.Sdk.Api
         /// <param name="activate">This query parameter is only valid for Classic Engine orgs. (optional, default to true)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (Policy)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Policy>> CreatePolicyWithHttpInfoAsync(  CreateOrUpdatePolicy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Policy>> CreatePolicyWithHttpInfoAsync(  Policy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Create a policy rule
         /// </summary>
@@ -506,7 +506,7 @@ namespace Okta.Sdk.Api
         /// <param name="policy"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of Policy</returns>
-        System.Threading.Tasks.Task<Policy> ReplacePolicyAsync(  string policyId ,   CreateOrUpdatePolicy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Policy> ReplacePolicyAsync(  string policyId ,   Policy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Replace a policy
         /// </summary>
@@ -518,7 +518,7 @@ namespace Okta.Sdk.Api
         /// <param name="policy"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (Policy)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Policy>> ReplacePolicyWithHttpInfoAsync(  string policyId ,   CreateOrUpdatePolicy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Policy>> ReplacePolicyWithHttpInfoAsync(  string policyId ,   Policy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Replace a policy rule
         /// </summary>
@@ -927,7 +927,7 @@ namespace Okta.Sdk.Api
         /// <param name="activate">This query parameter is only valid for Classic Engine orgs. (optional, default to true)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of Policy</returns>
-        public async System.Threading.Tasks.Task<Policy> CreatePolicyAsync(  CreateOrUpdatePolicy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Policy> CreatePolicyAsync(  Policy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Okta.Sdk.Client.ApiResponse<Policy> localVarResponse = await CreatePolicyWithHttpInfoAsync(policy, activate, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -940,7 +940,7 @@ namespace Okta.Sdk.Api
         /// <param name="activate">This query parameter is only valid for Classic Engine orgs. (optional, default to true)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (Policy)</returns>
-        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Policy>> CreatePolicyWithHttpInfoAsync(  CreateOrUpdatePolicy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Policy>> CreatePolicyWithHttpInfoAsync(  Policy policy ,   bool? activate = default(bool?) , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'policy' is set
             if (policy == null)
@@ -2648,7 +2648,7 @@ namespace Okta.Sdk.Api
         /// <param name="policy"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of Policy</returns>
-        public async System.Threading.Tasks.Task<Policy> ReplacePolicyAsync(  string policyId ,   CreateOrUpdatePolicy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Policy> ReplacePolicyAsync(  string policyId ,   Policy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Okta.Sdk.Client.ApiResponse<Policy> localVarResponse = await ReplacePolicyWithHttpInfoAsync(policyId, policy, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -2661,7 +2661,7 @@ namespace Okta.Sdk.Api
         /// <param name="policy"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (Policy)</returns>
-        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Policy>> ReplacePolicyWithHttpInfoAsync(  string policyId ,   CreateOrUpdatePolicy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Okta.Sdk.Client.ApiResponse<Policy>> ReplacePolicyWithHttpInfoAsync(  string policyId ,   Policy policy , System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'policyId' is set
             if (policyId == null)


### PR DESCRIPTION
## Problem
In v10, the `createPolicy` and `replacePolicy` operations were changed to accept `CreateOrUpdatePolicy` as the request body type. Since `PasswordPolicy`, `OktaSignOnPolicy`, and other concrete subtypes extend `Policy` (not `CreateOrUpdatePolicy`), it became impossible to pass them to `CreatePolicyAsync`/`ReplacePolicyAsync`.

## Fix
Restored the request body schema for `createPolicy` and `replacePolicy` to `Policy` (matching v9 behaviour), and regenerated the affected SDK surface:
- `CreatePolicyAsync(Policy policy, ...)`
- `ReplacePolicyAsync(string policyId, Policy policy, ...)`

Updated call sites in unit and integration tests that were using `CreateOrUpdatePolicy` directly.

## Validation
- ✅ 2776/2776 unit tests pass 
- ✅ PoC: `PasswordPolicy` with complexity settings round-trips correctly against a live org
- ✅ 11/11 Policy API integration tests pass