### PR TITLE
fix: exclude read-only fields from Application PUT/POST body (issue #871)

### DIFF
--- a/docs/ActiveDirectoryApplication.md
+++ b/docs/ActiveDirectoryApplication.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/Application.md
+++ b/docs/Application.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | **ApplicationSignOnMode** |  | 
-**Status** | **ApplicationLifecycleStatus** |  | [optional] 
+**Status** | **ApplicationLifecycleStatus** |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/ApplicationLinks.md
+++ b/docs/ApplicationLinks.md
@@ -1,5 +1,4 @@
 # Okta.Sdk.Model.ApplicationLinks
-Discoverable resources related to the app
 
 ## Properties
 

--- a/docs/AutoLoginApplication.md
+++ b/docs/AutoLoginApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/BasicAuthApplication.md
+++ b/docs/BasicAuthApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/BookmarkApplication.md
+++ b/docs/BookmarkApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/BrowserPluginApplication.md
+++ b/docs/BrowserPluginApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/OpenIdConnectApplication.md
+++ b/docs/OpenIdConnectApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/Saml11Application.md
+++ b/docs/Saml11Application.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/SamlApplication.md
+++ b/docs/SamlApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/SecurePasswordStoreApplication.md
+++ b/docs/SecurePasswordStoreApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/docs/WsFederationApplication.md
+++ b/docs/WsFederationApplication.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **Orn** | **string** | The Okta resource name (ORN) for the current app instance | [optional] [readonly] 
 **Profile** | **Dictionary&lt;string, Object&gt;** | Contains any valid JSON schema for specifying properties that can be referenced from a request (only available to OAuth 2.0 client apps). For example, add an app manager contact email address or define an allowlist of groups that you can then reference using the Okta Expression Language &#x60;getFilteredGroups&#x60; function.  &gt; **Notes:** &gt; * &#x60;profile&#x60; isn&#39;t encrypted, so don&#39;t store sensitive data in it. &gt; * &#x60;profile&#x60; doesn&#39;t limit the level of nesting in the JSON schema you created, but there is a practical size limit. Okta recommends a JSON schema size of 1 MB or less for best performance. | [optional] 
 **SignOnMode** | [**ApplicationSignOnMode**](ApplicationSignOnMode.md) |  | 
-**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] 
+**Status** | [**ApplicationLifecycleStatus**](ApplicationLifecycleStatus.md) |  | [optional] [readonly] 
 **UniversalLogout** | [**ApplicationUniversalLogout**](ApplicationUniversalLogout.md) |  | [optional] 
 **Visibility** | [**ApplicationVisibility**](ApplicationVisibility.md) |  | [optional] 
 **Embedded** | [**ApplicationEmbedded**](ApplicationEmbedded.md) |  | [optional] 

--- a/openapi3/management.yaml
+++ b/openapi3/management.yaml
@@ -56968,7 +56968,9 @@ components:
         signOnMode:
           $ref: '#/components/schemas/ApplicationSignOnMode'
         status:
-          $ref: '#/components/schemas/ApplicationLifecycleStatus'
+          allOf:
+            - $ref: '#/components/schemas/ApplicationLifecycleStatus'
+          readOnly: true
         universalLogout:
           $ref: '#/components/schemas/ApplicationUniversalLogout'
         visibility:
@@ -56984,8 +56986,12 @@ components:
                 type: object
                 properties: {}
           readOnly: true
+          x-okta-read-only: true
         _links:
-          $ref: '#/components/schemas/ApplicationLinks'
+          allOf:
+            - $ref: '#/components/schemas/ApplicationLinks'
+          readOnly: true
+          x-okta-read-only: true
       required:
         - signOnMode
         - label

--- a/openapi3/templates/modelGeneric.mustache
+++ b/openapi3/templates/modelGeneric.mustache
@@ -183,6 +183,18 @@
             return false;
         }
         {{/isReadOnly}}
+        {{^isReadOnly}}
+        {{#vendorExtensions.x-okta-read-only}}
+        /// <summary>
+        /// Returns false as {{name}} should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize{{name}}()
+        {
+            return false;
+        }
+        {{/vendorExtensions.x-okta-read-only}}
+        {{/isReadOnly}}
         {{/conditionalSerialization}}
         {{#conditionalSerialization}}
         {{#isReadOnly}}

--- a/src/Okta.Sdk.UnitTest/Model/ApplicationSerializationTests.cs
+++ b/src/Okta.Sdk.UnitTest/Model/ApplicationSerializationTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="ApplicationSerializationTests.cs" company="Okta, Inc">
+// Copyright (c) 2014-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Okta.Sdk.Model;
+using Xunit;
+
+namespace Okta.Sdk.UnitTest.Model
+{
+    /// <summary>
+    /// Unit tests for Application model serialization.
+    /// Verifies that read-only server-side fields (_links, _embedded, status) are NOT
+    /// included when serializing an Application for PUT/POST requests, even after the
+    /// object has been populated via deserialization from a GET response.
+    /// See: https://github.com/okta/okta-sdk-dotnet/issues/871
+    /// </summary>
+    public class ApplicationSerializationTests
+    {
+        // A realistic GET response JSON that includes server-set fields
+        private const string GetResponseJson = @"{
+            ""id"": ""0oasqfu0z0ELgxGl41d7"",
+            ""name"": ""oidc_client"",
+            ""label"": ""Test OIDC App"",
+            ""status"": ""ACTIVE"",
+            ""lastUpdated"": ""2024-01-15T10:00:00.000Z"",
+            ""created"": ""2024-01-10T08:00:00.000Z"",
+            ""signOnMode"": ""OPENID_CONNECT"",
+            ""orn"": ""orn:okta:atko:00o1ab:app:0oasqfu0z0ELgxGl41d7"",
+            ""_embedded"": {
+                ""user"": {}
+            },
+            ""_links"": {
+                ""appLinks"": [{""name"": ""oidc_client_link"", ""href"": ""https://example.okta.com/home/oidc_client/0oasqfu0z0ELgxGl41d7/aln5z7uhkbM6y7bMy0g7"", ""type"": ""text/html""}],
+                ""self"": {""href"": ""https://example.okta.com/api/v1/apps/0oasqfu0z0ELgxGl41d7""}
+            }
+        }";
+
+        [Fact]
+        public void Serialize_AfterDeserializingGetResponse_ShouldNotIncludeStatus()
+        {
+            // Arrange - simulate the GET→PUT flow
+            var app = JsonConvert.DeserializeObject<Application>(GetResponseJson);
+
+            // Act - serialize for PUT body
+            var json = JsonConvert.SerializeObject(app);
+            var obj = JObject.Parse(json);
+
+            // Assert - status must NOT be in PUT body (it's server-controlled)
+            obj.ContainsKey("status").Should().BeFalse(
+                "status is a server-managed read-only field and must not be sent in PUT/POST requests");
+        }
+
+        [Fact]
+        public void Serialize_AfterDeserializingGetResponse_ShouldNotIncludeLinks()
+        {
+            // Arrange
+            var app = JsonConvert.DeserializeObject<Application>(GetResponseJson);
+
+            // Act
+            var json = JsonConvert.SerializeObject(app);
+            var obj = JObject.Parse(json);
+
+            // Assert - _links must NOT be in PUT body (it's server-generated HAL)
+            obj.ContainsKey("_links").Should().BeFalse(
+                "_links is a server-generated HAL field and must not be sent in PUT/POST requests");
+        }
+
+        [Fact]
+        public void Serialize_AfterDeserializingGetResponse_ShouldNotIncludeEmbedded()
+        {
+            // Arrange
+            var app = JsonConvert.DeserializeObject<Application>(GetResponseJson);
+
+            // Act
+            var json = JsonConvert.SerializeObject(app);
+            var obj = JObject.Parse(json);
+
+            // Assert - _embedded must NOT be in PUT body (it's server-generated)
+            obj.ContainsKey("_embedded").Should().BeFalse(
+                "_embedded is a server-generated field and must not be sent in PUT/POST requests");
+        }
+
+        [Fact]
+        public void Serialize_AfterDeserializingGetResponse_ShouldNotIncludeReadOnlyFields()
+        {
+            // Arrange - simulate GET → PUT flow for an OIDC app (the subtype used in issue #871).
+            // When signOnMode is "OPENID_CONNECT", the JSON discriminator resolves the object to
+            // OpenIdConnectApplication, which intentionally overrides ShouldSerializeName() so
+            // that 'name' IS included (needed for app-type identification). All other server-managed
+            // fields must remain absent from the PUT body.
+            var app = JsonConvert.DeserializeObject<Application>(GetResponseJson);
+
+            // Act - serialize for PUT body
+            var json = JsonConvert.SerializeObject(app);
+            var obj = JObject.Parse(json);
+
+            // Assert - all server-managed fields from issue #871 must be absent
+            obj.ContainsKey("status").Should().BeFalse("status is a server-managed read-only field");
+            obj.ContainsKey("_links").Should().BeFalse("_links is server-generated HAL and must not be sent");
+            obj.ContainsKey("_embedded").Should().BeFalse("_embedded is server-generated and must not be sent");
+            // Additional read-only fields that must also be absent
+            obj.ContainsKey("id").Should().BeFalse("id is read-only");
+            obj.ContainsKey("created").Should().BeFalse("created is read-only");
+            obj.ContainsKey("lastUpdated").Should().BeFalse("lastUpdated is read-only");
+            obj.ContainsKey("orn").Should().BeFalse("orn is read-only");
+        }
+
+        [Fact]
+        public void Serialize_AfterDeserializingGetResponse_ShouldPreserveWritableFields()
+        {
+            // Arrange
+            var app = JsonConvert.DeserializeObject<Application>(GetResponseJson);
+
+            // Act
+            var json = JsonConvert.SerializeObject(app);
+            var obj = JObject.Parse(json);
+
+            // Assert - writable fields MUST be preserved in PUT body
+            obj.ContainsKey("label").Should().BeTrue("label is a writable field");
+            obj["label"]!.ToString().Should().Be("Test OIDC App");
+            obj.ContainsKey("signOnMode").Should().BeTrue("signOnMode is a required writable field");
+        }
+
+        [Fact]
+        public void ShouldSerializeStatus_ReturnsFalse()
+        {
+            var app = new Application();
+            app.ShouldSerializeStatus().Should().BeFalse();
+        }
+
+        [Fact]
+        public void ShouldSerializeLinks_ReturnsFalse()
+        {
+            var app = new Application();
+            app.ShouldSerializeLinks().Should().BeFalse();
+        }
+
+        [Fact]
+        public void ShouldSerializeEmbedded_ReturnsFalse()
+        {
+            var app = new Application();
+            app.ShouldSerializeEmbedded().Should().BeFalse();
+        }
+    }
+}

--- a/src/Okta.Sdk/Model/Application.cs
+++ b/src/Okta.Sdk/Model/Application.cs
@@ -366,6 +366,15 @@ namespace Okta.Sdk.Model
         [DataMember(Name = "status", EmitDefaultValue = true)]
         
         public ApplicationLifecycleStatus Status { get; set; }
+
+        /// <summary>
+        /// Returns false as Status should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeStatus()
+        {
+            return false;
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="Application" /> class.
         /// </summary>
@@ -492,11 +501,27 @@ namespace Okta.Sdk.Model
         public ApplicationEmbedded Embedded { get; set; }
 
         /// <summary>
+        /// Returns false as Embedded should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeEmbedded()
+        {
+            return false;
+        }
+        /// <summary>
         /// Gets or Sets Links
         /// </summary>
         [DataMember(Name = "_links", EmitDefaultValue = true)]
         public ApplicationLinks Links { get; set; }
 
+        /// <summary>
+        /// Returns false as Links should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeLinks()
+        {
+            return false;
+        }
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>

--- a/src/Okta.Sdk/Model/ApplicationLinks.cs
+++ b/src/Okta.Sdk/Model/ApplicationLinks.cs
@@ -32,9 +32,9 @@ namespace Okta.Sdk.Model
 {
     /// <summary>
     /// Template: ModelGeneric
-    /// Discoverable resources related to the app
+    /// ApplicationLinks
     /// </summary>
-    [DataContract(Name = "ApplicationLinks")]
+    [DataContract(Name = "Application__links")]
     
     public partial class ApplicationLinks : IEquatable<ApplicationLinks>
     {


### PR DESCRIPTION
## Problem
When doing a GET→PUT flow, the `Application` model was serializing server-managed read-only fields (`status`, `_links`, `_embedded`) into the request body. WIC orgs reject these with HTTP 500.

## Root Cause
The OpenAPI Generator doesn't propagate `isReadOnly` to complex object-type properties (`$ref`-based types) even when `readOnly: true` is set in the spec.

## Fix
- **`openapi3/management.yaml`**: Added `x-okta-read-only: true` vendor extension to `_links` and `_embedded` in the `Application` schema; added `allOf + readOnly: true` to `status`.
- **`openapi3/templates/modelGeneric.mustache`**: Added `{{#vendorExtensions.x-okta-read-only}}` block to emit `ShouldSerialize{{name}}() { return false; }` for complex-typed read-only properties.

## Result
`ShouldSerializeStatus()`, `ShouldSerializeLinks()`, and `ShouldSerializeEmbedded()` are now generated — all three fields are excluded from PUT/POST bodies.

## Testing
- Added `ApplicationSerializationTests.cs` with 8 unit tests covering the GET→PUT serialization flow.
- POC validated live against `dotnet-sdk-dcp.oktapreview.com`: PUT returns HTTP 200 with none of the forbidden fields in the body.
- Full unit test suite: 2782 passed, 0 failed.

Fixes #871